### PR TITLE
Refactor email handling and remove dependence on Flask-Mail.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,18 +6,32 @@ Here you can see the full list of changes between each Flask-Security release.
 Version 4.0.0
 -------------
 
-Release Target 2020
+Release Target Summer 2020
 
 - Removal of python 2.7 and <3.6 support
 - Removal of token caching feature (a relatively new feature that has some systemic issues)
 - Other possible breaking changes tracked `here`_
+
+Features
+++++++++
+- Removal of python 2.7 and <3.6 support
+- Removal of token caching feature (a relatively new feature that has some systemic issues)
+- (:pr:`xxx`) Remove dependence on Flask-Mail and refactor.
+
+Backwards Compatibility Concerns
++++++++++++++++++++++++++++++++++
+- (:pr:`xxx`) Remove dependence on Flask-Mail and refactor. The ``send_mail_task`` and
+  ``send_mail`` methods have been removed and replaced with a new :class:`.MailUtil` class.
+  If your application didn't use either of the deprecated methods, then the only change required
+  is to add Flask-Mail to your package requirements (since Flask-Security no longer lists it).
+  Please see the :ref:`emails_topic` for updated examples.
 
 .. _here: https://github.com/Flask-Middleware/flask-security/issues/85
 
 Version 3.4.2
 -------------
 
-Released May x, 2020
+Released May 2, 2020
 
 Only change is to move repo to the Flask-Middleware github organization.
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -138,11 +138,16 @@ Utils
 .. autoclass:: flask_security.PhoneUtil
   :members:
 
+.. autoclass:: flask_security.MailUtil
+  :members:
+
 .. autoclass:: flask_security.SmsSenderBaseClass
   :members: send_sms
 
 .. autoclass:: flask_security.SmsSenderFactory
   :members: createSender
+
+.. _signals_topic:
 
 Signals
 -------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -979,6 +979,8 @@ Unified Signin
 
 .. py:data:: SECURITY_US_EMAIL_SUBJECT
 
+    Sets the email subject when sending the verification code via email.
+
     Default: ``_("Verification Code")``
 
 .. py:data:: SECURITY_US_SETUP_WITHIN

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -49,6 +49,7 @@ from .forms import (
     TwoFactorVerifyPasswordForm,
     VerifyForm,
 )
+from .mail_util import MailUtil
 from .phone_util import PhoneUtil
 from .signals import (
     confirm_instructions_sent,

--- a/flask_security/changeable.py
+++ b/flask_security/changeable.py
@@ -13,7 +13,7 @@ from flask import current_app
 from werkzeug.local import LocalProxy
 
 from .signals import password_changed
-from .utils import config_value, hash_password
+from .utils import config_value, hash_password, send_mail
 
 # Convenient references
 _security = LocalProxy(lambda: current_app.extensions["security"])
@@ -28,7 +28,7 @@ def send_password_changed_notice(user):
     """
     if config_value("SEND_PASSWORD_CHANGE_EMAIL"):
         subject = config_value("EMAIL_SUBJECT_PASSWORD_CHANGE_NOTICE")
-        _security._send_mail(subject, user.email, "change_notice", user=user)
+        send_mail(subject, user.email, "change_notice", user=user)
 
 
 def change_user_password(user, password):

--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -17,6 +17,7 @@ from .utils import (
     config_value,
     get_token_status,
     hash_data,
+    send_mail,
     url_for_security,
     verify_hash,
 )
@@ -40,7 +41,7 @@ def send_confirmation_instructions(user):
 
     confirmation_link, token = generate_confirmation_link(user)
 
-    _security._send_mail(
+    send_mail(
         config_value("EMAIL_SUBJECT_CONFIRM"),
         user.email,
         "confirmation_instructions",

--- a/flask_security/mail_util.py
+++ b/flask_security/mail_util.py
@@ -1,0 +1,52 @@
+"""
+    flask_security.mail_util
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Utility class for managing outgoing emails
+
+    :copyright: (c) 2020 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+
+    While this default implementation uses FlaskMail - we want to make sure that
+    FlaskMail isn't REQUIRED (if this implementation isn't used).
+"""
+
+from flask import current_app
+from werkzeug.local import LocalProxy
+
+
+_security = LocalProxy(lambda: current_app.extensions["security"])
+
+
+class MailUtil:
+    """
+    To provide your own implementation, pass in the class as ``mail_util_cls``
+    at init time. Your class will be instantiated once prior to the first
+    request being handled.
+
+    .. versionadded:: 4.0.0
+    """
+
+    def send_mail(
+        self, template, subject, recipient, sender, body, html, user, **kwargs
+    ):
+        """Send an email via the Flask-Mail extension.
+
+        :param template: the Template name. The message has already been rendered
+            however this might be useful to differentiate why the email is being sent.
+        :param subject: Email subject
+        :param recipient: Email recipient
+        :param sender: who to send email as (see :py:data:`SECURITY_EMAIL_SENDER`)
+        :param body: the rendered body (text)
+        :param html: the rendered body (html)
+        :param user: the user model
+        """
+
+        from flask_mail import Message
+
+        msg = Message(subject, sender=sender, recipients=[recipient])
+        msg.body = body
+        msg.html = html
+
+        mail = current_app.extensions.get("mail")
+        mail.send(msg)

--- a/flask_security/passwordless.py
+++ b/flask_security/passwordless.py
@@ -12,7 +12,7 @@ from flask import current_app as app
 from werkzeug.local import LocalProxy
 
 from .signals import login_instructions_sent
-from .utils import config_value, get_token_status, url_for_security
+from .utils import config_value, get_token_status, send_mail, url_for_security
 
 # Convenient references
 _security = LocalProxy(lambda: app.extensions["security"])
@@ -24,12 +24,11 @@ def send_login_instructions(user):
     """Sends the login instructions email for the specified user.
 
     :param user: The user to send the instructions to
