### PR TITLE
Remove all requirements of 'email' as a USER_IDENTITY_ATTRIBUTE.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -128,6 +128,8 @@ Utils
 
 .. autofunction:: flask_security.transform_url
 
+.. autofunction:: flask_security.unique_identity_attribute
+
 .. autofunction:: flask_security.us_send_security_token
 
 .. autofunction:: flask_security.tf_send_security_token

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -165,9 +165,9 @@ paths:
           headers:
             Location:
               description: |
-                On spa-success: SECURITY_POST_LOGIN_VIEW?email={email}
+                On spa-success: SECURITY_POST_LOGIN_VIEW?identity={identity}&email={email}
 
-                On spa-error-expired: SECURITY_LOGIN_ERROR_VIEW?error={msg}&email={email}
+                On spa-error-expired: SECURITY_LOGIN_ERROR_VIEW?error={msg}&identity={identity}&email={email}
 
                 On spa-error-invalid-token: SECURITY_LOGIN_ERROR_VIEW?error={msg}
 
@@ -402,9 +402,9 @@ paths:
           headers:
             Location:
               description: |
-                On spa-success: SECURITY_RESET_VIEW?token={token}&email={email}
+                On spa-success: SECURITY_RESET_VIEW?token={token}&identity={identity}&email={email}
 
-                On spa-error-expired: SECURITY_RESET_ERROR_VIEW?error={msg}&email={email}
+                On spa-error-expired: SECURITY_RESET_ERROR_VIEW?error={msg}&identity={identity}&email={email}
 
                 On spa-error-invalid-token: SECURITY_RESET_ERROR_VIEW?error={msg}
 
@@ -413,9 +413,9 @@ paths:
                 type: string
               examples:
                 spa-success:
-                  value: SECURITY_RESET_VIEW?token={token}&email={email}
+                  value: SECURITY_RESET_VIEW?token={token}&identity={identity}&email={email}
                 spa-error-expired:
-                  value: SECURITY_RESET_ERROR_VIEW?error={msg}&email={email}
+                  value: SECURITY_RESET_ERROR_VIEW?error={msg}&identity={identity}&email={email}
                 spa-error-invalid-token:
                   value: SECURITY_RESET_ERROR_VIEW?error={msg}
                 default-error:
@@ -531,9 +531,9 @@ paths:
           headers:
             Location:
               description: |
-                On spa-success: SECURITY_POST_CONFIRM_VIEW?email={email}&{level}={msg}
+                On spa-success: SECURITY_POST_CONFIRM_VIEW?identity={identity}&email={email}&{level}={msg}
 
-                On spa-error-expired: SECURITY_CONFIRM_ERROR_VIEW?error={msg}&email={email}
+                On spa-error-expired: SECURITY_CONFIRM_ERROR_VIEW?error={msg}&identity={identity}&email={email}
 
                 On spa-error-invalid-token: SECURITY_CONFIRM_ERROR_VIEW?error={msg}
 
@@ -942,7 +942,7 @@ paths:
           headers:
             Location:
               description: |
-                On spa-success: SECURITY_POST_LOGIN_VIEW?email={email}
+                On spa-success: SECURITY_POST_LOGIN_VIEW?identity={identity}&email={email}
 
                 On spa-error-expired: SECURITY_LOGIN_ERROR_VIEW?error={msg}
 
@@ -1006,10 +1006,6 @@ components:
           description: >
             By default an empty dictionary is returned. However by overriding _User::get_security_payload()_ any attributes of the User model can be returned.
           properties:
-            email:
-              type: string
-              example: me@me.com
-              description: Email address of the user (you must implement get_security_payload to add this.
             authentication_token:
               type: string
               description: >

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -47,6 +47,7 @@ from .forms import (
     TwoFactorSetupForm,
     TwoFactorVerifyCodeForm,
     VerifyForm,
+    unique_identity_attribute,
 )
 from .mail_util import MailUtil
 from .phone_util import PhoneUtil

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -746,10 +746,15 @@ class UserMixin(BaseUserMixin):
         :return: A dict whose keys will be query params and values will be query values.
 
         .. versionadded:: 3.2.0
+
+        .. versionchanged:: 4.0.0
+            Add 'identity' using UserMixin.calc_username() - email is optional.
         """
         if not existing:
             existing = {}
-        existing.update({"email": self.email})
+        if hasattr(self, "email"):
+            existing.update({"email": self.email})
+        existing.update({"identity": self.calc_username()})
         return existing
 
     def verify_and_update_password(self, password):

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -153,8 +153,16 @@ def unique_user_email(form, field):
         raise ValidationError(msg)
 
 
-def unique_identity_attribute(form, field):  # pragma no cover
-    # TODO - use this for registration?
+def unique_identity_attribute(form, field):
+    """A validator that checks the field data against all configured
+    SECURITY_USER_IDENTITY_ATTRIBUTES.
+    This can be used as part of registration.
+
+    :param form:
+    :param field:
+    :return: Nothing; if field data corresponds to an existing User, ValidationError
+        is raised.
+    """
     for mapping in config_value("USER_IDENTITY_ATTRIBUTES"):
         attr = list(mapping.keys())[0]
         details = mapping[attr]

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -592,7 +592,7 @@ def reset_password(token):
             return tf_login(user, primary_authn_via="reset")
         login_user(user, authn_via=["reset"])
         if _security._want_json(request):
-            login_form = _security.login_form(MultiDict({"email": user.email}))
+            login_form = _security.login_form()
             login_form.user = user
             return base_render_json(login_form, include_auth_token=True)
         else:

--- a/tests/templates/_nav.html
+++ b/tests/templates/_nav.html
@@ -1,5 +1,5 @@
 {%- if current_user.is_authenticated -%}
-  <p>{{ _fsdomain('Welcome') }} {{ current_user.email }}</p>
+  <p>{{ _fsdomain('Welcome') }} {{ current_user.calc_username() }}</p>
 {%- endif %}
 <ul>
   <li><a href="{{ url_for('index') }}">Index</a></li>

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -162,8 +162,7 @@ def test_spa_get_bad_token(app, client, get_message):
         assert "localhost:8081" == split.netloc
         assert "/login-error" == split.path
         qparams = dict(parse_qsl(split.query))
-        assert len(qparams) == 2
-        assert all(k in qparams for k in ["email", "error"])
+        assert all(k in qparams for k in ["email", "error", "identity"])
 
         msg = get_message("LOGIN_EXPIRED", within="1 milliseconds", email="matt@lp.com")
         assert msg == qparams["error"].encode("utf-8")

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -427,8 +427,7 @@ def test_spa_get_bad_token(app, client, get_message):
         assert "localhost:8081" == split.netloc
         assert "/reset-error" == split.path
         qparams = dict(parse_qsl(split.query))
-        assert len(qparams) == 2
-        assert all(k in qparams for k in ["email", "error"])
+        assert all(k in qparams for k in ["email", "error", "identity"])
 
         msg = get_message(
             "PASSWORD_RESET_EXPIRED", within="1 milliseconds", email="joe@lp.com"


### PR DESCRIPTION
Adds tests that have username as the identity attribute, but still support getting and storing an email address for confirmation.

Added public API validator for unique identity attribute.

API changes - the JSON response, no longer require email in User model - return calc_username() instead.