### PR TITLE
Allow redirects on subdomains

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -27,9 +27,8 @@ These configuration keys are used globally across all features.
 
 .. py:data:: SECURITY_SUBDOMAIN
 
-    Specifies the subdomain for the Flask-Security blueprint. If set together with
-    Flask's ``SERVER_NAME`` configuration, will also allow post-login redirects
-    on subdomains of the base domain.
+    Specifies the subdomain for the Flask-Security blueprint. If your authenticated
+    content is on a different subdomain, also enable ``SECURITY_REDIRECT_ALLOW_SUBDOMAINS``.
 
     Default: ``None``.
 .. py:data:: SECURITY_FLASH_MESSAGES
@@ -190,6 +189,17 @@ These configuration keys are used globally across all features.
     Default: ``None``.
 
     .. versionadded:: 3.3.0
+
+.. py:data:: SECURITY_REDIRECT_ALLOW_SUBDOMAINS
+
+    If ``True`` then subdomains (and the root domain) of the top-level host set
+    by Flask's ``SERVER_NAME`` configuration will be allowed as post-login redirect targets.
+    This is beneficial if you wish to place your authentiation on one subdomain and
+    authenticated content on another, for example ``auth.domain.tld`` and ``app.domain.tld``.
+
+    Default: ``False``.
+
+    .. versionadded:: 3.4.5
 
 .. py:data:: SECURITY_CSRF_PROTECT_MECHANISMS
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -27,7 +27,9 @@ These configuration keys are used globally across all features.
 
 .. py:data:: SECURITY_SUBDOMAIN
 
