### PR TITLE
Doc and other small changes/fixes.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+default_language_version:
+    python: python3.8
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0
@@ -20,9 +22,8 @@ repos:
     rev: 20.8b1
     hooks:
     -   id: black
-        language_version: python3.6
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (C) 2012-2019 by Matthew Wright
-Copyright (C) 2019-2019 by Chris Wagner
+Copyright (C) 2012-2021 by Matthew Wright
+Copyright (C) 2019-2021 by Chris Wagner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Flask-Security"
-copyright = "2012-2020"
+copyright = "2012-2021"
 author = "Matt Wright & Chris Wagner"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -57,7 +57,7 @@ author = "Matt Wright & Chris Wagner"
 # built documents.
 #
 # The short X.Y version.
-version = "4.0.0"
+version = "4.0.1"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -177,6 +177,9 @@ These configuration keys are used globally across all features.
 
     Email address are validated using the `email_validator`_ package. Its methods
     have some configurable options - these can be set here and will be passed in.
+    For example setting this to: ``{"check_deliverability": False}`` is useful
+    when unit testing if the emails are fake.
+
 
     Default: ``None``, meaning use the defaults from email_validator package.
 
@@ -375,7 +378,7 @@ These are used by the Two-Factor and Unified Signin features.
 
 .. py:data:: SECURITY_TOTP_SECRETS
 
-    Secret used to encrypt totp_password both into DB and in session cookie.
+    Secret used to encrypt the totp_password both into DB and into the session cookie.
     Best practice is to set this to:
 
     .. code-block:: python
@@ -398,7 +401,13 @@ These are used by the Two-Factor and Unified Signin features.
 
 .. py:data:: SECURITY_SMS_SERVICE
 
-    Specifies the name of the sms service provider.
+    Specifies the name of the sms service provider. Out of the box
+    "Twilio" is supported. For other sms service providers you will need
+    to subclass :class:`.SmsSenderBaseClass` and register it:
+
+    .. code-block:: python
+
+        SmsSenderFactory.senders[<service-name>] = <service-class>
 
     Default: ``Dummy`` which does nothing.
 
@@ -407,8 +416,9 @@ These are used by the Two-Factor and Unified Signin features.
 .. py:data:: SECURITY_SMS_SERVICE_CONFIG
 
     Specifies a dictionary of basic configurations needed for use of a sms service.
+    For "Twilio" the following keys are required (fill in from your Twilio dashboard):
 
-    Default: ``{'ACCOUNT_ID': NONE, 'AUTH_TOKEN':NONE, 'PHONE_NUMBER': NONE}``
+    Default: ``{'ACCOUNT_SID': NONE, 'AUTH_TOKEN': NONE, 'PHONE_NUMBER': NONE}``
 
     .. versionadded:: 3.4.0
 
@@ -885,17 +895,17 @@ Configuration related to the two-factor authentication feature.
 
     Specifies the number of seconds access token is valid.
 
-    Default: ``2 minutes``.
+    Default: ``120``.
 .. py:data:: SECURITY_TWO_FACTOR_MAIL_VALIDITY
 
     Specifies the number of seconds access token is valid.
 
-    Default: ``5 minutes``.
+    Default: ``300``.
 .. py:data:: SECURITY_TWO_FACTOR_SMS_VALIDITY
 
     Specifies the number of seconds access token is valid.
 
-    Default: ``2 minutes``.
+    Default: ``120``.
 .. py:data:: SECURITY_TWO_FACTOR_RESCUE_MAIL
 
     Specifies the email address users send mail to when they can't complete the

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -256,7 +256,7 @@ This is supported by providing your own implementation of the :class:`.MailUtil`
             send_flask_mail.delay(
                 subject=subject,
                 sender=sender,
-                recipients=recipients,
+                recipients=[recipient],
                 body=body,
                 html=html,
             )
@@ -275,7 +275,9 @@ Then register your class as part of Flask-Security initialization::
 
     @celery.task
     def send_flask_mail(**kwargs):
