### PR TITLE
Small improvements to the freshness mechanism.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -96,6 +96,8 @@ Utils
 
 .. autofunction:: flask_security.get_hmac
 
+.. autofunction:: flask_security.get_request_attr
+
 .. autofunction:: flask_security.verify_password
 
 .. autofunction:: flask_security.verify_and_update_password

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -82,6 +82,7 @@ from .utils import (
     SmsSenderFactory,
     check_and_get_token_status,
     get_hmac,
+    get_request_attr,
     get_token_status,
     get_url,
     hash_password,

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -70,6 +70,7 @@ from .utils import (
     get_message,
     hash_data,
     localize_callback,
+    set_request_attr,
     uia_email_mapper,
     uia_phone_mapper,
     url_for_security,
@@ -446,6 +447,7 @@ def _user_loader(user_id):
         selector = dict(id=user_id)
     user = _security.datastore.find_user(**selector)
     if user and user.active:
+        set_request_attr("fs_authn_via", "session")
         return user
     return None
 
@@ -480,7 +482,7 @@ def _request_loader(request):
         user = None
 
     if user and user.verify_auth_token(data):
-        _request_ctx_stack.top.fs_authn_via = "token"
+        set_request_attr("fs_authn_via", "token")
         return user
 
     return _security.login_manager.anonymous_user()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ from flask_security import (
     auth_required,
     auth_token_required,
     http_auth_required,
+    get_request_attr,
     login_required,
     roles_accepted,
     roles_required,
@@ -122,16 +123,19 @@ def app(request):
     @http_auth_required
     @permissions_required("admin")
     def http_admin_required():
+        assert get_request_attr("fs_authn_via") == "basic"
         return "HTTP Authentication"
 
     @app.route("/http_custom_realm")
     @http_auth_required("My Realm")
     def http_custom_realm():
+        assert get_request_attr("fs_authn_via") == "basic"
         return render_template("index.html", content="HTTP Authentication")
 
     @app.route("/token", methods=["GET", "POST"])
     @auth_token_required
     def token():
+        assert get_request_attr("fs_authn_via") == "token"
         return render_template("index.html", content="Token Authentication")
 
     @app.route("/multi_auth")
@@ -154,6 +158,7 @@ def app(request):
     @app.route("/admin")
     @roles_required("admin")
     def admin():
+        assert get_request_attr("fs_authn_via") == "session"
         return render_template("index.html", content="Admin Page")
 
     @app.route("/admin_and_editor")
@@ -182,10 +187,6 @@ def app(request):
     @permissions_required("full-write", "super")
     def admin_perm_required():
         return render_template("index.html", content="Admin Page required")
-
-    @app.route("/unauthorized")
-    def unauthorized():
-        return render_template("unauthorized.html")
 
     @app.route("/page1")
     def page_1():

--- a/tests/templates/unauthorized.html
+++ b/tests/templates/unauthorized.html
@@ -1,3 +1,0 @@
-{% include "_messages.html" %}
-{% include "_nav.html" %}
-<h1>You are not allowed to access the requested resouce</h1>

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -479,7 +479,7 @@ def test_user_loader(app, sqlalchemy_datastore):
     from flask_security.core import _user_loader
 
     init_app_with_options(app, sqlalchemy_datastore)
-    with app.app_context():
+    with app.test_request_context():
         jill = sqlalchemy_datastore.find_user(email="jill@lp.com")
 
         # normal case


### PR DESCRIPTION
In the original code - the check for "basic" was done in the decorator - that has been moved to the utility method so callers that can't use the decorator can get identical behavior.

Added a request global fs_auth_via and set that in the decorators so that views, if need be, can get the method that was used to authenticate.

removed unused conftest endpoint and template.