### PR TITLE
Fix Basic Auth.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Release Target 2020
 Version 3.4.4
 --------------
 
-Released July xx, 2020
+Released July yy, 2020
 
 Bug/regression fixes.
 


### PR DESCRIPTION
In 3.3.0 the unauthenticated handler was changed to always redirect to the login view - that broke Basic Auth that of course requires a 401 with WWW-Authenticate header returned.

This also uncovered a redirect loop when redirecting in /login when the caller was already authenticated. Prior behavior was restored.

closes: #359