### PR TITLE
Improve new fs_token_uniquifier

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -86,7 +86,9 @@ then any existing authentication tokens will no longer be valid. This value is c
 whenever a user changes their password. If this is not the desired behavior then you can add an additional
 attribute to the UserModel: ``fs_token_uniquifier`` and that will be used instead, thus
 isolating password changes from authentication tokens. That attribute can be changed via
-:meth:`.UserDatastore.set_token_uniquifier`
+:meth:`.UserDatastore.set_token_uniquifier`. This attribute should have ``unique=True``.
+Unlike ``fs_uniquifier``, it can be set to ``nullable`` - it will automatically be generated
+at first use if null.
 
 .. _two-factor:
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -431,17 +431,7 @@ _default_forms = {
 
 
 def _user_loader(user_id):
-    """Try to load based on fs_uniquifier (alternative_id) if available.
-
-    Note that we don't try, and fall back to the other - primarily because some DBs
-    and drivers (psycopg2) really really hate getting mismatched types during queries.
-    They hate it enough that they abort the 'transaction' and refuse to do anything
-    in the future until the transaction is rolled-back. But we don't really control
-    that and there doesn't seem to be any way to catch the actual offensive query -
-    just next time and forever, things fail.
-    This assumes that if the app has fs_uniquifier, it is non-nullable as we specify
-    so we use that and only that.
-    """
+    """Load based on fs_uniquifier (alternative_id)."""
     user = _security.datastore.find_user(fs_uniquifier=str(user_id))
     if user and user.active:
         set_request_attr("fs_authn_via", "session")

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -635,7 +635,7 @@ class RoleMixin:
 
         .. versionadded:: 3.3.0
 
-        .. deprecated:: 4.0.0
+        .. deprecated:: 3.4.4
             Use :meth:`.UserDatastore.add_permissions_to_role`
         """
         if hasattr(self, "permissions"):
@@ -658,7 +658,7 @@ class RoleMixin:
 
         .. versionadded:: 3.3.0
 
-        .. deprecated:: 4.0.0
+        .. deprecated:: 3.4.4
             Use :meth:`.UserDatastore.remove_permissions_from_role`
         """
         if hasattr(self, "permissions"):
@@ -693,16 +693,21 @@ class UserMixin(BaseUserMixin):
     def get_auth_token(self):
         """Constructs the user's authentication token.
 
+        :raises ValueError: If fs_token_uniquifier is part of model but not set.
+
         We optionally use a separate uniquifier so that changing password doesn't
         invalidate auth tokens.
 
         This data MUST be securely signed using the ``remember_token_serializer``
 
         .. versionchanged:: 4.0.0
-            If user model has fs_token_uniquifier - use that
+            If user model has fs_token_uniquifier - use that and raise ValueError
+            if not set.
         """
 
         if hasattr(self, "fs_token_uniquifier"):
+            if not self.fs_token_uniquifier:
+                raise ValueError()
             data = [str(self.fs_token_uniquifier)]
         else:
             data = [str(self.fs_uniquifier)]

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -8,7 +8,6 @@
     :copyright: (c) 2019-2020 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
-from abc import abstractmethod
 import json
 import uuid
 
@@ -131,14 +130,6 @@ class UserDatastore:
     def __init__(self, user_model, role_model):
         self.user_model = user_model
         self.role_model = role_model
-
-    @abstractmethod
-    def put(self, user):
-        pass
-
-    @abstractmethod
-    def delete(self, user):
-        pass
 
     def _prepare_role_modify_args(self, role):
         if isinstance(role, str):

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -8,6 +8,7 @@
     :copyright: (c) 2019-2020 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
+from abc import abstractmethod
 import json
 import uuid
 
@@ -130,6 +131,14 @@ class UserDatastore:
     def __init__(self, user_model, role_model):
         self.user_model = user_model
         self.role_model = role_model
+
+    @abstractmethod
+    def put(self, user):
+        pass
+
+    @abstractmethod
+    def delete(self, user):
+        pass
 
     def _prepare_role_modify_args(self, role):
         if isinstance(role, str):

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -858,6 +858,11 @@ def base_render_json(
     additional=None,
     error_status_code=400,
 ):
+    """
+    This method is called by all views that return JSON responses.
+    This fills in the response and then calls :meth:`.Security.render_json`
+    which can be overridden by the app.
+    """
     has_errors = len(form.errors) > 0
 
     user = form.user if hasattr(form, "user") else None
@@ -873,7 +878,7 @@ def base_render_json(
                 payload["user"] = user.get_security_payload()
 
             if include_auth_token:
-                # view wants to return auth_token - check behavior config
+                # view willing to return auth_token - check behavior config
                 if (
                     config_value("BACKWARDS_COMPAT_AUTH_TOKEN")
                     or "include_auth_token" in request.args


### PR DESCRIPTION
Allow for it to be Nullable and initialize on first use if null - this means that applications don't need a data migration to enable this.

factored out the _commit logic into utils.py since there were 3 copies.

a few other minor doc changes.