-    :param token: The login token
     """
     token = generate_login_token(user)
     login_link = url_for_security("token_login", token=token, _external=True)
 
-    _security._send_mail(
+    send_mail(
         config_value("EMAIL_SUBJECT_PASSWORDLESS"),
         user.email,
         "login_instructions",

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -17,6 +17,7 @@ from .utils import (
     get_token_status,
     hash_data,
     hash_password,
+    send_mail,
     url_for_security,
     verify_hash,
 )
@@ -36,7 +37,7 @@ def send_reset_password_instructions(user):
     reset_link = url_for_security("reset_password", token=token, _external=True)
 
     if config_value("SEND_PASSWORD_RESET_EMAIL"):
-        _security._send_mail(
+        send_mail(
             config_value("EMAIL_SUBJECT_PASSWORD_RESET"),
             user.email,
             "reset_instructions",
@@ -55,7 +56,7 @@ def send_password_reset_notice(user):
     :param user: The user to send the notice to
     """
     if config_value("SEND_PASSWORD_RESET_NOTICE_EMAIL"):
-        _security._send_mail(
+        send_mail(
             config_value("EMAIL_SUBJECT_PASSWORD_NOTICE"),
             user.email,
             "reset_notice",

--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -16,7 +16,7 @@ from werkzeug.local import LocalProxy
 
 from .confirmable import generate_confirmation_link
 from .signals import user_registered
-from .utils import config_value, do_flash, get_message, hash_password
+from .utils import config_value, do_flash, get_message, hash_password, send_mail
 
 # Convenient references
 _security = LocalProxy(lambda: app.extensions["security"])
@@ -60,7 +60,7 @@ def register_user(registration_form):
     )
 
     if config_value("SEND_REGISTER_EMAIL"):
-        _security._send_mail(
+        send_mail(
             config_value("EMAIL_SUBJECT_REGISTER"),
             user.email,
             "welcome",

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -19,6 +19,7 @@ from .utils import (
     do_flash,
     login_user,
     json_error_response,
+    send_mail,
     url_for_security,
 )
 from .signals import (
@@ -66,7 +67,7 @@ def tf_send_security_token(user, method, totp_secret, phone_number):
     """
     token_to_be_sent = _security._totp_factory.generate_totp_password(totp_secret)
     if method == "email" or method == "mail":
-        _security._send_mail(
+        send_mail(
             config_value("EMAIL_SUBJECT_TWO_FACTOR"),
             user.email,
             "two_factor_instructions",

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -59,6 +59,7 @@ from .utils import (
     json_error_response,
     login_user,
     propagate_next,
+    send_mail,
     suppress_form_csrf,
     url_for_security,
 )
@@ -935,7 +936,7 @@ def us_send_security_token(
             login_link = url_for_security(
                 "us_verify_link", email=user.email, code=token, _external=True
             )
-        _security._send_mail(
+        send_mail(
             config_value("US_EMAIL_SUBJECT"),
             user.email,
             "us_instructions",

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -89,6 +89,7 @@ from .utils import (
     json_error_response,
     login_user,
     logout_user,
+    send_mail,
     slash_url_suffix,
     suppress_form_csrf,
     url_for_security,
@@ -931,7 +932,7 @@ def two_factor_rescue():
                     )
         # send app provider a mail message regarding trouble
         elif problem == "no_mail_access":
-            _security._send_mail(
+            send_mail(
                 config_value("EMAIL_SUBJECT_TWO_FACTOR_RESCUE"),
                 config_value("TWO_FACTOR_RESCUE_MAIL"),
                 "two_factor_rescue",

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ with open("flask_security/__init__.py", encoding="utf8") as f:
     version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
 
 tests_require = [
+    "Flask-Mail>=0.9.1",
     "Flask-Mongoengine>=0.9.5",
     "peewee>=3.11.2",
     "Flask-SQLAlchemy>=2.3",
@@ -52,7 +53,6 @@ setup_requires = ["Babel>=1.3", "pytest-runner>=5.2", "twine", "wheel"]
 install_requires = [
     "Flask>=1.1.1",
     "Flask-Login>=0.4.1",
-    "Flask-Mail>=0.9.1",
     "Flask-Principal>=0.4.0",
     "Flask-WTF>=0.14.2",
     "Flask-BabelEx>=0.9.3",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -58,45 +58,22 @@ from flask_security.utils import (
 
 
 @pytest.mark.recoverable()
-def test_async_email_task(app, client):
-    app.mail_sent = False
-
-    @app.security.send_mail_task
-    def send_email(msg):
-        app.mail_sent = True
-
-    client.post("/reset", data=dict(email="matt@lp.com"))
-    assert app.mail_sent is True
-
-
-@pytest.mark.recoverable()
-def test_alt_send_mail(app, sqlalchemy_datastore):
-    """ Verify that can override the send_mail method. """
-    app.mail_sent = False
-
-    def send_email(subject, email, template, **kwargs):
-        app.mail_sent = True
+def test_my_mail_util(app, sqlalchemy_datastore):
+    class MyMailUtil:
+        def send_mail(self, template, subject, recipient, sender, body, html, user):
+            assert template == "reset_instructions"
+            assert subject == app.config["SECURITY_EMAIL_SUBJECT_PASSWORD_RESET"]
+            assert recipient == "matt@lp.com"
+            assert user.email == "matt@lp.com"
+            assert sender == "no-reply@localhost"
+            assert isinstance(sender, str)
 
     init_app_with_options(
-        app, sqlalchemy_datastore, **{"security_args": {"send_mail": send_email}}
+        app, sqlalchemy_datastore, **{"security_args": {"mail_util_cls": MyMailUtil}}
     )
+
     client = app.test_client()
-
     client.post("/reset", data=dict(email="matt@lp.com"))
-    assert app.mail_sent is True
-
-
-@pytest.mark.recoverable()
-def test_alt_send_mail_decorator(app, client):
-    """ Verify that can override the send_mail method. """
-    app.mail_sent = False
-
-    @app.security.send_mail
-    def send_email(subject, email, template, **kwargs):
-        app.mail_sent = True
-
-    client.post("/reset", data=dict(email="matt@lp.com"))
-    assert app.mail_sent is True
 
 
 def test_register_blueprint_flag(app, sqlalchemy_datastore):
@@ -453,6 +430,7 @@ def test_no_email_sender(app):
     security.init_app(app)
 
     with app.app_context():
+        app.try_trigger_before_first_request_functions()
         user = TestUser("matt@lp.com")
         with app.mail.record_messages() as outbox:
             send_mail("Test Default Sender", user.email, "welcome", user=user)

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -379,6 +379,7 @@ def test_post_already_authenticated(client, get_message):
     )
 
 
+@pytest.mark.settings(us_email_subject="Code For You")
 def test_verify_link(app, client, get_message):
     auths = []
 
@@ -395,6 +396,9 @@ def test_verify_link(app, client, get_message):
         assert response.status_code == 200
         assert b"Sign In" in response.data
 
+    assert outbox[0].recipients == ["matt@lp.com"]
+    assert outbox[0].sender == "no-reply@localhost"
+    assert outbox[0].subject == "Code For You"
     matcher = re.match(
         r".*(http://[^\s*]*).*", outbox[0].body, re.IGNORECASE | re.DOTALL
     )


### PR DESCRIPTION
Rather than have 2 different methods that can be overwritten - a new class MailUtil has been created. The default
implementation is the same as before and sends email via Flask-Mail. However the class can nbe overwritten and used as part of Flask-Security
initialization - so any email package can be used.

This is not backwards compatible - the send_mail and send_mail_task overridable methods have been removed.