### PR TITLE
Fix peewee

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,12 @@ Features
   primary key.
 - (:pr:`xxx`) Change ``USER_IDENTITY_ATTRIBUTES`` configuration variable semantics.
 
+Fixed
++++++
+- (:issue:`347`) Fix peewee. Turns out - due to lack of unit tests - peewee hasn't worked since
+  'permissions' were added in 3.3. Furthermore, changes in 3.4 around get_id and alternative tokens also
+  didn't work since peewee defines its own `get_id`.
+
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
 - (:pr:`328`) Remove dependence on Flask-Mail and refactor. The ``send_mail_task`` and

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -272,6 +272,7 @@ possible using MongoEngine:
     class Role(db.Document, RoleMixin):
         name = db.StringField(max_length=80, unique=True)
         description = db.StringField(max_length=255)
+        permissions = db.StringField(max_length=255)
 
     class User(db.Document, UserMixin):
         email = db.StringField(max_length=255)
@@ -347,11 +348,14 @@ possible using Peewee:
     # Create database connection object
     db = FlaskDB(app)
 
-    class Role(db.Model, RoleMixin):
+    class Role(RoleMixin, db.Model):
         name = CharField(unique=True)
         description = TextField(null=True)
+        permissions = TextField(null=True)
 
-    class User(db.Model, UserMixin):
+    # N.B. order is important since db.Model also contains a get_id() -
+    # we need the one from UserMixin.
+    class User(UserMixin, db.Model):
         email = TextField()
         password = TextField()
         active = BooleanField(default=True)
@@ -366,6 +370,9 @@ possible using Peewee:
         role = ForeignKeyField(Role, related_name='users')
         name = property(lambda self: self.role.name)
         description = property(lambda self: self.role.description)
+
+        def get_permissions(self):
+            return self.role.get_permissions()
 
     # Setup Flask-Security
     user_datastore = PeeweeUserDatastore(db, User, Role, UserRoles)

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -155,12 +155,10 @@ def roles_add(user, role):
     if user_obj is None:
         raise click.UsageError("ERROR: User not found.")
 
-    user, role = _datastore._prepare_role_modify_args(user_obj, role)
-    if user is None:
-        raise click.UsageError("Cannot find user.")
+    role = _datastore._prepare_role_modify_args(role)
     if role is None:
         raise click.UsageError("Cannot find role.")
-    if _datastore.add_role_to_user(user, role):
+    if _datastore.add_role_to_user(user_obj, role):
         click.secho(
             f'Role "{role}" added to user "{user}" successfully.', fg="green",
         )
@@ -179,12 +177,10 @@ def roles_remove(user, role):
     if user_obj is None:
         raise click.UsageError("ERROR: User not found.")
 
-    user, role = _datastore._prepare_role_modify_args(user_obj, role)
-    if user is None:
-        raise click.UsageError("Cannot find user.")
+    role = _datastore._prepare_role_modify_args(role)
     if role is None:
         raise click.UsageError("Cannot find role.")
-    if _datastore.remove_role_from_user(user, role):
+    if _datastore.remove_role_from_user(user_obj, role):
         click.secho(
             f'Role "{role}" removed from user "{user}" successfully.', fg="green",
         )

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -614,9 +614,8 @@ class RoleMixin:
         """
         Return set of permissions associated with role.
 
-        Either takes a comma separated string of permissions or
-        an interable of strings if permissions are in their own
-        table.
+        Supports permissions being a comma separated string, an iterable, or a set
+        based on how the underlying DB model was built.
 
         .. versionadded:: 3.3.0
         """
@@ -636,9 +635,10 @@ class RoleMixin:
 
         :param permissions: a set, list, or single string.
 
-        Caller must commit to DB.
-
         .. versionadded:: 3.3.0
+
+        .. deprecated:: 4.0.0
+            Use :meth:`.UserDatastore.add_permissions_to_role`
         """
         if hasattr(self, "permissions"):
             current_perms = self.get_permissions()
@@ -649,7 +649,7 @@ class RoleMixin:
             else:
                 perms = {permissions}
             self.permissions = ",".join(current_perms.union(perms))
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError("Role model doesn't have permissions")
 
     def remove_permissions(self, permissions):
@@ -658,9 +658,10 @@ class RoleMixin:
 
         :param permissions: a set, list, or single string.
 
-        Caller must commit to DB.
-
         .. versionadded:: 3.3.0
+
+        .. deprecated:: 4.0.0
+            Use :meth:`.UserDatastore.remove_permissions_from_role`
         """
         if hasattr(self, "permissions"):
             current_perms = self.get_permissions()
@@ -671,7 +672,7 @@ class RoleMixin:
             else:
                 perms = {permissions}
             self.permissions = ",".join(current_perms.difference(perms))
