### PR TITLE
Improve CLI

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,7 +24,7 @@ Features
   not making sense - the documentation has never been correct.
 - (:pr:`339`) Require ``fs_uniquifier`` in the UserModel and stop using/referencing the UserModel
   primary key.
-- (:pr:`xxx`) Change ``USER_IDENTITY_ATTRIBUTES`` configuration variable semantics.
+- (:pr:`349`) Change ``USER_IDENTITY_ATTRIBUTES`` configuration variable semantics.
 
 Fixed
 +++++
@@ -56,7 +56,7 @@ Backwards Compatibility Concerns
   interprets or uses the UserModel primary key - just the ``fs_uniquifier`` field. See the changes section for 3.3
   for information on how to do the schema and data upgrades required to add this field.
 
-- (:pr:`xxx`) :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES` has changed syntax and semantics. It now contains
+- (:pr:`349`) :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES` has changed syntax and semantics. It now contains
   the combined information from the old USER_IDENTITY_ATTRIBUTES and the newly introduced in 3.4 :py:data:`SECURITY_USER_IDENTITY_MAPPINGS`.
   This enabled changing the underlying way we validate credentials in the login form and unified sign in form.
   In prior releases we simply tried to look up the form value as the PK of the UserModel - this often failed and then
@@ -64,11 +64,9 @@ Backwards Compatibility Concerns
   wanting to have a standard PK for the user model. Now, using the mapping configuration, the UserModel attribute/column the input
   corresponds to is determined, then the UserModel is queried specifically for that *attribute:value* pair.
 
-  This affects Registration as well - in prior releases, the default RegisterForm had a field called ``email``. However
-  the code called UserModel.get_user() with the value of this field, which would proceed to query ALL configured USER_IDENTITY_ATTRIBUTES.
-  Some applications used this fact to effectively change what the application user needed to log in - however mostly it generated
-  extreme confusion with developers. While it is easy to extend the RegistrationForm and template to add additional attributes,
-  ``email`` is required (a regression from 3.4)
+- (:pr:`xxx`) The :class:`flask_security.PhoneUtil` is now initialized as part of Flask-Security initialization rather than
+  ``@app.before_first_request`` (since that broke the CLI). So it isn't called in an application context, the *app* being initialized is
+  passed as an argument to *__init__*.
 
 .. _here: https://github.com/Flask-Middleware/flask-security/issues/85
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -139,9 +139,11 @@ Utils
 
 .. autoclass:: flask_security.PhoneUtil
   :members:
+  :special-members: __init__
 
 .. autoclass:: flask_security.MailUtil
   :members:
+  :special-members: __init__
 
 .. autoclass:: flask_security.SmsSenderBaseClass
   :members: send_sms

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1107,13 +1107,8 @@ class Security:
                 # Add configured header to WTF_CSRF_HEADERS
                 current_app.config["WTF_CSRF_HEADERS"].append(cv("CSRF_HEADER"))
 
-        @app.before_first_request
-        def _init_phone_util():
-            state._phone_util = state.phone_util_cls()
-
-        @app.before_first_request
-        def _init_mail_util():
-            state._mail_util = state.mail_util_cls()
+        state._phone_util = state.phone_util_cls(app)
+        state._mail_util = state.mail_util_cls(app)
 
         app.extensions["security"] = state
 

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -161,6 +161,7 @@ class UserDatastore:
         :param user: The user to manipulate. Can be an User object or email
         :param role: The role to add to the user. Can be a Role object or
             string role name
+        :return: True is role was added, False if role already existed.
         """
         role = self._prepare_role_modify_args(role)
         if role not in user.roles:
@@ -175,6 +176,8 @@ class UserDatastore:
         :param user: The user to manipulate. Can be an User object or email
         :param role: The role to remove from the user. Can be a Role object or
             string role name
+        :return: True if role was removed, False if role doesn't exist or user didn't
+            have role.
         """
         rv = False
         role = self._prepare_role_modify_args(role)
@@ -190,16 +193,20 @@ class UserDatastore:
         :param role: The role to modify. Can be a Role object or
             string role name
         :param permissions: a set, list, or single string.
+        :return: True if permissions added, False if role doesn't exist.
 
         Caller must commit to DB.
 
         .. versionadded:: 4.0.0
         """
 
+        rv = False
         role = self._prepare_role_modify_args(role)
-        role.add_permissions(permissions)
-        self.put(role)
-        return role.get_permissions()
+        if role:
+            rv = True
+            role.add_permissions(permissions)
+            self.put(role)
+        return rv
 
     def remove_permissions_from_role(self, role, permissions):
         """Remove one or more permissions from a role.
