### PR TITLE
Change and reset password should invalidate all sessions.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Here you can see the full list of changes between each Flask-Security release.
 Version 4.0.0
 -------------
 
-Release Target Fall 2020
+Release Target Really Early 2021
 
 **PLEASE READ CHANGE NOTES CAREFULLY - THERE ARE LIKELY REQUIRED CHANGES YOU WILL HAVE TO MAKE TO EVEN START YOUR APPLICATION WITH 4.0**
 
@@ -58,6 +58,9 @@ Fixed
   db.put() can be called. Added :meth:`.UserDatastore.add_permissions_to_role` and :meth:`.UserDatastore.remove_permissions_from_role`.
   The methods :meth:`.RoleMixin.add_permissions` and :meth:`.RoleMixin.remove_permissions` have been deprecated.
 - (:issue:`395`) Provide ability to change table names for User and Role tables in the fsqla model.
+- (:issue:`338`) All sessions are invalidated when a user changes or resets their password. This is accomplished by
+  changing the user's `fs_uniquifier`. The user is automatically re-logged in (and a new session
+  created) after a successful change operation.
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
@@ -122,6 +125,11 @@ Backwards Compatibility Concerns
   make the user experience slightly nicer - especially for mobile devices. Some applications use the email form field for other
   identity attributes (such as username). If your application does this you will probably need to subclass ``LoginForm`` and change
   the email type back to StringField.
+
+- (:issue:`338`) By default, both passwords and authentication tokens use the same attribute ``fs_uniquifier`` to
+  uniquely identify the user. This means that if the user changes or resets their password, all authentication tokens
+  also become invalid. This could be viewed as a feature or a bug. If this behavior isn't desired, add another
+  uniquifier: ``fs_token_uniquifier`` to your UserModel and that will be used to generate authentication tokens.
 
 Version 3.4.4
 --------------

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -98,6 +98,13 @@ will require the following additional field:
 
 * ``us_phone_number`` (string)
 
+Separate Identity Domains
+~~~~~~~~~~~~~~~~~~~~~~~~~
+If you want authentication tokens to not be invalidated when the user changes their
+password add the following to your `User` model:
+
+* ``fs_token_uniquifier`` (unique, non-nullable)
+
 Permissions
 ^^^^^^^^^^^
 If you want to protect endpoints with permissions, and assign permissions to roles

--- a/flask_security/changeable.py
+++ b/flask_security/changeable.py
@@ -5,15 +5,17 @@
     Flask-Security recoverable module
 
     :copyright: (c) 2012 by Matt Wright.
+    :copyright: (c) 2019-2020 by J. Christopher Wagner (jwag).
     :author: Eskil Heyn Olsen
     :license: MIT, see LICENSE for more details.
 """
 
-from flask import current_app
+from flask import current_app, request, session
+from flask_login import COOKIE_NAME as REMEMBER_COOKIE_NAME
 from werkzeug.local import LocalProxy
 
 from .signals import password_changed
-from .utils import config_value, hash_password, send_mail
+from .utils import config_value, hash_password, login_user, send_mail
 
 # Convenient references
 _security = LocalProxy(lambda: current_app.extensions["security"])
@@ -38,6 +40,17 @@ def change_user_password(user, password):
     :param password: The unhashed new password
     """
     user.password = hash_password(password)
+    # Change uniquifier - this will cause ALL sessions to be invalidated.
+    _datastore.set_uniquifier(user)
     _datastore.put(user)
+
+    # re-login user - this will update session, optional remember etc.
+    remember_cookie_name = current_app.config.get(
+        "REMEMBER_COOKIE_NAME", REMEMBER_COOKIE_NAME
+    )
+    has_remember_cookie = (
+        remember_cookie_name in request.cookies and session.get("remember") != "clear"
+    )
+    login_user(user, remember=has_remember_cookie, authn_via=["change"])
     send_password_changed_notice(user)
     password_changed.send(current_app._get_current_object(), user=user)

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -281,7 +281,7 @@ def users_deactivate(user):
 @users.command(
     "reset_access",
     help="Reset all authentication credentials for user."
-    " This includes session, auth token, two-factor"
+    " This includes sessions, authentication tokens, two-factor"
     " and unified sign in secrets. ",
 )
 @click.argument("user")


### PR DESCRIPTION
Now, change and reset password operations change the fs_uniquifier which will invalidate all sessions.
It also will invalidate all auth tokens - which may or may not be what the application wants.
Add an optiona fs_token_uniquifier UserModel attribute that if present will be used for auth tokens.

Documentation improvements.

closes #338