### PR TITLE
Add blinker as an explicit dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requires = [
     "email-validator>=1.1.1",
     "itsdangerous>=1.1.0",
     "passlib>=1.7.2",
+    "blinker",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
In `signals.py`, there is an import of `blinker`:

https://github.com/Flask-Middleware/flask-security/blob/8ae5b21e69dc6b2acab38d25f4c74498e8158bf9/flask_security/signals.py#L12

Currently `blinker` comes in through Flask-Principal (and maybe other dependencies), but it may be desirable to make this an explicit dependency of this project. 