### PR TITLE
Adds `NextFormMixin` to match intended behavior

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -345,7 +345,7 @@ class LoginForm(Form, NextFormMixin):
         return True
 
 
-class VerifyForm(Form, PasswordFormMixin):
+class VerifyForm(Form, PasswordFormMixin, NextFormMixin):
     """The verify authentication form"""
 
     user = None


### PR DESCRIPTION
On the documentation, the intended use case for VerifyForm shows that the `next` form should be used but it looks like `NextFormMixin` is missing from the Form itself.