-        mail.send(Message(**kwargs))
+        # If you use Flask_Mail - it needs an app context
+        with app.app_context():
+            mail.send(Message(**kwargs))
 
     def create_app(config):
         """Initialize Flask instance."""

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -9,6 +9,12 @@ There are some complete (but simple) examples available in the *examples* direct
     They basically create a single user, and you can login as that user... that's it.
     As you add more features, additional packages (e.g. Flask-Mail, Flask-Babel, pyqrcode) might be required
     and will need to be added to your requirements.txt (or equivalent) file.
+    Flask-Security does some configuration validation and will output error messages to the console
+    for some missing packages.
+
+.. note::
+    The default ``SECURITY_PASSWORD_HASH`` is "bcrypt" - so be sure to install bcrypt.
+    If you opt for a different hash e.g. "argon2" you will need to install a different package.
 
 .. danger::
    The examples below place secrets in source files. Never do this for your application
@@ -36,7 +42,7 @@ SQLAlchemy Install requirements
 ::
 
      $ mkvirtualenv <your-app-name>
-     $ pip install flask-security-too flask-sqlalchemy
+     $ pip install flask-security-too flask-sqlalchemy bcrypt
 
 
 SQLAlchemy Application
@@ -117,7 +123,7 @@ SQLAlchemy Install requirements
 ::
 
      $ mkvirtualenv <your-app-name>
-     $ pip install flask-security-too sqlalchemy
+     $ pip install flask-security-too sqlalchemy bcrypt
 
 Also, you can use the extension `Flask-SQLAlchemy-Session documentation
 <http://flask-sqlalchemy-session.readthedocs.io/en/latest/>`_.
@@ -242,7 +248,7 @@ MongoEngine Install requirements
 ::
 
     $ mkvirtualenv <your-app-name>
-    $ pip install flask-security-too flask-mongoengine
+    $ pip install flask-security-too flask-mongoengine bcrypt
 
 MongoEngine Application
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -321,7 +327,7 @@ Peewee Install requirements
 ::
 
     $ mkvirtualenv <your-app-name>
-    $ pip install flask-security-too peewee
+    $ pip install flask-security-too peewee bcrypt
 
 Peewee Application
 ~~~~~~~~~~~~~~~~~~
@@ -468,5 +474,15 @@ in 2 ways:
 
 Look in the `Flask-Security repo`_ *examples* directory for actual code that implements the
 first approach.
+
+You also might want to set the following configurations in your conftest.py:
+
+.. code-block:: python
+
+    app.config["WTF_CSRF_ENABLED"] = False
+    # Our test emails/domain isn't necessarily valid
+    app.config["SECURITY_EMAIL_VALIDATOR_ARGS"] = {"check_deliverability": False}
+    # Make this plaintext for most tests - reduces unit test time by 50%
+    app.config["SECURITY_PASSWORD_HASH"] = "plaintext"
 
 .. _Flask-Security repo: https://github.com/Flask-Middleware/flask-security

--- a/docs/spa.rst
+++ b/docs/spa.rst
@@ -15,7 +15,9 @@ For the purposes of this application note - this implies:
       via a templating language.
 
     * The user interface interacts with the backend Flask application via JSON requests
-      and responses - not forms.
+      and responses - not forms. The external (json/form) API is described `here`_
+
+.. _here: _static/openapi_view.html
 
     * SPAs are still browser based - so they have the same security vulnerabilities as
       traditional html/form-based applications.

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -103,4 +103,4 @@ from .utils import (
     verify_and_update_password,
 )
 
