### PR TITLE
Updated UserMixin.verify_auth_token

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -730,10 +730,9 @@ class UserMixin(BaseUserMixin):
 
         # Version 3.x generated tokens that map to data with 3 elements, and fs_uniquifier was on last element.
         # Version 4.0.0 generates tokens that map to data with only 1 element, which maps to fs_uniquifier.
-        # Thus correct index should be that of the last element of data.
         # Here we compute uniquifier_index so that we can pick up correct index for matching
         # fs_uniquifier in version 4.0.0 even if token was created with version 3.x
-        uniquifier_index = len(data) - 1
+        uniquifier_index = 0 if len(data) == 1 else 2
 
         if hasattr(self, "fs_token_uniquifier"):
             return data[uniquifier_index] == self.fs_token_uniquifier

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -728,10 +728,17 @@ class UserMixin(BaseUserMixin):
             use ``fs_uniquifier``.
         """
 
-        if hasattr(self, "fs_token_uniquifier"):
-            return data[0] == self.fs_token_uniquifier
+        # Version 3.x generated tokens that map to data with 3 elements, and fs_uniquifier was on last element.
+        # Version 4.0.0 generates tokens that map to data with only 1 element, which maps to fs_uniquifier.
+        # Thus correct index should be that of the last element of data.
+        # Here we compute uniquifier_index so that we can pick up correct index for matching
+        # fs_uniquifier in version 4.0.0 even if token was created with version 3.x
+        uniquifier_index = len(data) - 1
 
-        return data[0] == self.fs_uniquifier
+        if hasattr(self, "fs_token_uniquifier"):
+            return data[uniquifier_index] == self.fs_token_uniquifier
+
+        return data[uniquifier_index] == self.fs_uniquifier
 
     def has_role(self, role):
         """Returns `True` if the user identifies with the specified role.


### PR DESCRIPTION
See #461.
This code should let flask security version 4.x correctly read tokens generated with flask security version 3.x

I didn't include any test, and this is a feature that shouldn't go untested.
I would welcome pointers to existing tests I could use as a base.
Since v3.x token needs to be used I thought it might be best to hard code token for the test - that is if I can hard code fs uniquifier too.