### PR TITLE
Add email normalization.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,7 @@ Features & Cleanup
   (if and only if) the UserModel contains an 'email' columns, a new query param 'identity' is returned
   which returns the value of UserModel.calc_username().
 - (:pr:`382`) Improvements and documentation for two-factor authentication.
+- (:pr:`xxx`) Add support for email validation and normalization.
 
 Fixed
 +++++
@@ -76,7 +77,7 @@ Backwards Compatibility Concerns
   corresponds to is determined, then the UserModel is queried specifically for that *attribute:value* pair.
 
 - (:pr:`354`) The :class:`flask_security.PhoneUtil` is now initialized as part of Flask-Security initialization rather than
-  ``@app.before_first_request`` (since that broke the CLI). So it isn't called in an application context, the *app* being initialized is
+  ``@app.before_first_request`` (since that broke the CLI). Since it isn't called in an application context, the *app* being initialized is
   passed as an argument to *__init__*.
 
 - (:issue:`381`) When using Flask-Babel (>= 2.0) it is required that the application initialize Flask-Babel (e.g. Babel(app)).
@@ -84,6 +85,12 @@ Backwards Compatibility Concerns
   is installed, but not initialized. Also, Flask-Security no longer has a dependency on either Flask-Babel or Flask-BabelEx - if neither
   are installed, it falls back to a dummy translation. Thus - if you application expects translations services, it must specify the appropriate
   dependency.
+
+- (:pr:`xxx`) Email input is now normalized prior to being stored in the DB. Previously, it was validated, but the raw input
+  was stored. Normalization and validation rely on the `email_validator <https://pypi.org/project/email-validator/>`_ package.
+  The :class:`.MailUtil` class provides the interface for normalization and validation - allowing all this to be customized.
+  If you have unicode local or domain parts - existing users may have difficulties logging in. Administratively you need to
+  read each user record, normalize the email (see :class:`.MailUtil`), and write it back.
 
 .. _here: https://github.com/Flask-Middleware/flask-security/issues/85
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -161,6 +161,17 @@ These configuration keys are used globally across all features.
 
     Default: ``None``, meaning the token never expires.
 
+.. py:data:: SECURITY_EMAIL_VALIDATOR_ARGS
+
+    Email address are validated using the `email_validator`_ package. Its methods
+    have some configurable options - these can be set here and will be passed in.
+
+    Default: ``None``, meaning use the defaults from email_validator package.
+
+    .. versionadded:: 4.0.0
+
+.. _email_validator: https://pypi.org/project/email-validator/
+
 .. py:data:: SECURITY_DEFAULT_HTTP_AUTH_REALM
 
     Specifies the default authentication realm when using basic HTTP auth.

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -141,6 +141,11 @@ modified an existing security template) just use that method::
 
     {{ _fsdomain("Login") }}
 
+Be aware that Flask-Security will validate and normalize email input using the
+`email_validator <https://pypi.org/project/email-validator/>`_ package.
+The normalized form is stored in the DB.
+
+
 .. _emails_topic:
 
 Emails
@@ -228,7 +233,7 @@ us_instructions                 N/A                                US_EMAIL_SUBJ
 
 When sending an email, Flask-Security goes through the following steps:
 
-  #. Call the email context processor as described above
+  #. Calls the email context processor as described above
 
   #. Calls ``render_template`` (as configured at Flask-Security initialization time) with the
      context and template to produce a text and/or html version of the message
@@ -244,7 +249,8 @@ Emails with Celery
 Sometimes it makes sense to send emails via a task queue, such as `Celery`_.
 This is supported by providing your own implementation of the :class:`.MailUtil` class::
 
