### PR TITLE
Add tox support for running against latest pallets modules.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.10.0
+    rev: v2.11.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,33 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 4.0.1
+-------------
+
+Released TBD
+
+Features
+++++++++
+
+Fixes
++++++
+- (:issue:`461`) 4.0 doesn't accept 3.4 authentication tokens. (kuba-lilz)
+- (:issue:`460`) 2-fa error: Failed to send code - improved documentation and debuggability.
+- (:issue:`454`) 2-fa error: TypeError - fixed documentation.
+- (:issue:`443`) Calling create user without any arguments - fixed underlying cause
+  of translating form errors in the CLI.
+- (:issue:`442`) Email validation confusion - added documentation.
+- (:pr:`470`) Add note about updating DB using MySQL. (jugmac00)
+- (:pr:`468`) Fix documentation - uia_phone_number should be uia_phone_mapper. (dvrg)
+- (:pr:`457`) Improve chinese translations. (zxjlm)
+- (:pr:`453`) Improve basque and spanish translations. (mmozos)
+- (:pr:`448`) Add Afrikaans translations. (lonelyvikingmichael)
+- (:pr:`467`) Add Blinker as explicit dependency, improve/fix celery usage docs,
+  dont require pyqrcode unless authenticator configured, improve SMS configuration
+  variables documentation.
+
+
+
 Version 4.0.0
 -------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -727,7 +727,7 @@ def datastore(request, app, tmpdir, realdburl):
 def script_info(app, sqlalchemy_datastore):
     from flask.cli import ScriptInfo
 
-    def create_app(info):
+    def create_app():
         uia = [
             {"email": {"mapper": uia_email_mapper}},
             {"username": {"mapper": lambda x: x}},

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,17 @@ commands =
     python setup.py compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}
 
+[testenv:py38-master]
+deps =
+    -r requirements/tests.txt
+    git+git://github.com/pallets/werkzeug@master#egg=werkzeug
+    git+git://github.com/pallets/flask@master#egg=flask
+    git+git://github.com/pallets/flask-sqlalchemy@master#egg=flask-sqlalchemy
+    git+git://github.com/pallets/jinja@master#egg=jinja2
+commands =
+    python setup.py compile_catalog
+    pytest --basetemp={envtmpdir} {posargs:tests}
+
 [testenv:style]
 deps = pre-commit
 skip_install = true


### PR DESCRIPTION
Werkzeug, flask, flask-sqlalchemy, jinja2 are all close to major releases - make sure we work with them.

Fixed one deprecation warning w.r.t. script_info and CLI testing.

Get CHANGES.rst up to date with all the work we have done.