### PR TITLE
Add password normalization.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,12 +6,10 @@ Here you can see the full list of changes between each Flask-Security release.
 Version 4.0.0
 -------------
 
-Release Target Summer 2020
+Release Target Fall 2020
 
 **PLEASE READ CHANGE NOTES CAREFULLY - THERE ARE LIKELY REQUIRED CHANGES YOU WILL HAVE TO MAKE TO EVEN START YOUR APPLICATION WITH 4.0**
 
-- Removal of python 2.7 and <3.6 support
-- Removal of token caching feature (a relatively new feature that has some systemic issues)
 - Other possible breaking changes tracked `here`_
 
 Features & Cleanup
@@ -30,14 +28,15 @@ Features & Cleanup
   (if and only if) the UserModel contains an 'email' columns, a new query param 'identity' is returned
   which returns the value of UserModel.calc_username().
 - (:pr:`382`) Improvements and documentation for two-factor authentication.
-- (:pr:`xxx`) Add support for email validation and normalization.
+- (:pr:`394`) Add support for email validation and normalization.
+- (:issue:`231`) Normalize unicode passwords.
 
 Fixed
 +++++
 - (:issue:`347`) Fix peewee. Turns out - due to lack of unit tests - peewee hasn't worked since
   'permissions' were added in 3.3. Furthermore, changes in 3.4 around get_id and alternative tokens also
   didn't work since peewee defines its own `get_id` method.
-- (:issue:`389`) Fixes for translations. First - email subjects were never being translated. Second converted
+- (:issue:`389`) Fixes for translations. First - email subjects were never being translated. Second, converted
   all templates to use _fsdomain(xx) rather than _(xx) so that they get translated regardless of the app's domain.
 - (:issue:`381`) Support Flask-Babel 2.0 which has backported Domain support. Flask-Security now supports
   Flask-Babel (>=2.00), Flask-BabelEx, as well as no translation support. Please see backwards compatibility notes below.
@@ -86,11 +85,17 @@ Backwards Compatibility Concerns
   are installed, it falls back to a dummy translation. Thus - if you application expects translations services, it must specify the appropriate
   dependency.
 
-- (:pr:`xxx`) Email input is now normalized prior to being stored in the DB. Previously, it was validated, but the raw input
+- (:pr:`394`) Email input is now normalized prior to being stored in the DB. Previously, it was validated, but the raw input
   was stored. Normalization and validation rely on the `email_validator <https://pypi.org/project/email-validator/>`_ package.
   The :class:`.MailUtil` class provides the interface for normalization and validation - allowing all this to be customized.
   If you have unicode local or domain parts - existing users may have difficulties logging in. Administratively you need to
   read each user record, normalize the email (see :class:`.MailUtil`), and write it back.
+
+- (:issue:`381`) Passwords are now, by default, normalized using Python's unicodedata.normalize() method.
+  The :py:data:`SECURITY_PASSWORD_NORMALIZE_FORM` defaults to "NKFD". If your users have unicode passswords
+  they may have difficulty authenticating. You can turn off this normalization or have your users reset their passwords.
+  Password normalization and validation has been encapsulated in a new :class:`.PasswordUtil` class. This replaces
+  the method ``password_validator`` introduced in 3.4.0.
 
 .. _here: https://github.com/Flask-Middleware/flask-security/issues/85
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -147,6 +147,10 @@ Utils
   :members:
   :special-members: __init__
 
+.. autoclass:: flask_security.PasswordUtil
+  :members:
+  :special-members: __init__
+
 .. autoclass:: flask_security.SmsSenderBaseClass
   :members: send_sms
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -143,6 +143,18 @@ These configuration keys are used globally across all features.
 
     .. versionadded:: 3.4.0
 
+.. py:data:: SECURITY_PASSWORD_NORMALIZE_FORM
+
+    Passwords are normalized prior to changing or comparing. This satisfies
+    the NIST requirement: `5.1.1.2 Memorized Secret Verifiers`_.
+    Normalization is performed using the Python unicodedata.normalize() method.
+
+    Default: "NFKD"
+
+    .. versionadded:: 4.0.0
+
+.. _5.1.1.2 Memorized Secret Verifiers: https://pages.nist.gov/800-63-3/sp800-63b.html#sec5
+
 .. py:data:: SECURITY_TOKEN_AUTHENTICATION_KEY
 
     Specifies the query string parameter to read when using token authentication.

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -102,11 +102,18 @@ is a useful place to start. Flask-Security has a default password validator that
 
 Be aware that ``zxcvbn`` is not actively being maintained, and has localization issues.
 
