### PR TITLE
make post redirects default to APPLICATION_ROOT config

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -533,16 +533,16 @@ Login/Logout
 .. py:data:: SECURITY_POST_LOGIN_VIEW
 
     Specifies the default view to redirect to after a user logs in. This value can be set to a URL
-    or an endpoint name.
+    or an endpoint name. Defaults to the Flask config ``APPLICATION_ROOT`` value which itself defaults to ``"/"``.
 
-    Default: ``"/"``.
+    Default: ``APPLICATION_ROOT``.
 
 .. py:data:: SECURITY_POST_LOGOUT_VIEW
 
-    Specifies the default view to redirect to after a user logs out.
-    This value can be set to a URL or an endpoint name.
+    Specifies the default view to redirect to after a user logs out. This value can be set to a URL
+    or an endpoint name. Defaults to the Flask config ``APPLICATION_ROOT`` value which itself defaults to ``"/"``.
 
-    Default: ``"/"``.
+    Default: ``APPLICATION_ROOT``.
 
 
 .. py:data:: SECURITY_UNAUTHORIZED_VIEW

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1031,6 +1031,14 @@ class Security:
         if "mail_util_cls" not in kwargs:
             kwargs.setdefault("mail_util_cls", MailUtil)
 
+        # default post redirects to APPLICATION_ROOT, which itself defaults to "/"
+        app.config.setdefault(
+            "SECURITY_POST_LOGIN_VIEW", app.config.get("APPLICATION_ROOT", "/")
+        )
+        app.config.setdefault(
+            "SECURITY_POST_LOGOUT_VIEW", app.config.get("APPLICATION_ROOT", "/")
+        )
+
         for key, value in _default_config.items():
             app.config.setdefault("SECURITY_" + key, value)
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -525,7 +525,7 @@ def find_redirect(key):
     rv = (
         get_url(session.pop(key.lower(), None))
         or get_url(current_app.config[key.upper()] or None)
-        or "/"
+        or current_app.config.get("APPLICATION_ROOT", "/")
     )
     return rv
 


### PR DESCRIPTION
PR adds out-of-the-box support when using flask's `APPLICATION_ROOT` config. This is useful if leveraging `werkzeug.middleware.dispatcher.DispatcherMiddleware` to prefix the app URL path. For POST redirects, rather than falling back on `/` we use the `APPLICATION_ROOT` config instead, which itself defaults to `/` by flask.

Ex `src/main/__init__.py`:

```python
from flask import Flask, url_for
from werkzeug.exceptions import NotFound
from werkzeug.middleware.dispatcher import DispatcherMiddleware

app = Flask(__name__)
assert app.config["APPLICATION_ROOT"] == "/"
app.config["APPLICATION_ROOT"] = "/v1.1"

@app.route("/", methods=["GET"])
def index():
    return "Ok", 200

application = DispatcherMiddleware(NotFound, {
    app.config.get('APPLICATION_ROOT'): app,
})

assert url_for(".index", app) == "/v1.1/"
```

The entrypoint then becomes the `DispatcherMiddleware` application rather than the flask app
```
gunicorn --bind :$PORT main:application
```