### PR TITLE
Fix Basic Auth.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -76,6 +76,35 @@ Backwards Compatibility Concerns
 
 .. _here: https://github.com/Flask-Middleware/flask-security/issues/85
 
+Version 3.4.4
+--------------
+
+Released July xx, 2020
+
+Bug/regression fixes.
+
+Fixed
++++++
+
+- (:issue:`359`) Basic Auth broken. When the unauthenticated handler was changed to provide a more
+  uniform/consistent response - it broke using Basic Auth from a browser, since it always redirected rather than
+  returning 401. Now, if the response headers contain  ``WWW-Authenticate``
+  (which is set if ``basic`` @auth_required method is used), a 401 is returned. See below
+  for backwards compatibility concerns.
+
+- (:pr:`xx`) As part of figuring out issue 359 - a redirect loop was found. In release 3.3.0 code was put
+  in to redirect to :py:data:`SECURITY_POST_LOGIN_VIEW` when GET or POST was called and the caller was already authenticated. The
+  method used would honor the request ``next`` query parameter. This could cause redirect loops. The pre-3.3.0 behavior
+  of redirecting to :py:data:`SECURITY_POST_LOGIN_VIEW` and ignoring the ``next`` parameter has been restored.
+
+Compatibility Concerns
+++++++++++++++++++++++
+
+In 3.3.0, `.Security.auth_required` was changed to add a default argument if none was given. The default
+include all current methods - ``session``, ``token``, and ``basic``. However ``basic`` really isn't like the others
+and requires that we send back a ``WWW-Authenticate`` header if authentication fails (and return a 401 and not redirect).
+``basic`` has been removed from the default set and must once again be explicitly requested.
+
 Version 3.4.3
 -------------
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -304,17 +304,21 @@ its own JsonEncoder on its blueprint.
 For a very long read and discussion; look at `this`_. Out of the box, Flask-Security in
 tandem with Flask-Login, behave as follows:
 
-    * If authentication fails as the result of a `@login_required`, `@auth_required`,
-      `@http_auth_required`, or `@token_auth_required` then if the request 'wants' a JSON
+    * If authentication fails as the result of a `@login_required`, `@auth_required("session", "token")`,
+      or `@token_auth_required` then if the request 'wants' a JSON
       response, :meth:`.Security.render_json` is called with a 401 status code. If not
       then flask_login.LoginManager.unauthorized() is called. By default THAT will redirect to
       a login view.
 
+    * If authentication fails as the result of a `@http_auth_required` or `@auth_required("basic")`
+      then a 401 is returned along with the http header ``WWW-Authenticate`` set to
+      ``Basic realm="xxxx"``. The realm name is defined by :py:data:`SECURITY_DEFAULT_HTTP_AUTH_REALM`.
+
     * If authorization fails as the result of `@roles_required`, `@roles_accepted`,
       `@permissions_required`, or `@permissions_accepted`, then if the request 'wants' a JSON
       response, :meth:`.Security.render_json` is called with a 403 status code. If not,
-      then if *SECURITY_UNAUTHORIZED_VIEW* is defined, the response will redirected.
-      If *SECURITY_UNAUTHORIZED_VIEW* is not defined, then ``abort(403)`` is called.
+      then if :py:data:`SECURITY_UNAUTHORIZED_VIEW` is defined, the response will redirected.
+      If :py:data:`SECURITY_UNAUTHORIZED_VIEW` is not defined, then ``abort(403)`` is called.
 
 All this can be easily changed by registering any or all of :meth:`.Security.render_json`,
 :meth:`.Security.unauthn_handler` and :meth:`.Security.unauthz_handler`.

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -64,21 +64,29 @@ def _get_unauthorized_response(text=None, headers=None):  # pragma: no cover
 def default_unauthn_handler(mechanisms, headers=None):
     """ Default callback for failures to authenticate
 
-    If caller wants JSON - return 401
+    If caller wants JSON - return 401.
+    If caller wants BasicAuth - return 401 (the WWW-Authenticate header is set).
     Otherwise - assume caller is html and redirect if possible to a login view.
     We let Flask-Login handle this.
 
     """
+    headers = headers or {}
     msg = get_message("UNAUTHENTICATED")[0]
 
     if config_value("BACKWARDS_COMPAT_UNAUTHN"):
         return _get_unauthenticated_response(headers=headers)
     if _security._want_json(request):
-        # Ignore headers since today, the only thing in there might be WWW-Authenticate
-        # and we never want to send that in a JSON response (browsers will intercept
-        # that and pop up their own login form).
+        # Remove WWW-Authenticate from headers for JSON responses since
+        # browsers will intercept that and pop up their own login form.
+        headers.pop("WWW-Authenticate", None)
         payload = json_error_response(errors=msg)
-        return _security._render_json(payload, 401, None, None)
+        return _security._render_json(payload, 401, headers, None)
+
+    # Basic-Auth is often used to provide a browser based login form and then the
+    # browser will always add the BasicAuth credentials. For that to work we need to
+    # return 401 and not redirect to our login view.
+    if "WWW-Authenticate" in headers:
+        return Response(msg, 401, headers)
     return _security.login_manager.unauthorized()
 
 