-    class MyMailUtil:
+    from flask_security import MailUtil
+    class MyMailUtil(MailUtil):
 
         def send_mail(self, template, subject, recipient, sender, body, html, user, **kwargs):
             send_flask_mail.delay(

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -179,6 +179,8 @@ User Registration
 Flask-Security comes packaged with a basic user registration view. This view is
 very simple and new users need only supply an email address and their password.
 This view can be overridden if your registration process requires more fields.
+User email is validated and normalized using the
+`email_validator <https://pypi.org/project/email-validator/>`_ package.
 
 
 Login Tracking

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -94,6 +94,7 @@ _default_config = {
     "FLASH_MESSAGES": True,
     "I18N_DOMAIN": "flask_security",
     "I18N_DIRNAME": pkg_resources.resource_filename("flask_security", "translations"),
+    "EMAIL_VALIDATOR_ARGS": None,
     "PASSWORD_HASH": "bcrypt",
     "PASSWORD_SALT": None,
     "PASSWORD_SINGLE_HASH": {

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -322,6 +322,10 @@ class UserDatastore:
         :kwparam roles: list of roles to be added to user.
             Can be Role objects or strings
 
+        .. note::
+            No normalization is done on email - it is assumed the caller has already
+            done that.
+
         .. danger::
            Be aware that whatever `password` is passed in will
            be stored directly in the DB. Do NOT pass in a plaintext password!

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -396,10 +396,6 @@ def us_signin_send_code():
         }
         return base_render_json(form, include_user=False, additional=payload)
 
-    if form.requires_confirmation and _security.requires_confirmation_error_view:
-        do_flash(*get_message("CONFIRMATION_REQUIRED"))
-        return redirect(get_url(_security.requires_confirmation_error_view))
-
     return _security.render_template(
         config_value("US_SIGNIN_TEMPLATE"),
         us_signin_form=form,

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -30,7 +30,7 @@ from flask_login import current_user
 from flask_login import COOKIE_NAME as REMEMBER_COOKIE_NAME
 from flask_principal import AnonymousIdentity, Identity, identity_changed, Need
 from flask_wtf import csrf
-from wtforms import validators, ValidationError
+from wtforms import ValidationError
 from itsdangerous import BadSignature, SignatureExpired
 from werkzeug.local import LocalProxy
 from werkzeug.datastructures import MultiDict
@@ -757,18 +757,10 @@ def uia_email_mapper(identity):
     .. versionadded:: 3.4.0
     """
 
-    # Fake up enough to invoke the WTforms email validator.
-    class FakeField:
-        pass
-
-    email_validator = validators.Email(message="nothing")
-    field = FakeField()
-    field.data = identity
     try:
-        email_validator(None, field)
-    except ValidationError:
+        return _security._mail_util.normalize(identity)
+    except ValueError:
         return None
-    return identity
 
 
 def use_double_hash(password_hash=None):

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ install_requires = [
     "Flask-Login>=0.4.1",
     "Flask-Principal>=0.4.0",
     "Flask-WTF>=0.14.3",
-    "email-validator>=1.0.5",
+    "email-validator>=1.1.1",
     "itsdangerous>=1.1.0",
     "passlib>=1.7.2",
 ]

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -9,7 +9,6 @@
 """
 
 import base64
-import sys
 
 import pytest
 from flask import Flask
@@ -356,7 +355,6 @@ def test_unicode_length(app, client, get_message):
     assert response.status_code == 200
 
 
-@pytest.mark.skipif(sys.version_info < (3, 0), reason="requires python3 or higher")
 def test_unicode_invalid_length(app, client, get_message):
     # From NIST and OWASP - each unicode code point should count as a character.
     authenticate(client)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -76,6 +76,19 @@ def test_cli_createuser_extraargs(script_info):
     assert "was already activated" in result.output
 
 
+def test_cli_createuser_normalize(script_info):
+    """Test create user CLI that is properly normalizes email."""
+    runner = CliRunner()
+
+    result = runner.invoke(
+        users_create,
+        ["email@EXAMPLE.org", "--password", "battery staple"],
+        obj=script_info,
+    )
+    assert result.exit_code == 0
+    assert "email@example.org" in result.stdout
+
+
 def test_cli_createrole(script_info):
     """Test create user CLI."""
     runner = CliRunner()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -61,11 +61,12 @@ from flask_security.utils import (
 
 @pytest.mark.recoverable()
 def test_my_mail_util(app, sqlalchemy_datastore):
-    class MyMailUtil:
-        def __init__(self, app):
-            pass
+    from flask_security import MailUtil
 
-        def send_mail(self, template, subject, recipient, sender, body, html, user):
+    class MyMailUtil(MailUtil):
+        def send_mail(
+            self, template, subject, recipient, sender, body, html, user, **kwargs
+        ):
             assert template == "reset_instructions"
             assert subject == app.config["SECURITY_EMAIL_SUBJECT_PASSWORD_RESET"]
             assert recipient == "matt@lp.com"

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -497,3 +497,11 @@ def test_reset_inactive(client, get_message):
         headers={"Content-Type": "application/json"},
     )
     assert response.status_code == 400
+
+
+def test_email_normalization(client, get_message):
+    response = client.post(
+        "/reset", data=dict(email="joe@LP.COM"), follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert get_message("PASSWORD_RESET_REQUEST", email="joe@lp.com") in response.data


### PR DESCRIPTION
Use email_validator to both validate and normalize email addresses. We store the normalized form in the DB.

Add new option SECURITY_EMAIL_VALIDATOR_ARGS to allow passing keyword arguments to email_validator.validate_email() method.