### PR TITLE
add note about db migration when using a MySQL database

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -492,6 +492,9 @@ add code like this to your migrations::update method::
     # finally - set nullable to false
     op.alter_column('user', 'fs_uniquifier', nullable=False)
 
+    # for MySQL the previous line has to be replaced with...
+    # op.alter_column('user', 'fs_uniquifier', existing_type=sa.String(length=64), nullable=False)
+
 
 Version 3.2.0
 -------------


### PR DESCRIPTION
Since version `4.0.0` the `UserModel` must contain `fs_notifier`.

While the changelog offered a db migration guide, the listed code did
not work when a MySQL database gets used.

Now, the code listing got updated, and also shows how to proceed when
using a MySQL database.