-        else:
+        else:  # pragma: no cover
             raise NotImplementedError("Role model doesn't have permissions")
 
 
@@ -730,9 +731,8 @@ class UserMixin(BaseUserMixin):
 
         """
         for role in self.roles:
-            if hasattr(role, "permissions"):
-                if permission in role.get_permissions():
-                    return True
+            if permission in role.get_permissions():
+                return True
         return False
 
     def get_security_payload(self):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -265,42 +265,42 @@ def test_unauthorized_access_with_referrer(client, get_message):
 
 
 @pytest.mark.settings(unauthorized_view="/unauthz")
-def test_roles_accepted(client):
+def test_roles_accepted(clients):
     # This specificaly tests that we can pass a URL for unauthorized_view.
     for user in ("matt@lp.com", "joe@lp.com"):
-        authenticate(client, user)
-        response = client.get("/admin_or_editor")
+        authenticate(clients, user)
+        response = clients.get("/admin_or_editor")
         assert b"Admin or Editor Page" in response.data
-        logout(client)
+        logout(clients)
 
-    authenticate(client, "jill@lp.com")
-    response = client.get("/admin_or_editor", follow_redirects=True)
+    authenticate(clients, "jill@lp.com")
+    response = clients.get("/admin_or_editor", follow_redirects=True)
     assert b"Unauthorized" in response.data
 
 
 @pytest.mark.settings(unauthorized_view="unauthz")
-def test_permissions_accepted(client):
+def test_permissions_accepted(clients):
     for user in ("matt@lp.com", "joe@lp.com"):
-        authenticate(client, user)
-        response = client.get("/admin_perm")
+        authenticate(clients, user)
+        response = clients.get("/admin_perm")
         assert b"Admin Page with full-write or super" in response.data
-        logout(client)
+        logout(clients)
 
-    authenticate(client, "jill@lp.com")
-    response = client.get("/admin_perm", follow_redirects=True)
+    authenticate(clients, "jill@lp.com")
+    response = clients.get("/admin_perm", follow_redirects=True)
     assert b"Unauthorized" in response.data
 
 
 @pytest.mark.settings(unauthorized_view="unauthz")
-def test_permissions_required(client):
+def test_permissions_required(clients):
     for user in ["matt@lp.com"]:
-        authenticate(client, user)
-        response = client.get("/admin_perm_required")
+        authenticate(clients, user)
+        response = clients.get("/admin_perm_required")
         assert b"Admin Page required" in response.data
-        logout(client)
+        logout(clients)
 
-    authenticate(client, "joe@lp.com")
-    response = client.get("/admin_perm_required", follow_redirects=True)
+    authenticate(clients, "joe@lp.com")
+    response = clients.get("/admin_perm_required", follow_redirects=True)
     assert b"Unauthorized" in response.data
 
 
@@ -311,15 +311,15 @@ def test_unauthenticated_role_required(client, get_message):
 
 
 @pytest.mark.settings(unauthorized_view="unauthz")
-def test_multiple_role_required(client):
+def test_multiple_role_required(clients):
     for user in ("matt@lp.com", "joe@lp.com"):
-        authenticate(client, user)
-        response = client.get("/admin_and_editor", follow_redirects=True)
+        authenticate(clients, user)
+        response = clients.get("/admin_and_editor", follow_redirects=True)
         assert b"Unauthorized" in response.data
-        client.get("/logout")
+        clients.get("/logout")
 
-    authenticate(client, "dave@lp.com")
-    response = client.get("/admin_and_editor", follow_redirects=True)
+    authenticate(clients, "dave@lp.com")
+    response = clients.get("/admin_and_editor", follow_redirects=True)
     assert b"Admin and Editor Page" in response.data
 
 

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -119,6 +119,8 @@ def test_confirmable_flag(app, clients, get_message):
     with app.app_context():
         app.security.datastore.delete(user)
         app.security.datastore.commit()
+        if hasattr(app.security.datastore.db, "close_db"):
+            app.security.datastore.db.close_db(None)
 
     response = clients.get("/confirm/" + token, follow_redirects=True)
     assert get_message("INVALID_CONFIRMATION_TOKEN") in response.data


### PR DESCRIPTION
peewee ORM has been broken for a while - basically there weren't tests that tested higher level functionality. Added support for lower-case in find_user.

This uncovered a bug in permissions - add/remove in the RoleMixin are fine - but all mutating operations need to be accessible from the datastore
layer so that a db.put() can be done. So new methods - add_permission_to_role and remove_permission_from_role were added to UserDatastore.

Unrelated (but what found all these issues) - change _prepare_role_modify_args - which is just used by CLI to not take user - assume user is always an object so that that method doesn't assume 'email' is the primary user identity method.

Update quickstart for peewee to hopefully be correct.

closes: #347