### PR TITLE
Add support for Flask-Babel 2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,7 +29,9 @@ Features & Cleanup
   JSON SPA redirects used to always include a query param 'email=xx'. While that is still sent
   (if and only if) the UserModel contains an 'email' columns, a new query param 'identity' is returned
   which returns the value of UserModel.calc_username().
-- (:pr:`xxx`) Improvements and documentation for two-factor authentication.
+- (:pr:`382`) Improvements and documentation for two-factor authentication.
+- (:issue:`381`) Support Flask-Babel 2.0 which has backported Domain support. Flask-Security now supports
+  Flask-Babel (>=2.00), Flask-BabelEx, as well as no translation support. Please see backwards compatibility notes below.
 
 Fixed
 +++++
@@ -75,6 +77,12 @@ Backwards Compatibility Concerns
   ``@app.before_first_request`` (since that broke the CLI). So it isn't called in an application context, the *app* being initialized is
   passed as an argument to *__init__*.
 
+- (:issue:`381`) When using Flask-Babel (>= 2.0) it is required that the application initialize Flask-Babel (e.g. Babel(app)).
+  Flask-BabelEx would self-initialize so it didn't matter. Flask-Security will throw a run time error upon first request if Flask-Babel
+  is installed, but not initialized. Also, Flask-Security no longer has a dependency on either Flask-Babel or Flask-BabelEx - if neither
+  are installed, it falls back to a dummy translation. Thus - if you application expects translations services, it must specify the appropriate
+  dependency.
+
 .. _here: https://github.com/Flask-Middleware/flask-security/issues/85
 
 Version 3.4.4
@@ -101,7 +109,7 @@ Fixed
 Compatibility Concerns
 ++++++++++++++++++++++
 
-In 3.3.0, `.Security.auth_required` was changed to add a default argument if none was given. The default
+In 3.3.0, :meth:`flask_security.auth_required` was changed to add a default argument if none was given. The default
 include all current methods - ``session``, ``token``, and ``basic``. However ``basic`` really isn't like the others
 and requires that we send back a ``WWW-Authenticate`` header if authentication fails (and return a 401 and not redirect).
 ``basic`` has been removed from the default set and must once again be explicitly requested.

--- a/examples/fsqlalchemy1/app.py
+++ b/examples/fsqlalchemy1/app.py
@@ -18,6 +18,7 @@ import os
 from flask import Flask, abort, current_app, render_template_string
 from flask.json import JSONEncoder
 from flask_sqlalchemy import SQLAlchemy