-__version__ = "4.0.0"
+__version__ = "4.0.1"

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -728,10 +728,13 @@ class UserMixin(BaseUserMixin):
             use ``fs_uniquifier``.
         """
 
-        # Version 3.x generated tokens that map to data with 3 elements, and fs_uniquifier was on last element.
-        # Version 4.0.0 generates tokens that map to data with only 1 element, which maps to fs_uniquifier.
-        # Here we compute uniquifier_index so that we can pick up correct index for matching
-        # fs_uniquifier in version 4.0.0 even if token was created with version 3.x
+        # Version 3.x generated tokens that map to data with 3 elements,
+        # and fs_uniquifier was on last element.
+        # Version 4.0.0 generates tokens that map to data with only 1 element,
+        # which maps to fs_uniquifier.
+        # Here we compute uniquifier_index so that we can pick up correct index for
+        # matching fs_uniquifier in version 4.0.0 even if token was created with
+        # version 3.x
         uniquifier_index = 0 if len(data) == 1 else 2
 
         if hasattr(self, "fs_token_uniquifier"):
@@ -1219,8 +1222,18 @@ class Security:
                 raise ValueError("Must configure some TWO_FACTOR_ENABLED_METHODS")
 
         if multi_factor:
-            self._check_modules("pyqrcode", "TWO_FACTOR or UNIFIED_SIGNIN")
+            # cryptography is used to encrypt TOTP secrets
             self._check_modules("cryptography", "TWO_FACTOR or UNIFIED_SIGNIN")
+
+            need_qrcode = (
+                cv("UNIFIED_SIGNIN", app=app)
+                and "authenticator" in cv("US_ENABLED_METHODS", app=app)
+            ) or (
+                cv("TWO_FACTOR", app=app)
+                and "authenticator" in cv("TWO_FACTOR_ENABLED_METHODS", app=app)
+            )
+            if need_qrcode:
+                self._check_modules("pyqrcode", "TWO_FACTOR or UNIFIED_SIGNIN")
 
             need_sms = (
                 cv("UNIFIED_SIGNIN", app=app)

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -340,9 +340,17 @@ class UserDatastore:
         :kwparam roles: list of roles to be added to user.
             Can be Role objects or strings
 
+        Any other element of the User data model may be supplied as well.
+
         .. note::
             No normalization is done on email - it is assumed the caller has already
             done that.
+
+            Best practice is::
+
+                try:
+                    enorm = app.security._mail_util.validate(email)
+                except ValueError:
 
         .. note::
             The roles kwparam is modified as part of the call - it will, if necessary
@@ -357,13 +365,14 @@ class UserDatastore:
            (e.g for minimum length).
 
            Best practice is::
+
             pbad, pnorm = app.security._password_util.validate(password, True)
 
            Look for `pbad` being None. Pass the normalized password `pnorm` to this
            method.
 
         The new user's ``active`` property will be set to ``True``
-        unless explicitly set to ``False`` in `kwargs`.
+        unless explicitly set to ``False`` in `kwargs` (e.g. active = False)
         """
         kwargs = self._prepare_create_user_args(**kwargs)
         user = self.user_model(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ install_requires = [
     "email-validator>=1.1.1",
     "itsdangerous>=1.1.0",
     "passlib>=1.7.2",
+    "blinker>=1.4",
 ]
 
 packages = find_packages(exclude=["tests"])


### PR DESCRIPTION
Configuration.rst - point out setting EMAIL_VALIDATOR_ARGS for unit testing.
Improve doc for create_user by adding best practice code for validating emails.
Don't require pyqrcode unless configured authenticator app.
Add more documentation for SMS_SERVICE and fix error in SMS_SERVICE_CONFIG.
Fix TWO_FACTOR_XX_VALIDITY defaults - they should be numbers.

In customizing improve doc for celery and fix incorrect args.

Quickstart.rst - add bcrypt to pip install since by default that is needed.
Added additional configuration variables to set for unit testing.

Add information about setting up SMS in two_factor_configurations.rst as well as add required package installs.

Added link to YAML api doc right at top of spa.rst

Try to fix CI by pegging tox style at 3.8
Hard requirement on blinker since FS requires working signals
Bump to 4.0.1

Thanks @najibfahs, @virajut