-    Specifies the subdomain for the Flask-Security blueprint.
+    Specifies the subdomain for the Flask-Security blueprint. If set together with
+    Flask's ``SERVER_NAME`` configuration, will also allow post-login redirects
+    on subdomains of the base domain.
 
     Default: ``None``.
 .. py:data:: SECURITY_FLASH_MESSAGES

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -153,6 +153,7 @@ _default_config = {
     "LOGIN_ERROR_VIEW": None,
     "REDIRECT_HOST": None,
     "REDIRECT_BEHAVIOR": None,
+    "REDIRECT_ALLOW_SUBDOMAINS": False,
     "FORGOT_PASSWORD_TEMPLATE": "security/forgot_password.html",
     "LOGIN_USER_TEMPLATE": "security/login_user.html",
     "REGISTER_USER_TEMPLATE": "security/register_user.html",

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -467,25 +467,24 @@ def url_for_security(endpoint, **values):
     return url_for(endpoint, **values)
 
 
-def validate_url_is_subdomain(url):
-    if url is None or url.strip() == "":
-        return False
-    url_split = urlsplit(url)
-    base_domain = current_app.config.get("SERVER_NAME")
-    if base_domain and url_split.netloc.endswith(f".{base_domain}"):
-        return True
-    return False
-
-
 def validate_redirect_url(url):
     if url is None or url.strip() == "":
         return False
     url_next = urlsplit(url)
     url_base = urlsplit(request.host_url)
     if (url_next.netloc or url_next.scheme) and url_next.netloc != url_base.netloc:
-        # Require that both the SECURITY_SUBDOMAIN config option is set as well as
-        # Flask's SERVER_NAME setting to explictly enable subdomain redirects
-        return bool(config_value("SUBDOMAIN")) and validate_url_is_subdomain(url)
+        base_domain = current_app.config.get("SERVER_NAME")
+        if (
+            config_value("REDIRECT_ALLOW_SUBDOMAINS")
+            and base_domain
+            and (
+                url_next.netloc == base_domain
+                or url_next.netloc.endswith(f".{base_domain}")
+            )
+        ):
+            return True
+        else:
+            return False
     return True
 
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -473,6 +473,9 @@ def validate_redirect_url(url):
     url_next = urlsplit(url)
     url_base = urlsplit(request.host_url)
     if (url_next.netloc or url_next.scheme) and url_next.netloc != url_base.netloc:
+        base_domain = current_app.config.get("SERVER_NAME")
+        if base_domain and url_next.netloc.endswith(f'.{base_domain}'):
+            return True
         return False
     return True
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -467,16 +467,25 @@ def url_for_security(endpoint, **values):
     return url_for(endpoint, **values)
 
 
+def validate_url_is_subdomain(url):
+    if url is None or url.strip() == "":
+        return False
+    url_split = urlsplit(url)
+    base_domain = current_app.config.get("SERVER_NAME")
+    if base_domain and url_split.netloc.endswith(f".{base_domain}"):
+        return True
+    return False
+
+
 def validate_redirect_url(url):
     if url is None or url.strip() == "":
         return False
     url_next = urlsplit(url)
     url_base = urlsplit(request.host_url)
     if (url_next.netloc or url_next.scheme) and url_next.netloc != url_base.netloc:
-        base_domain = current_app.config.get("SERVER_NAME")
-        if base_domain and url_next.netloc.endswith(f'.{base_domain}'):
-            return True
-        return False
+        # Require that both the SECURITY_SUBDOMAIN config option is set as well as
+        # Flask's SERVER_NAME setting to explictly enable subdomain redirects
+        return bool(config_value("SUBDOMAIN")) and validate_url_is_subdomain(url)
     return True
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -73,35 +73,33 @@ def test_authenticate_with_invalid_malformed_next(client, get_message):
 
 def test_authenticate_with_subdomain_next(app, client, get_message):
     app.config["SERVER_NAME"] = "lp.com"
-    app.config["SECURITY_SUBDOMAIN"] = "auth"
+    app.config["SECURITY_REDIRECT_ALLOW_SUBDOMAINS"] = True
     data = dict(email="matt@lp.com", password="password")
-    response = client.post("/login?next=http://subdomain.lp.com", data=data)
+    response = client.post("/login?next=http://sub.lp.com", data=data)
+    assert response.status_code == 302
+
+
+def test_authenticate_with_root_domain_next(app, client, get_message):
+    app.config["SERVER_NAME"] = "lp.com"
+    app.config["SECURITY_SUBDOMAIN"] = "auth"
+    app.config["SECURITY_REDIRECT_ALLOW_SUBDOMAINS"] = True
+    data = dict(email="matt@lp.com", password="password")
+    response = client.post("/login?next=http://lp.com", data=data)
     assert response.status_code == 302
 
 
 def test_authenticate_with_invalid_subdomain_next(app, client, get_message):
     app.config["SERVER_NAME"] = "lp.com"
-    app.config["SECURITY_SUBDOMAIN"] = "auth"
+    app.config["SECURITY_REDIRECT_ALLOW_SUBDOMAINS"] = True
     data = dict(email="matt@lp.com", password="password")
-    response = client.post("/login?next=http://subdomain.lp.net", data=data)
+    response = client.post("/login?next=http://sub.lp.net", data=data)
     assert get_message("INVALID_REDIRECT") in response.data
 
 
-def test_authenticate_with_subdomain_next_invalid_config(app, client, get_message):
+def test_authenticate_with_subdomain_next_default_config(app, client, get_message):
     app.config["SERVER_NAME"] = "lp.com"
-    app.config["SECURITY_SUBDOMAIN"] = None
     data = dict(email="matt@lp.com", password="password")
-    response = client.post("/login?next=http://subdomain.lp.com", data=data)
-    assert get_message("INVALID_REDIRECT") in response.data
-
-
-def test_authenticate_with_subdomain_next_invalid_flask_config(
-    app, client, get_message
-):
-    app.config["SERVER_NAME"] = None
-    app.config["SECURITY_SUBDOMAIN"] = "auth"
-    data = dict(email="matt@lp.com", password="password")
-    response = client.post("/login?next=http://subdomain.lp.com", data=data)
+    response = client.post("/login?next=http://sub.lp.com", data=data)
     assert get_message("INVALID_REDIRECT") in response.data
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -71,6 +71,40 @@ def test_authenticate_with_invalid_malformed_next(client, get_message):
     assert get_message("INVALID_REDIRECT") in response.data
 
 
+def test_authenticate_with_subdomain_next(app, client, get_message):
+    app.config["SERVER_NAME"] = "lp.com"
+    app.config["SECURITY_SUBDOMAIN"] = "auth"
+    data = dict(email="matt@lp.com", password="password")
+    response = client.post("/login?next=http://subdomain.lp.com", data=data)
+    assert response.status_code == 302
+
+
+def test_authenticate_with_invalid_subdomain_next(app, client, get_message):
+    app.config["SERVER_NAME"] = "lp.com"
+    app.config["SECURITY_SUBDOMAIN"] = "auth"
+    data = dict(email="matt@lp.com", password="password")
+    response = client.post("/login?next=http://subdomain.lp.net", data=data)
+    assert get_message("INVALID_REDIRECT") in response.data
+
+
+def test_authenticate_with_subdomain_next_invalid_config(app, client, get_message):
+    app.config["SERVER_NAME"] = "lp.com"
+    app.config["SECURITY_SUBDOMAIN"] = None
+    data = dict(email="matt@lp.com", password="password")
+    response = client.post("/login?next=http://subdomain.lp.com", data=data)
+    assert get_message("INVALID_REDIRECT") in response.data
+
+
+def test_authenticate_with_subdomain_next_invalid_flask_config(
+    app, client, get_message
+):
+    app.config["SERVER_NAME"] = None
+    app.config["SECURITY_SUBDOMAIN"] = "auth"
+    data = dict(email="matt@lp.com", password="password")
+    response = client.post("/login?next=http://subdomain.lp.com", data=data)
+    assert get_message("INVALID_REDIRECT") in response.data
+
+
 def test_authenticate_case_insensitive_email(app, client):
     response = authenticate(client, "MATT@lp.com", follow_redirects=True)
     assert b"Welcome matt@lp.com" in response.data


### PR DESCRIPTION
Currently, post-login redirects to any external host are (correctly) blocked. However, given that Flask Security allows for its blueprint to be registered on a specific subdomain, this creates a use-case whereby the developer might wish to deploy flask-security based authentication at `auth.domain.tld` and then redirect users to `app.domain.tld`, `app2.domain.tld`, etc.

This PR introduces a conservative and opinionated approach to allowing redirects across subdomains that match on the domain of the [Flask app host](https://flask.palletsprojects.com/en/1.1.x/config/#SERVER_NAME).

The requirements for allowing subdomain redirects are:

- The config value `SECURITY_REDIRECT_ALLOW_SUBDOMAINS ` is set to `True`
- Flask's `app.config['SERVER_NAME']` is set (which is also required by Flask to enable subdomain route matching support)

With this configuration in place, Flask Security will allow redirects to `*.domain.tld` and `domain.tld` provided that `SERVER_NAME` is set to `domain.tld`.

There are additional cases where less explicit logic may be desired, for example, normalising or stripping the port number from `SERVER_NAME` on comparison, but I have not addressed this for now to establish the basics.

Closes #366