### PR TITLE
Setup optional redirect after requires_confirmation error & doc

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -679,6 +679,13 @@ Confirmable
     the value of ``SECURITY_CONFIRMABLE`` is set to ``True``.
 
     Default: ``False``.
+.. py:data:: SECURITY_REQUIRES_CONFIRMATION_ERROR_VIEW
+
+    Specifies a redirect page if the users tries to login with an un-confirmed email address.
+    If an URL endpoint is specified, flashes an error messages and passes user email as an argument.
+    Default behavior is to reload the login form with an error message without redirecting to an other page.
+
+    Default: ``None``.
 
 Changeable
 ----------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -681,9 +681,10 @@ Confirmable
     Default: ``False``.
 .. py:data:: SECURITY_REQUIRES_CONFIRMATION_ERROR_VIEW
 
-    Specifies a redirect page if the users tries to login with an un-confirmed email address.
+    Specifies a redirect page if the users tries to login, reset password or us-signin with an unconfirmed account.
     If an URL endpoint is specified, flashes an error messages and passes user email as an argument.
-    Default behavior is to reload the login form with an error message without redirecting to an other page.
+    For us-signin, no argument is specified: it simply flashes the error message and redirects.
+    Default behavior is to reload the form with an error message without redirecting to an other page.
 
     Default: ``None``.
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -151,6 +151,7 @@ _default_config = {
     "RESET_ERROR_VIEW": None,
     "RESET_VIEW": None,
     "LOGIN_ERROR_VIEW": None,
+    "REQUIRES_CONFIRMATION_ERROR_VIEW": None,
     "REDIRECT_HOST": None,
     "REDIRECT_BEHAVIOR": None,
     "REDIRECT_ALLOW_SUBDOMAINS": False,

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -296,13 +296,18 @@ class ForgotPasswordForm(Form, UserEmailFormMixin):
 
     submit = SubmitField(get_form_field_label("recover_password"))
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.requires_confirmation = False
+
     def validate(self):
         if not super().validate():
             return False
         if not self.user.is_active:
             self.email.errors.append(get_message("DISABLED_ACCOUNT")[0])
             return False
-        if requires_confirmation(self.user):
+        self.requires_confirmation = requires_confirmation(self.user)
+        if self.requires_confirmation:
             self.email.errors.append(get_message("CONFIRMATION_REQUIRED")[0])
             return False
         return True

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -351,6 +351,7 @@ class LoginForm(Form, NextFormMixin):
                 )
             )
             self.password.description = html
+        self.requires_confirmation = False
 
     def validate(self):
         if not super().validate():
@@ -374,7 +375,8 @@ class LoginForm(Form, NextFormMixin):
         if not self.user.verify_and_update_password(self.password.data):
             self.password.errors.append(get_message("INVALID_PASSWORD")[0])
             return False