-The entire validator can be easily changed by supplying a :meth:`.Security.password_validator`.
-This enables application to e.g. use any piece of the UserModel (which is a parameter) as part of validation.
+In addition to validation, unicode passwords should be normalized as specified
+by NIST requirement: `5.1.1.2 Memorized Secret Verifiers`_. Normalization can
+be disabled by setting the :py:data:`SECURITY_PASSWORD_NORMALIZE_FORM` to ``None``.
+Validation and normalization is encapsulated in :class:`.PasswordUtil`.
+This can be overridden by passing your class at app initialization time.
+The :meth:`.PasswordUtil.validate` is passed additional kwargs to allow custom
+validators more flexibility.
 A custom validator can still call the underlying methods where appropriate:
 :func:`flask_security.password_length_validator`, :func:`flask_security.password_complexity_validator`,
 and :func:`flask_security.password_breached_validator`.
+
+.. _5.1.1.2 Memorized Secret Verifiers: https://pages.nist.gov/800-63-3/sp800-63b.html#sec5
 
 .. _csrftopic:
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -50,6 +50,7 @@ from .forms import (
     unique_identity_attribute,
 )
 from .mail_util import MailUtil
+from .password_util import PasswordUtil
 from .phone_util import PhoneUtil
 from .signals import (
     confirm_instructions_sent,

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -120,10 +120,10 @@ def users_create(attributes, password, active):
     form = _security.confirm_register_form(MultiDict(kwargs), meta={"csrf": False})
 
     if form.validate():
-        # We don't use the form to provide values so that this CLI can actually
-        # set any usermodel attribute. This means though that things like email
-        # normalization has to be done here (since normally that is part of validation)
-        kwargs["password"] = hash_password(kwargs["password"])
+        # We don't use the form directly to provide values so that this CLI can actually
+        # set any usermodel attribute. We do grab email and password from the form
+        # so that we get any normalization results.
+        kwargs["password"] = hash_password(form.password.data)
         kwargs["active"] = active
         # echo normalized email...
         if "email" in kwargs:

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -331,11 +331,14 @@ class UserDatastore:
            be stored directly in the DB. Do NOT pass in a plaintext password!
            Best practice is to pass in ``hash_password(plaintext_password)``.
 
-           Furthermore, no validation is done on the password (e.g for minimum length).
-           Best practice is to call
-           ``app.security._password_validator(plaintext_password, True)``
-           and look for a ``None`` return meaning the password conforms to the
-           configured validations.
+           Furthermore, no validation nor normalization is done on the password
+           (e.g for minimum length).
+
+           Best practice is::
+            pbad, pnorm = app.security._password_util.validate(password, True)
+
+           Look for `pbad` being None. Pass the normalized password `pnorm` to this
+           method.
 
         The new user's ``active`` property will be set to ``True``
         unless explicitly set to ``False`` in `kwargs`.

--- a/flask_security/mail_util.py
+++ b/flask_security/mail_util.py
@@ -13,11 +13,8 @@
 
 import email_validator
 from flask import current_app
-from werkzeug.local import LocalProxy
 
 from .utils import config_value
-
-_security = LocalProxy(lambda: current_app.extensions["security"])
 
 
 class MailUtil:

--- a/flask_security/password_util.py
+++ b/flask_security/password_util.py
@@ -1,0 +1,77 @@
+"""
+    flask_security.password_util
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Utility class providing methods for validating and normalizing passwords.
+
+    :copyright: (c) 2020 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+
+"""
+import unicodedata
+
+from .utils import (
+    config_value,
+    password_length_validator,
+    password_breached_validator,
+    password_complexity_validator,
+)
+
+
+class PasswordUtil:
+    """
+    Utility class providing methods for validating and normalizing passwords.
+
+    To provide your own implementation, pass in the class as ``password_util_cls``
+    at init time.  Your class will be instantiated once as part of app initialization.
+
+    .. versionadded:: 4.0.0
+    """
+
+    def __init__(self, app):
+        """ Instantiate class.
+
+        :param app: The Flask application being initialized.
+        """
+        pass
+
+    def normalize(self, password):
+        """
+        Given an input password - return a normalized version (using Python's
+        unicodedata.normalize()).
+        Must be called in app context and uses
+        :py:data:`SECURITY_PASSWORD_NORMALIZE_FORM` config variable.
+        """
+        cf = config_value("PASSWORD_NORMALIZE_FORM")
+        if cf:
+            return unicodedata.normalize(cf, password)
+        return password
+
+    def validate(self, password, is_register, **kwargs):
+        """
+        Password validation.
+        Called in app/request context.
+
+        If is_register is True then kwargs will be the contents of the register form.
+        If is_register is False, then there is a single kwarg "user" which has the
+        current user data model.
+
+        The password is first normalized then validated.
+        Return value is a tuple (msgs, normalized_password)
+        """
+
+        cf = config_value("PASSWORD_NORMALIZE_FORM")
+        if cf:
+            pnorm = unicodedata.normalize(cf, password)
+        else:
+            pnorm = password
+
+        notok = password_length_validator(pnorm)
+        if notok:
+            return notok, pnorm
+
+        notok = password_breached_validator(pnorm)
+        if notok:
+            return notok, pnorm
+
+        return password_complexity_validator(pnorm, is_register, **kwargs), pnorm

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -169,6 +169,7 @@ class _UnifiedPassCodeForm(Form):
             ok = False
             for method in config_value("US_ENABLED_METHODS"):
                 if method == "password":
+                    passcode = _security._password_util.normalize(passcode)
                     if self.user.verify_and_update_password(passcode):
                         ok = True
                         break

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -266,6 +266,9 @@ def verify_password(password, password_hash):
     :param password: A plaintext password to verify
     :param password_hash: The expected hash value of the password
                           (usually from your database)
+
+    .. note::
+        Make sure that the password passed in has already been normalized.
     """
     if use_double_hash(password_hash):
         password = get_hmac(password)
@@ -1075,24 +1078,6 @@ def password_breached_validator(password):
             if pwn == "strict":
                 return [get_message("PASSWORD_BREACHED_SITE_ERROR")[0]]
     return None
-
-
-def default_password_validator(password, is_register, **kwargs):
-    """
-    Password validation.
-    Called in app/request context.
-
-    N.B. do not call this directly - use security._password_validator
-    """
-    notok = password_length_validator(password)
-    if notok:
-        return notok
-
-    notok = password_breached_validator(password)
-    if notok:
-        return notok
-
-    return password_complexity_validator(password, is_register, **kwargs)
 
 
 def pwned(password):

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -269,6 +269,45 @@ def test_simple_signin_json(app, client_nc, get_message):
     assert len(flashes) == 0
 
 
+@pytest.mark.changeable()
+def test_signin_pwd_json(app, client, get_message):
+    # Make sure us-signin accepts a normalized and original password.
+    authenticate(client)
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    data = dict(
+        password="password",
+        new_password="new strong password\N{ROMAN NUMERAL ONE}",
+        new_password_confirm="new strong password\N{ROMAN NUMERAL ONE}",
+    )
+    response = client.post(
+        "/change", json=data, headers={"Content-Type": "application/json"},
+    )
+    assert response.status_code == 200
+    logout(client)
+
+    response = client.post(
+        "/us-signin",
+        json=dict(
+            identity="matt@lp.com", passcode="new strong password\N{ROMAN NUMERAL ONE}"
+        ),
+        headers=headers,
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+    logout(client)
+
+    response = client.post(
+        "/us-signin",
+        json=dict(
+            identity="matt@lp.com",
+            passcode="new strong password\N{LATIN CAPITAL LETTER I}",
+        ),
+        headers=headers,
+        follow_redirects=False,
+    )
+    assert response.status_code == 200
+
+
 def test_admin_setup_user_reset(app, client_nc, get_message):
     # Test that we can setup SMS using datastore admin method, and that
     # the datastore admin reset (reset_user_access) disables it.


### PR DESCRIPTION
Remove password_validator method (introduced in 3.4.0) in favor of a PasswordUtil class that encapsulates
both validation and normalization.

Normalization is controlled via SECURITY_PASSWORD_NORMALIZE_FORM config variable and defaults to "NFKD".