### PR TITLE
Revamp how USER_IDENTITY_ATTRIBUTES is configured and used.

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -82,6 +82,8 @@ user's UserModel. If that field is changed (via :meth:`.UserDatastore.set_uniqui
 then any existing authentication tokens will no longer be valid. Changing
 the user's password will not affect tokens.
 
+.. _two-factor:
+
 Two-factor Authentication (alpha)
 ----------------------------------------
 Two-factor authentication is enabled by generating time-based one time passwords
@@ -126,7 +128,7 @@ many different servers as part of being delivered - and b) is available from any
 
 Using SMS or an authenticator app means you are providing "something you have" (the mobile device)
 and either "something you know" (passcode to unlock your device)
-or "something you are" (biometric passcode to unlock your device).
+or "something you are" (biometric quality to unlock your device).
 This effectively means that using a one-time code to sign in, is in fact already two-factor (if using
 SMS or authenticator app). Many large authentication providers already offer this - here is
 `Microsoft's`_ version.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,13 +30,13 @@ Flask application. They include:
 Many of these features are made possible by integrating various Flask extensions
 and libraries. They include:
 
-1. `Flask-Login <https://flask-login.readthedocs.org/en/latest/>`_
-2. `Flask-Mail <https://pypi.org/project/Flask-Mail/>`_
-3. `Flask-Principal <https://pypi.org/project/Flask-Principal/>`_
-4. `Flask-WTF <https://pypi.org/project/Flask-WTF/>`_
-5. `itsdangerous <https://pypi.org/project/itsdangerous/>`_
-6. `passlib <https://pypi.org/project/passlib/>`_
-7. `PyQRCode <https://pypi.org/project/PyQRCode/>`_
+* `Flask-Login <https://flask-login.readthedocs.org/en/latest/>`_
+* `Flask-Mail <https://pypi.org/project/Flask-Mail/>`_
+* `Flask-Principal <https://pypi.org/project/Flask-Principal/>`_
+* `Flask-WTF <https://pypi.org/project/Flask-WTF/>`_
+* `itsdangerous <https://pypi.org/project/itsdangerous/>`_
+* `passlib <https://pypi.org/project/passlib/>`_
+* `PyQRCode <https://pypi.org/project/PyQRCode/>`_
 
 Additionally, it assumes you'll be using a common library for your database
 connections and model definitions. Flask-Security supports the following Flask

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -61,7 +61,7 @@ Freshness
 ++++++++++
 A common pattern for browser-based sites is to use sessions to manage identity. This is usually
 implemented using session cookies. These cookies expire once the session (browser tab) is closed. This is very
-convenient, and keep the users from having to constantly re-authenticate. The downside is that sessions can easily be
+convenient, and keeps the users from having to constantly re-authenticate. The downside is that sessions can easily be
 open for days or weeks. This adds to the security risk that some bad-actor or XSS gets control of the browser and then can
 do anything the user can. To mitigate that, operations that change fundamental identity characteristics (such as email, password, etc.)
 can be protected by requiring a 'fresh' or recent authentication. Flask-Security supports this with the following:
@@ -69,10 +69,10 @@ can be protected by requiring a 'fresh' or recent authentication. Flask-Security
     - :func:`.auth_required` takes parameters that define how recent the authentication must have happened. In addition a grace
       period can be specified so that multiple step operations don't require re-authentication in the middle.
     - A default :meth:`.Security.reauthn_handler` that is called when a request fails the recent authentication check.
-    - :py:data:`SECURITY_VERIFY_URL` and :py:data:`SECURITY_US_VERIFY_URL` endpoints that request the user to re-authenticate
-    - VerifyForm and UsVerifyForm forms that can be extended.
+    - :py:data:`SECURITY_VERIFY_URL` and :py:data:`SECURITY_US_VERIFY_URL` endpoints that request the user to re-authenticate.
+    - ``VerifyForm`` and ``UsVerifyForm`` forms that can be extended.
 
-Flask-Security itself uses this as part of securing the :ref:`unified-sign-in` setup endpoint.
+Flask-Security itself uses this as part of securing the :ref:`unified-sign-in` and :ref:`two-factor` setup endpoints.
 
 .. _pass_validation_topic:
 

--- a/examples/unified_signin/server/app.py
+++ b/examples/unified_signin/server/app.py
@@ -17,7 +17,13 @@ import os
 
 from flask import Flask
 from flask.json import JSONEncoder
-from flask_security import Security, SmsSenderFactory, SmsSenderBaseClass
+from flask_security import (
+    Security,
+    SmsSenderFactory,
+    SmsSenderBaseClass,
+    uia_phone_mapper,
+    uia_email_mapper,
+)
 from flask_wtf import CSRFProtect
 
 from models import db, user_datastore