+from flask_babel import Babel
 from flask_security import (
     Security,
     SQLAlchemyUserDatastore,
@@ -81,6 +82,10 @@ class Blog(db.Model):
 # Setup Flask-Security
 user_datastore = SQLAlchemyUserDatastore(db, User, Role)
 app.security = Security(app, user_datastore)
+
+# Setup Babel - not strictly necessary but since this virtualenv has Flask-Babel
+# we need to initialize it
+Babel(app)
 
 # Set this so unit tests can mock out.
 app.blog_cls = Blog

--- a/examples/unified_signin/server/app.py
+++ b/examples/unified_signin/server/app.py
@@ -16,6 +16,7 @@ import datetime
 import os
 
 from flask import Flask
+from flask_babel import Babel
 from flask.json import JSONEncoder
 from flask_security import (
     Security,
@@ -139,6 +140,7 @@ def create_app():
 
     # Initialize standard Flask extensions
     CaptureMail(app)
+    Babel(app)
     # Enable CSRF on all api endpoints.
     CSRFProtect(app)
     db.init_app(app)

--- a/flask_security/babel.py
+++ b/flask_security/babel.py
@@ -3,19 +3,95 @@
     ~~~~~~~~~~~~~~~~~~~~
 
     I18N support for Flask-Security.
+
+    As of Flask-Babel 2.0.0 - it supports the Flask-BabelEx Domain extension - and it
+    is maintained. (Flask-BabelEx is no longer maintained). So we start with that,
+    then fall back to Flask-BabelEx, then fall back to a Null Domain
+    (just as Flask-Admin).
 """
 
-from flask_babelex import Domain
+# flake8: noqa: F811
+
 from wtforms.i18n import messages_path
 
-wtforms_domain = Domain(messages_path(), domain="wtforms")
+from .utils import config_value as cv
+
+_domain_cls = None
+try:
+    from flask_babel import Domain
+
+    _domain_cls = Domain
+except ImportError:
+    try:
+        from flask_babelex import Domain
+
+        _domain_cls = Domain
+    except ImportError:
+        # Fake up just enough
+        class Domain:
+            @staticmethod
+            def gettext(string, **variables):
+                return string % variables
+
+            @staticmethod
+            def ngettext(singular, plural, num, **variables):
+                variables.setdefault("num", num)
+                return (singular if num == 1 else plural) % variables
+
+            @staticmethod
+            def lazy_gettext(string, **variables):
+                return Domain.gettext(string, **variables)
+
+            class Translations:
+                """ dummy Translations class for WTForms, no translation support """
+
+                def gettext(self, string):
+                    return string
+
+                def ngettext(self, singular, plural, n):
+                    return singular if n == 1 else plural
+
+        def get_i18n_domain(app):
+            return Domain()
+
+        def have_babel():
+            return False
+
+        def is_lazy_string(obj):
+            return False
+
+        def make_lazy_string(__func, msg):
+            return msg
 
 
-class Translations:
-    """Fixes WTForms translation support and uses wtforms translations."""
+if _domain_cls:
+    # Have either Flask-Babel or Flask-BabelEx
+    from babel.support import LazyProxy
 
-    def gettext(self, string):
-        return wtforms_domain.gettext(string)
+    wtforms_domain = _domain_cls(messages_path(), domain="wtforms")
 
-    def ngettext(self, singular, plural, n):
-        return wtforms_domain.ngettext(singular, plural, n)
+    def get_i18n_domain(app):
+        return _domain_cls(
+            translation_directories=cv("I18N_DIRNAME", app=app),
+            domain=cv("I18N_DOMAIN", app=app),
+        )
+
+    def have_babel():
+        return True
+
+    def is_lazy_string(obj):
+        """Checks if the given object is a lazy string."""
+        return isinstance(obj, LazyProxy)
+
+    def make_lazy_string(__func, msg):
+        """Creates a lazy string by invoking func with args."""
+        return LazyProxy(__func, msg, enable_cache=False)
+
+    class Translations:
+        """Fixes WTForms translation support and uses wtforms translations."""
+
+        def gettext(self, string):
+            return wtforms_domain.gettext(string)
+
+        def ngettext(self, singular, plural, n):
+            return wtforms_domain.ngettext(singular, plural, n)

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -15,7 +15,6 @@ import inspect
 from flask import Markup, current_app, request
 from flask_login import current_user
 from flask_wtf import FlaskForm as BaseForm
-from speaklater import is_lazy_string, make_lazy_string
 from werkzeug.local import LocalProxy
 from wtforms import (
     BooleanField,
@@ -29,6 +28,7 @@ from wtforms import (
     validators,
 )
 
+from .babel import is_lazy_string, make_lazy_string
 from .confirmable import requires_confirmation
 from .utils import (
     _,

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -32,9 +32,9 @@ from flask_principal import AnonymousIdentity, Identity, identity_changed, Need
 from flask_wtf import csrf
 from wtforms import validators, ValidationError
 from itsdangerous import BadSignature, SignatureExpired
-from speaklater import is_lazy_string
 from werkzeug.local import LocalProxy
 from werkzeug.datastructures import MultiDict
+
 from .quart_compat import best
 from .signals import user_authenticated
 
@@ -936,6 +936,8 @@ class FsJsonEncoder(JSONEncoder):
     """
 
     def default(self, obj):
+        from .babel import is_lazy_string
+
         if is_lazy_string(obj):
             return str(obj)
         else:

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ with open("flask_security/__init__.py", encoding="utf8") as f:
     version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
 
 tests_require = [
+    "Flask-Babel>=2.0.0",
     "Flask-Mail>=0.9.1",
     "Flask-Mongoengine>=0.9.5",
     "peewee>=3.11.2",
@@ -53,8 +54,7 @@ install_requires = [
     "Flask>=1.1.1",
     "Flask-Login>=0.4.1",
     "Flask-Principal>=0.4.0",
-    "Flask-WTF>=0.14.2",
-    "Flask-BabelEx>=0.9.3",
+    "Flask-WTF>=0.14.3",
     "email-validator>=1.0.5",
     "itsdangerous>=1.1.0",
     "passlib>=1.7.2",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,6 @@ from flask import Flask, Response, render_template
 from flask import jsonify
 from flask import request as flask_request
 from flask.json import JSONEncoder
-from flask_babelex import Babel
 from flask_mail import Mail
 
 from flask_security import (
@@ -44,6 +43,15 @@ from flask_security import (
 )
 
 from tests.test_utils import populate_data
+
+NO_BABEL = False
+try:
+    from flask_babel import Babel
+except ImportError:
+    try:
+        from flask_babelex import Babel
+    except ImportError:
+        NO_BABEL = True
 
 
 @pytest.fixture()
@@ -92,7 +100,7 @@ def app(request):
             app.config["SECURITY_" + key.upper()] = value
 
     mail = Mail(app)
-    if babel is None or babel.args[0]:
+    if not NO_BABEL and (babel is None or babel.args[0]):
         Babel(app)
     app.json_encoder = JSONEncoder
     app.mail = mail

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -406,8 +406,9 @@ def test_form_required_local_message(app, sqlalchemy_datastore):
 
 @pytest.mark.babel(False)
 def test_without_babel(client):
-    response = client.get("/login")
-    assert b"Login" in response.data
+    # This isn't really 'without' babel - it is without initializing babel
+    with pytest.raises(ValueError):
+        client.get("/login")
 
 
 def test_no_email_sender(app):
@@ -424,6 +425,7 @@ def test_no_email_sender(app):
     security.init_app(app)
 
     with app.app_context():
+        app.try_trigger_before_first_request_functions()
         user = TestUser("matt@lp.com")
         with app.mail.record_messages() as outbox:
             send_mail("Test Default Sender", user.email, "welcome", user=user)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@
     :license: MIT, see LICENSE for more details.
 """
 from contextlib import contextmanager
+import re
 
 from flask.json.tag import TaggedJSONSerializer
 from flask.signals import message_flashed
@@ -97,7 +98,12 @@ def check_xlation(app, locale):
     with app.test_request_context():
         domain = app.security.i18n_domain
         xlations = domain.get_translations()
-        return xlations and xlations._info.get("language", None) == locale
+        if not xlations:
+            return False
+        # Flask-Babel doesn't populate _info as Flask-BabelEx did - so look in first
+        # string which is catalog info.
+        matcher = re.search(r"Language:\s*(\w+)", xlations._catalog[""])
+        return matcher.group(1) == locale
 
 
 def create_roles(ds):

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -25,7 +25,13 @@ import datetime
 import os
 
 from flask import Flask, flash, render_template_string, request, session
-import flask_babelex
+
+try:
+    import flask_babel
+
+    HAVE_BABEL = True
+except ImportError:
+    HAVE_BABEL = False
 from flask.json import JSONEncoder
 from flask_security import (
     Security,
@@ -114,21 +120,22 @@ def create_app():
 
     # This is NOT ideal since it basically changes entire APP (which is fine for
     # this test - but not fine for general use).
-    babel = flask_babelex.Babel(app, default_domain=security.i18n_domain)
+    if HAVE_BABEL:
+        babel = flask_babel.Babel(app, default_domain=security.i18n_domain)
 
-    @babel.localeselector
-    def get_locale():
-        # For a given session - set lang based on first request.
-        # Honor explicit url request first
-        if "lang" not in session:
-            locale = request.args.get("lang", None)
-            if not locale:
-                locale = request.accept_languages.best
-            if not locale:
-                locale = "en"
-            if locale:
-                session["lang"] = locale
-        return session.get("lang", None).replace("-", "_")
+        @babel.localeselector
+        def get_locale():
+            # For a given session - set lang based on first request.
+            # Honor explicit url request first
+            if "lang" not in session:
+                locale = request.args.get("lang", None)
+                if not locale:
+                    locale = request.accept_languages.best
+                if not locale:
+                    locale = "en"
+                if locale:
+                    session["lang"] = locale
+            return session.get("lang", None).replace("-", "_")
 
     # Create a user to test with
     @app.before_first_request


### PR DESCRIPTION
Finally - Domain support was backported! So everyone can move back to a maintained Flask-Babel package.
To ease transition - followed the approach Flask-Admin did - and support Flask-Babel, fall back to Flask-BabelEx, and then fall
back to a dummy translation (thus Flask-Security no longer requires any Babel package).

Flask-Babel doesn't 'auto initialize' which Flask-BabelEx did - so added a runtime check to make sure that if the package is installed,
the application has initialized it (otherwise a very difficult to decipher error message gets raised).

closes: #381 