-        if requires_confirmation(self.user):
+        self.requires_confirmation = requires_confirmation(self.user)
+        if self.requires_confirmation:
             self.email.errors.append(get_message("CONFIRMATION_REQUIRED")[0])
             return False
         if not self.user.is_active:

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -199,7 +199,7 @@ def login():
             return redirect(
                 get_url(
                     _security.requires_confirmation_error_view,
-                    qparams={'email': form.email.data}
+                    qparams={'email': form.email.data},
                 )
             )
         return _security.render_template(

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -199,7 +199,7 @@ def login():
             return redirect(
                 get_url(
                     _security.requires_confirmation_error_view,
-                    qparams={'email': form.email.data},
+                    qparams={"email": form.email.data},
                 )
             )
         return _security.render_template(

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -196,10 +196,12 @@ def login():
     else:
         if form.requires_confirmation and _security.requires_confirmation_error_view:
             do_flash(*get_message("CONFIRMATION_REQUIRED"))
-            return redirect(get_url(
-                _security.requires_confirmation_error_view,
-                qparams={'email': form.email.data}
-            ))
+            return redirect(
+                get_url(
+                    _security.requires_confirmation_error_view,
+                    qparams={'email': form.email.data}
+                )
+            )
         return _security.render_template(
             config_value("LOGIN_USER_TEMPLATE"), login_user_form=form, **_ctx("login")
         )

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -489,6 +489,15 @@ def forgot_password():
     if _security._want_json(request):
         return base_render_json(form, include_user=False)
 
+    if form.requires_confirmation and _security.requires_confirmation_error_view:
+        do_flash(*get_message("CONFIRMATION_REQUIRED"))
+        return redirect(
+            get_url(
+                _security.requires_confirmation_error_view,
+                qparams={"email": form.email.data},
+            )
+        )
+
     return _security.render_template(
         config_value("FORGOT_PASSWORD_TEMPLATE"),
         forgot_password_form=form,

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -194,6 +194,12 @@ def login():
     if current_user.is_authenticated:
         return redirect(get_url(_security.post_login_view))
     else:
+        if form.requires_confirmation and _security.requires_confirmation_error_view:
+            do_flash(*get_message("CONFIRMATION_REQUIRED"))
+            return redirect(get_url(
+                _security.requires_confirmation_error_view,
+                qparams={'email': form.email.data}
+            ))
         return _security.render_template(
             config_value("LOGIN_USER_TEMPLATE"), login_user_form=form, **_ctx("login")
         )

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -127,6 +127,17 @@ def test_confirmable_flag(app, clients, get_message):
 
 
 @pytest.mark.registerable()
+@pytest.mark.settings(requires_confirmation_error_view="/confirm")
+def test_requires_confirmation_error_redirect(app, clients):
+    data = dict(email="jyl@lp.com", password="awesome sunset")
+    response = clients.post("/register", data=data)
+
+    response = authenticate(clients, **data, follow_redirects=True)
+    assert b"send_confirmation_form" in response.data
+    assert b"jyl@lp.com" in response.data
+
+
+@pytest.mark.registerable()
 @pytest.mark.settings(confirm_email_within="1 milliseconds")
 def test_expired_confirmation_token(client, get_message):
     with capture_registrations() as registrations:

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -124,7 +124,9 @@ def test_requires_confirmation_error_redirect(app, clients):
     data = dict(email="jyl@lp.com", password="awesome sunset")
     clients.post("/register", data=data)
 
-    response = clients.post("/reset", data=dict(email="jyl@lp.com"), follow_redirects=True)
+    response = clients.post(
+        "/reset", data=dict(email="jyl@lp.com"), follow_redirects=True
+    )
     assert b"send_confirmation_form" in response.data
     assert b"jyl@lp.com" in response.data
 

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -117,6 +117,18 @@ def test_recoverable_flag(app, clients, get_message):
     assert get_message("INVALID_RESET_PASSWORD_TOKEN") in response.data
 
 
+@pytest.mark.confirmable()
+@pytest.mark.registerable()
+@pytest.mark.settings(requires_confirmation_error_view="/confirm")
+def test_requires_confirmation_error_redirect(app, clients):
+    data = dict(email="jyl@lp.com", password="awesome sunset")
+    clients.post("/register", data=data)
+
+    response = clients.post("/reset", data=dict(email="jyl@lp.com"), follow_redirects=True)
+    assert b"send_confirmation_form" in response.data
+    assert b"jyl@lp.com" in response.data
+
+
 @pytest.mark.settings()
 def test_recoverable_json(app, client, get_message):
     recorded_resets = []

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -1007,10 +1007,7 @@ def test_next(app, client, get_message):
 @pytest.mark.settings(requires_confirmation_error_view="/confirm")
 def test_requires_confirmation_error_redirect(app, client):
     data = dict(
-        email="jyl@lp.com",
-        password="password",
-        password_confirm="password",
-        next="",
+        email="jyl@lp.com", password="password", password_confirm="password", next=""
     )
     response = client.post("/register", data=data, follow_redirects=True)
 

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -1004,6 +1004,33 @@ def test_next(app, client, get_message):
 
 @pytest.mark.registerable()
 @pytest.mark.confirmable()
+@pytest.mark.settings(requires_confirmation_error_view="/confirm")
+def test_requires_confirmation_error_redirect(app, client):
+    data = dict(
+        email="jyl@lp.com",
+        password="password",
+        password_confirm="password",
+        next="",
+    )
+    response = client.post("/register", data=data, follow_redirects=True)
+
+    with capture_send_code_requests() as requests:
+        response = client.post(
+            "/us-signin/send-code",
+            data=dict(identity="jyl@lp.com", chosen_method="email"),
+            follow_redirects=True,
+        )
+
+    response = client.post(
+        "/us-signin",
+        data=dict(identity="jyl@lp.com", passcode=requests[0]["token"]),
+        follow_redirects=True,
+    )
+    assert b"send_confirmation_form" in response.data
+
+
+@pytest.mark.registerable()
+@pytest.mark.confirmable()
 def test_confirmable(app, client, get_message):
     # Verify can't log in if need confirmation.
     data = dict(


### PR DESCRIPTION
Added an option "SECURITY_REQUIRES_CONFIRMATION_ERROR_VIEW". If set to an URL endpoint, will redirect a user who tries to login with an unconfirmed email address while flashing the default error message & passing the email as an argument.

I was unable to check if the sphinx doc could build properly, I had an ``invalid command 'sphinx_build'`` error when trying to do so (?). However, as I didn't add much, it should be no problem.

I didn't add any specific test for this option (not too sure how I'd have to to that to be fair), but if you deem it important, I can look into it !