@@ -69,7 +75,10 @@ def create_app():
     app.config["SECURITY_FLASH_MESSAGES"] = False
 
     # Allow signing in with a phone number or email
-    app.config["SECURITY_USER_IDENTITY_ATTRIBUTES"] = ["email", "us_phone_number"]
+    app.config["SECURITY_USER_IDENTITY_ATTRIBUTES"] = [
+        {"email": {"mapper": uia_email_mapper, "case_insensitive": True}},
+        {"us_phone_number": {"mapper": uia_phone_mapper}},
+    ]
     app.config["SECURITY_US_ENABLED_METHODS"] = ["password", "email", "sms"]
 
     app.config["SECURITY_TOTP_SECRETS"] = {

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -24,6 +24,7 @@ from .utils import (
     FsPermNeed,
     config_value,
     do_flash,
+    find_user,
     get_message,
     get_url,
     check_and_update_authn_fresh,
@@ -158,7 +159,7 @@ def _check_http_auth():
     auth = request.authorization or BasicAuth(username=None, password=None)
     if not auth.username:
         return False
-    user = _security.datastore.get_user(auth.username)
+    user = find_user(auth.username)
 
     if user and user.verify_and_update_password(auth.password):
         _security.datastore.commit()

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ tests_require = [
 ]
 
 extras_require = {
-    "docs": ["Pallets-Sphinx-Themes>=1.2.1", "Sphinx>=3.0.3", "sphinx-issues>=1.2.0"],
+    "docs": ["Pallets-Sphinx-Themes>=1.2.3", "Sphinx>=3.0.3", "sphinx-issues>=1.2.0"],
     "tests": tests_require,
 }
 
@@ -47,7 +47,7 @@ extras_require["all"] = []
 for reqs in extras_require.values():
     extras_require["all"].extend(reqs)
 
-setup_requires = ["Babel>=1.3", "pytest-runner>=5.2", "twine", "wheel"]
+setup_requires = ["Babel>=2.8.0", "pytest-runner>=5.2", "twine", "wheel"]
 
 install_requires = [
     "Flask>=1.1.1",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,6 +39,18 @@ def test_cli_createuser(script_info):
     )
     assert result.exit_code == 0
 
+    # create user with email and username
+    result = runner.invoke(
+        users_create,
+        ["email1@example.org", "username:lookatme!", "--password", "battery staple"],
+        obj=script_info,
+    )
+    assert result.exit_code == 0
+
+    # try to activate using username
+    result = runner.invoke(users_activate, "lookatme!", obj=script_info)
+    assert result.exit_code == 0
+
 
 def test_cli_createrole(script_info):
     """Test create user CLI."""

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -15,6 +15,8 @@ import pytest
 
 from flask import Blueprint
 
+from flask_security import uia_email_mapper
+
 from tests.test_utils import (
     authenticate,
     json_authenticate,
@@ -370,7 +372,12 @@ def test_http_auth(client):
     assert b"HTTP Authentication" in response.data
 
 
-@pytest.mark.settings(USER_IDENTITY_ATTRIBUTES=("email", "username"))
+@pytest.mark.settings(
+    USER_IDENTITY_ATTRIBUTES=[
+        {"email": {"mapper": uia_email_mapper}},
+        {"username": {"mapper": lambda x: x}},
+    ]
+)
 def test_http_auth_username(client):
     response = client.get(
         "/http",

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -235,17 +235,6 @@ def test_logout_methods_none(app, sqlalchemy_datastore):
     assert response.status_code == 404
 
 
-def test_addition_identity_attributes(app, sqlalchemy_datastore):
-    init_app_with_options(
-        app,
-        sqlalchemy_datastore,
-        **{"SECURITY_USER_IDENTITY_ATTRIBUTES": ("email", "username")}
-    )
-    client = app.test_client()
-    response = authenticate(client, email="matt", follow_redirects=True)
-    assert b"Welcome matt@lp.com" in response.data
-
-
 def test_passwordless_and_two_factor_configuration_mismatch(app, sqlalchemy_datastore):
     with pytest.raises(ValueError):
         init_app_with_options(


### PR DESCRIPTION
Aka - get rid of get_user.

Now, when looking up a user by identity attribute (such as in login, cli), FS will loop through each configured USER_IDENTITY_ATTRIBUTE and calling a mapping function which determines whether the input value is valid for that attribute - then the usermodel.find_user is called with the matching attribute name and value. This paradigm was introduced in 3.4 as part of Unified Sign In - and now is in use everywhere.

removing usermodel.get_user resolves a lot of historic issues with DBs and ORMs really not liking querying on different type entities.

Fix/enhance CLI so that you can create a user with multiple identity attributes (before the same value was set to all identity attributes).

N.B. with this PR - there is a regression with registration as noted in CHANGES.rst

closes: #337