@@ -213,6 +221,9 @@ def http_auth_required(realm):
 
     :param realm: optional realm name
 
+    If authentication fails, then a 401 with the 'WWW-Authenticate' header set will be
+    returned.
+
     Once authenticated, if so configured, CSRF protection will be tested.
     """
 
@@ -272,7 +283,7 @@ def auth_required(*auth_methods, **kwargs):
             return 'Dashboard'
 
     :param auth_methods: Specified mechanisms (token, basic, session). If not specified
-        then all current available mechanisms will be tried.
+        then all current available mechanisms (except "basic") will be tried.
     :kwparam within: Add 'freshness' check to authentication. Is either an int
         specifying # of minutes, or a callable that returns a timedelta. For timedeltas,
         timedelta.total_seconds() is used for the calculations:
@@ -303,6 +314,11 @@ def auth_required(*auth_methods, **kwargs):
     As a side effect, upon successful authentication, the request global
      ``fs_authn_via`` will be set to the method ("basic", "token", "session")
 
+    .. note::
+        If "basic" is specified in addition to other methods, then if authentication
+        fails, a 401 with the "WWW-Authenticate" header will be returned - rather than
+        being redirected to the login view.
+
     .. versionchanged:: 3.3.0
        If ``auth_methods`` isn't specified, then all will be tried. Authentication
        mechanisms will always be tried in order of ``token``, ``session``, ``basic``
@@ -310,6 +326,9 @@ def auth_required(*auth_methods, **kwargs):
 
     .. versionchanged:: 3.4.0
         Added ``within`` and ``grace`` parameters to enforce a freshness check.
+
+    .. versionchanged:: 3.4.4
+        If ``auth_methods`` isn't specified try all mechanisms EXCEPT ``basic``.
 
     """
 
@@ -320,7 +339,7 @@ def auth_required(*auth_methods, **kwargs):
     }
     mechanisms_order = ["token", "session", "basic"]
     if not auth_methods:
