### PR TITLE
Fix form errors in CLI.

### DIFF
--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -66,6 +66,15 @@ def commit(fn):
     return wrapper
 
 
+def fix_errors(form_errors):
+    # Form errors might have lazy text which normally would be processed by
+    # render_template
+    errors = {}
+    for k, v in form_errors.items():
+        errors[k] = [str(e) for e in v]
+    return errors
+
+
 @click.group()
 def users():
     """User commands.
@@ -134,7 +143,7 @@ def users_create(attributes, password, active):
         kwargs["password"] = "****"
         click.echo(kwargs)
     else:
-        raise click.UsageError("Error creating user. %s" % form.errors)
+        raise click.UsageError("Error creating user. %s" % fix_errors(form.errors))
 
 
 @roles.command("create")

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -175,7 +175,7 @@ def unique_identity_attribute(form, field):
     SECURITY_USER_IDENTITY_ATTRIBUTES.
     This can be used as part of registration.
 
-    Be aware that the "mapper" function likely also nornalizes the input in addition
+    Be aware that the "mapper" function likely also normalizes the input in addition
     to validating it.
 
     :param form:

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -19,7 +19,7 @@ pyqrcode
 pytest-cache
 pytest-cov
 pytest
-sqlalchemy
+sqlalchemy<1.4.0
 sqlalchemy-utils
 werkzeug
 zxcvbn

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -97,6 +97,27 @@ def test_cli_createuser_normalize(script_info):
         )
 
 
+def test_cli_createuser_errors(script_info):
+    # check that errors are stringified
+    runner = CliRunner()
+    result = runner.invoke(
+        users_create, ["--password", "battery staple"], obj=script_info
+    )
+    assert result.exit_code == 2
+    assert "Email not provided" in result.output
+
+
+def test_cli_locale(script_info):
+    app = script_info.load_app()
+    app.config["BABEL_DEFAULT_LOCALE"] = "fr_FR"
+    runner = CliRunner()
+    result = runner.invoke(
+        users_create, ["--password", "battery staple"], obj=script_info
+    )
+    assert result.exit_code == 2
+    assert "Merci d'indiquer une adresse email" in result.output
+
+
 def test_cli_createrole(script_info):
     """Test create user CLI."""
     runner = CliRunner()


### PR DESCRIPTION
Some form errors are lazy text - and those weren't getting properly formatted (normally render_template) would do that.

Improve the fsqlalchemy example to make it more robust and useful.

Pin sqlalchemy at <1.4 since there are mismatches with sqlalchemy_utils.

Closes: #443