@@ -207,16 +214,20 @@ class UserDatastore:
         :param role: The role to modify. Can be a Role object or
             string role name
         :param permissions: a set, list, or single string.
+        :return: True if permissions removed, False if role doesn't exist.
 
         Caller must commit to DB.
 
         .. versionadded:: 4.0.0
         """
 
+        rv = False
         role = self._prepare_role_modify_args(role)
-        role.remove_permissions(permissions)
-        self.put(role)
-        return role.get_permissions()
+        if role:
+            rv = True
+            role.remove_permissions(permissions)
+            self.put(role)
+        return rv
 
     def toggle_active(self, user):
         """Toggles a user's active status. Always returns True."""

--- a/flask_security/mail_util.py
+++ b/flask_security/mail_util.py
@@ -21,11 +21,17 @@ _security = LocalProxy(lambda: current_app.extensions["security"])
 class MailUtil:
     """
     To provide your own implementation, pass in the class as ``mail_util_cls``
-    at init time. Your class will be instantiated once prior to the first
-    request being handled.
+    at init time.  Your class will be instantiated once as part of app initialization.
 
     .. versionadded:: 4.0.0
     """
+
+    def __init__(self, app):
+        """ Instantiate class.
+
+        :param app: The Flask application being initialized.
+        """
+        pass
 
     def send_mail(
         self, template, subject, recipient, sender, body, html, user, **kwargs

--- a/flask_security/phone_util.py
+++ b/flask_security/phone_util.py
@@ -19,11 +19,20 @@ class PhoneUtil:
     Subclass this to use a different underlying phone number parsing library.
 
     To provide your own implementation, pass in the class as ``phone_util_cls``
-    at init time. Your class will be instantiated once prior to the first
-    request being handled.
+    at init time. Your class will be instantiated once as part of app initialization.
 
     .. versionadded:: 3.4.0
+
+    .. versionchanged:: 4.0.0
+        __init__ takes app argument
     """
+
+    def __init__(self, app):
+        """ Instantiate class.
+
+        :param app: The Flask application being initialized.
+        """
+        pass
 
     def validate_phone_number(self, input_data):
         """ Return ``None`` if a valid phone number else an error message. """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -697,7 +697,8 @@ def datastore(request, app, tmpdir, realdburl):
 
 
 @pytest.fixture()
-def script_info(app, datastore):
+# def script_info(app, datastore): # Fix me when pony works
+def script_info(app, sqlalchemy_datastore):
     from flask.cli import ScriptInfo
 
     def create_app(info):
@@ -707,7 +708,7 @@ def script_info(app, datastore):
         ]
 
         app.config.update(**{"SECURITY_USER_IDENTITY_ATTRIBUTES": uia})
-        app.security = Security(app, datastore=datastore)
+        app.security = Security(app, datastore=sqlalchemy_datastore)
         return app
 
     return ScriptInfo(create_app=create_app)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -62,6 +62,9 @@ from flask_security.utils import (
 @pytest.mark.recoverable()
 def test_my_mail_util(app, sqlalchemy_datastore):
     class MyMailUtil:
+        def __init__(self, app):
+            pass
+
         def send_mail(self, template, subject, recipient, sender, body, html, user):
             assert template == "reset_instructions"
             assert subject == app.config["SECURITY_EMAIL_SUBJECT_PASSWORD_RESET"]
@@ -666,6 +669,9 @@ def test_method_view(app, client):
 
 def test_phone_util_override(app):
     class MyPhoneUtil:
+        def __init__(self, app):
+            pass
+
         def validate_phone_number(self, input_data):
             return "call-me"
 


### PR DESCRIPTION
Add better help.

users_create now takes attr:value pairs so any attribute of the UserModel can be set (not just identity attributes).

Add new commands - add_permissions and remove_permissions.

Add new command - reset_access.

When testing it became obvious that CLIs don't issue 'requests' so that initialization done as part of @app.before_first_request wouldn't be done -
that's how we initialized the phone_util and mail_util classes - changed those to be instantiated as part of normal Flask-Security initialization.

Temporarily disable testing pony and other datastores against CLI (since pony doesn't work with permissions yet).

Remove wording in CHANGES around breaking Registration - don't think that actually is a regression.

closes: #345, #296