-        auth_methods = {"basic", "session", "token"}
+        auth_methods = {"session", "token"}
     else:
         auth_methods = [am for am in auth_methods]
 

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -144,21 +144,20 @@ def login():
     """
 
     if current_user.is_authenticated and request.method == "POST":
-        # Just redirect current_user to POST_LOGIN_VIEW (or next).
+        # Just redirect current_user to POST_LOGIN_VIEW.
         # While its tempting to try to logout the current user and login the
         # new requested user - that simply doesn't work with CSRF.
 
-        # While this is close to anonymous_user_required - it differs in that
-        # it uses get_post_login_redirect which correctly handles 'next'.
-        # TODO: consider changing anonymous_user_required to also call
-        # get_post_login_redirect - not sure why it never has?
+        # This does NOT use get_post_login_redirect() so that it doesn't look at
+        # 'next' - which can cause infinite redirect loops
+        # (see test_common::test_authenticated_loop)
         if _security._want_json(request):
             payload = json_error_response(
                 errors=get_message("ANONYMOUS_USER_REQUIRED")[0]
             )
             return _security._render_json(payload, 400, None, None)
         else:
-            return redirect(get_post_login_redirect())
+            return redirect(get_url(_security.post_login_view))
 
     form_class = _security.login_form
 
@@ -193,9 +192,7 @@ def login():
         return base_render_json(form, include_auth_token=True)
 
     if current_user.is_authenticated:
-        # Basically a no-op if authenticated - just perform the same
-        # post-login redirect as if user just logged in.
-        return redirect(get_post_login_redirect())
+        return redirect(get_url(_security.post_login_view))
     else:
         return _security.render_template(
             config_value("LOGIN_USER_TEMPLATE"), login_user_form=form, **_ctx("login")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -127,9 +127,9 @@ def test_get_already_authenticated(client):
 def test_get_already_authenticated_next(client):
     response = authenticate(client, follow_redirects=True)
     assert b"Welcome matt@lp.com" in response.data
-    # This should override post_login_view
+    # This should NOT override post_login_view due to potential redirect loops.
     response = client.get("/login?next=/page1", follow_redirects=True)
-    assert b"Page 1" in response.data
+    assert b"Post Login" in response.data
 
 
 @pytest.mark.settings(post_login_view="/post_login")
@@ -139,8 +139,9 @@ def test_post_already_authenticated(client):
     data = dict(email="matt@lp.com", password="password")
     response = client.post("/login", data=data, follow_redirects=True)
     assert b"Post Login" in response.data
+    # This should NOT override post_login_view due to potential redirect loops.
     response = client.post("/login?next=/page1", data=data, follow_redirects=True)
-    assert b"Page 1" in response.data
+    assert b"Post Login" in response.data
 
 
 def test_login_form(client):
@@ -394,6 +395,15 @@ def test_token_auth_via_header_invalid_token(client):
 
 
 def test_http_auth(client):
+    # browsers expect 401 response with WWW-Authenticate header - which will prompt
+    # them to pop up a login form.
+    response = client.get("/http", headers={})
+    assert response.status_code == 401
+    assert b"You are not authenticated" in response.data
+    assert "WWW-Authenticate" in response.headers
+    assert 'Basic realm="Login Required"' == response.headers["WWW-Authenticate"]
+
+    # Now provide correct credentials
     response = client.get(
         "/http",
         headers={
@@ -539,8 +549,10 @@ def test_multi_auth_basic(client):
     assert b"Basic" in response.data
 
     response = client.get("/multi_auth")
-    # Default unauthn is to redirect
-    assert response.status_code == 302
+    # Default unauthn with basic is to return 401 with WWW-Authenticate Header
+    # so that browser pops up a username/password dialog
+    assert response.status_code == 401
+    assert "WWW-Authenticate" in response.headers
 
 
 @pytest.mark.settings(backwards_compat_unauthn=True)
@@ -557,7 +569,6 @@ def test_multi_auth_basic_invalid(client):
     assert 'Basic realm="Login Required"' == response.headers["WWW-Authenticate"]
 
     response = client.get("/multi_auth")
-    print(response.headers)
     assert response.status_code == 401
 
 
@@ -572,6 +583,20 @@ def test_multi_auth_session(client):
     authenticate(client)
     response = client.get("/multi_auth")
     assert b"Session" in response.data
+
+
+def test_authenticated_loop(client):
+    # If user is already authenticated say via session, and then hits an endpoint
+    # protected with @auth_token_required() - then they will be redirected to the login
+    # page which will simply note the current user is already logged in and redirect
+    # to POST_LOGIN_VIEW. Between 3.3.0 and 3.4.4 - this redirect would honor the 'next'
+    # parameter - thus redirecting back to the endpoint that caused the redirect in the
+    # first place - thus an infinite loop.
+    authenticate(client)
+
+    response = client.get("/token", follow_redirects=True)
+    assert response.status_code == 200
+    assert b"Home Page" in response.data
 
 
 def test_user_deleted_during_session_reverts_to_anonymous_user(app, client):

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -34,8 +34,10 @@ def test_view_configuration(client):
         "/http",
         headers={"Authorization": "Basic %s" % base64.b64encode(b"joe@lp.com:bogus")},
     )
-    assert response.status_code == 302
-    assert response.headers["Location"] == "http://localhost/custom_login?next=%2Fhttp"
+    assert response.status_code == 401
+    assert b"You are not authenticated" in response.data
+    assert "WWW-Authenticate" in response.headers
+    assert 'Basic realm="Custom Realm"' == response.headers["WWW-Authenticate"]
 
 
 @pytest.mark.settings(login_user_template="custom_security/login_user.html")

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -50,11 +50,11 @@ def test_render_json_logout(app, client):
 def test_default_unauthn(app, client):
     """ Test default unauthn handler with and without json """
 
-    response = client.get("/multi_auth")
+    response = client.get("/profile")
     assert response.status_code == 302
-    assert response.headers["Location"] == "http://localhost/login?next=%2Fmulti_auth"
+    assert response.headers["Location"] == "http://localhost/login?next=%2Fprofile"
 
-    response = client.get("/multi_auth", headers={"Accept": "application/json"})
+    response = client.get("/profile", headers={"Accept": "application/json"})
     assert response.status_code == 401
     assert response.json["meta"]["code"] == 401
     # While "Basic" is acceptable, we never get a WWW-Authenticate header back since
@@ -66,11 +66,11 @@ def test_default_unauthn(app, client):
 def test_default_unauthn_bp(app, client):
     """ Test default unauthn handler with blueprint prefix and login url """
 
-    response = client.get("/multi_auth")
+    response = client.get("/profile")
     assert response.status_code == 302
     assert (
         response.headers["Location"]
-        == "http://localhost/myprefix/mylogin?next=%2Fmulti_auth"
+        == "http://localhost/myprefix/mylogin?next=%2Fprofile"
     )
 
 

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -29,6 +29,7 @@ import flask_babelex
 from flask.json import JSONEncoder
 from flask_security import (
     Security,
+    auth_required,
     current_user,
     login_required,
     SQLAlchemySessionUserDatastore,
@@ -172,6 +173,11 @@ def create_app():
             "{{ _fsdomain('Welcome') }} {{email}} !",
             email=current_user.email,
         )
+
+    @app.route("/basicauth")
+    @auth_required("basic")
+    def basic():
+        return render_template_string("Basic auth success")
 
     return app
 


### PR DESCRIPTION
In 3.3.0 the unauthenticated handler was changed to always redirect to the login view - that broke Basic Auth that of course requires a 401 with WWW-Authenticate header returned.

This also uncovered a redirect loop when redirecting in /login when the caller was already authenticated. Prior behavior was restored.

closes: #359