### PR TITLE
Update German translation

### DIFF
--- a/docs/two_factor_configurations.rst
+++ b/docs/two_factor_configurations.rst
@@ -173,7 +173,7 @@ entered, the new configuration will be permanently stored.
 
 Initial login/registration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This is basically a combination of the above two - initial POST to ``/login`` will return indicating that 2FA is required. The user must then POST to ``/tf-setup`` to setup
+This is basically a combination of the above two - initial POST to ``/login`` will return indicating that 2FA is required. The user must then POST to ``/tf_setup`` to setup
 the desired 2FA method, and finally have the user enter the code and POST to ``/tf-validate``.
 
 Rescue

--- a/docs/two_factor_configurations.rst
+++ b/docs/two_factor_configurations.rst
@@ -173,7 +173,7 @@ entered, the new configuration will be permanently stored.
 
 Initial login/registration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-This is basically a combination of the above two - initial POST to ``/login`` will return indicating that 2FA is required. The user must then POST to ``/tf_setup`` to setup
+This is basically a combination of the above two - initial POST to ``/login`` will return indicating that 2FA is required. The user must then POST to ``/tf-setup`` to setup
 the desired 2FA method, and finally have the user enter the code and POST to ``/tf-validate``.
 
 Rescue

--- a/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
@@ -1,10 +1,10 @@
-# German translation for Flask-Security (Du/Sie distinction has been
-# avoided)
-# Copyright (C) 2017 ORGANIZATION
+# German translation for Flask-Security
+# Copyright (C) 2017-2021 ORGANIZATION
 # This file is distributed under the same license as the Flask-Security
 # project.
 # Ingo Kleiber <ingo@kleiber.me>, 2017,
 # Erich Seifert <dev@erichseifert.de>, 2017.
+# Pascua Theus <pascua@identeco.de>, 2021
 #
 msgid ""
 msgstr ""
@@ -12,7 +12,7 @@ msgstr ""
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
 "POT-Creation-Date: 2021-03-31 21:47-0700\n"
 "PO-Revision-Date: 2017-09-25 09:14+0200\n"
-"Last-Translator: Erich Seifert <dev@erichseifert.de>\n"
+"Last-Translator: Pascua Theus <pascua@identeco.de>\n"
 "Language: de_DE\n"
 "Language-Team: de_DE <LL@li.org>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
@@ -58,27 +58,27 @@ msgstr "Anleitung zur Passwortwiederherstellung"
 
 #: flask_security/core.py:218
 msgid "Two-factor Login"
-msgstr ""
+msgstr "Zwei-Faktor-Anmeldung"
 
 #: flask_security/core.py:219
 msgid "Two-factor Rescue"
-msgstr ""
+msgstr "Zwei-Faktor-Wiederherstellung"
 
 #: flask_security/core.py:263
 msgid "Verification Code"
-msgstr ""
+msgstr "Verifizierungscode"
 
 #: flask_security/core.py:278
 msgid "Input not appropriate for requested API"
-msgstr ""
+msgstr "Ungültige Eingabe für die angeforderte Ressource"
 
 #: flask_security/core.py:279
 msgid "You do not have permission to view this resource."
-msgstr "Keine Berechtigung um diese Ressource zu sehen."
+msgstr "Sie haben keine Berechtigung, um diese Ressource zu sehen."
 
 #: flask_security/core.py:281
 msgid "You are not authenticated. Please supply the correct credentials."
-msgstr ""
+msgstr "Sie sind nicht angemeldet. Bitte geben Sie die korrekten Zugangsdaten ein."
 
 #: flask_security/core.py:285
 #, fuzzy
@@ -196,7 +196,7 @@ msgstr "Ungültige E-Mail-Adresse"
 
 #: flask_security/core.py:349
 msgid "Invalid code"
-msgstr ""
+msgstr "Ungültiger Code"
 
 #: flask_security/core.py:350
 msgid "Password not provided"
@@ -213,23 +213,23 @@ msgstr "Das Passwort muss mindestens %(length)s Zeichen lang sein"
 
 #: flask_security/core.py:356
 msgid "Password not complex enough"
-msgstr ""
+msgstr "Passwort ist nicht komplex genug"
 
 #: flask_security/core.py:357
 msgid "Password on breached list"
-msgstr ""
+msgstr "Passwort ist öffentlich bekannt"
 
 #: flask_security/core.py:359
 msgid "Failed to contact breached passwords site"
-msgstr ""
+msgstr "Konnte keine Verbindung zum Dienst aufbauen, um Passwörter zu überprüfen."
 
 #: flask_security/core.py:362
 msgid "Phone number not valid e.g. missing country code"
-msgstr ""
+msgstr "Telefonnumer ist ungültig, eventuell fehlt die Landesvorwahl"
 
 #: flask_security/core.py:363
 msgid "Specified user does not exist"
-msgstr "Angegebener Benutzer existiert nicht"
+msgstr "Der angegebene Benutzer existiert nicht"
 
 #: flask_security/core.py:364
 msgid "Invalid password"
@@ -237,11 +237,11 @@ msgstr "Ungültiges Passwort"
 
 #: flask_security/core.py:365
 msgid "Password or code submitted is not valid"
-msgstr ""
+msgstr "Übermitteltes Passwort oder Code ist ungültig"
 
 #: flask_security/core.py:366
 msgid "You have successfully logged in."
-msgstr "Die Anmeldung war erfolgreich."
+msgstr "Sie wurden angemeldet."
 
 #: flask_security/core.py:367
 msgid "Forgot password?"
@@ -265,56 +265,56 @@ msgstr "Das Passwort wurde erfolgreich geändert."
 
 #: flask_security/core.py:380
 msgid "Please log in to access this page."
-msgstr "Bitte anmelden, um diese Seite zu sehen."
+msgstr "Bitte anmelden Sie sich an, um diese Seite zu sehen."
 
 #: flask_security/core.py:381
 msgid "Please reauthenticate to access this page."
-msgstr "Bitte neu authentifizieren, um auf diese Seite zuzugreifen."
+msgstr "Bitte neu anmelden, um auf diese Seite zuzugreifen."
 
 #: flask_security/core.py:382
 msgid "Reauthentication successful"
-msgstr ""
+msgstr "Neuanmeldung erfolgreich"
 
 #: flask_security/core.py:384
 msgid "You can only access this endpoint when not logged in."
-msgstr ""
+msgstr "Dieser Endpunkt ist nur für angemeldete Nutzer erlaubt."
 
 #: flask_security/core.py:387
 msgid "Failed to send code. Please try again later"
-msgstr ""
+msgstr "Zusendung des Codes fehlgeschlagen. Bitte versuchen Sie es später noch einmal."
 
 #: flask_security/core.py:388
 msgid "Invalid Token"
-msgstr ""
+msgstr "Untültiger Token"
 
 #: flask_security/core.py:389
 msgid "Your token has been confirmed"
-msgstr ""
+msgstr "Ihr Token wurde bestätigt"
 
 #: flask_security/core.py:391
 msgid "You successfully changed your two-factor method."
-msgstr ""
+msgstr "Zwei-Faktor-Methode wurde geändert"
 
 #: flask_security/core.py:395
 msgid "You currently do not have permissions to access this page"
-msgstr ""
+msgstr "Sie haben aktuell nicht die nötigen Rechte, um die Seite anzusehen"
 
 #: flask_security/core.py:398
 msgid "Marked method is not valid"
-msgstr ""
+msgstr "Ausgewählte Methode ist nicht gültig"
 
 #: flask_security/core.py:400
 msgid "You successfully disabled two factor authorization."
-msgstr ""
+msgstr "Zwei-Faktor-Authentisierung wurde deaktiviert"
 
 #: flask_security/core.py:403
 msgid "Requested method is not valid"
-msgstr ""
+msgstr "Angefragte Methode ist ungültig"
 
 #: flask_security/core.py:405
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
-msgstr ""
+msgstr "Einrichtung muss innerhalb %(within)s abgeschlossen werden. Bitte neu beginnen."
 
 #: flask_security/core.py:408
 msgid "Unified sign in setup successful"
@@ -322,12 +322,12 @@ msgstr ""
 
 #: flask_security/core.py:409
 msgid "You must specify a valid identity to sign in"
-msgstr ""
+msgstr "Sie müssen eine gültige Identität auswählen, um sich anzumelden"
 
 #: flask_security/core.py:410
 #, python-format
 msgid "Use this code to sign in: %(code)s."
-msgstr ""
+msgstr "Code zur Anmeldung: %(code)s"
 
 #: flask_security/forms.py:53
 msgid "Email Address"
@@ -351,7 +351,7 @@ msgstr "Anmelden"
 #: flask_security/templates/security/email/us_instructions.html:8
 #: flask_security/templates/security/us_signin.html:6
 msgid "Sign In"
-msgstr ""
+msgstr "Anmeldung"
 
 #: flask_security/forms.py:58 flask_security/templates/security/_menu.html:11
 #: flask_security/templates/security/register_user.html:6
@@ -388,71 +388,71 @@ msgstr "Anmelde-Link versenden"
 
 #: flask_security/forms.py:66
 msgid "Verify Password"
-msgstr ""
+msgstr "Password bestätigen"
 
 #: flask_security/forms.py:67
 msgid "Change Method"
-msgstr ""
+msgstr "Methode ändern"
 
 #: flask_security/forms.py:68
 msgid "Phone Number"
-msgstr ""
+msgstr "Telefonnummer"
 
 #: flask_security/forms.py:69
 msgid "Authentication Code"
-msgstr ""
+msgstr "Authentisierungscode"
 
 #: flask_security/forms.py:70
 msgid "Submit"
-msgstr ""
+msgstr "Bestätigen"
 
 #: flask_security/forms.py:71
 msgid "Submit Code"
-msgstr ""
+msgstr "Code bestätigen"
 
 #: flask_security/forms.py:72
 msgid "Error(s)"
-msgstr ""
+msgstr "Fehler"
 
 #: flask_security/forms.py:73
 msgid "Identity"
-msgstr ""
+msgstr "Identität"
 
 #: flask_security/forms.py:74
 msgid "Send Code"
-msgstr ""
+msgstr "Sende Code"
 
 #: flask_security/forms.py:75
 msgid "Passcode"
-msgstr ""
+msgstr "Anmelde-Code"
 
 #: flask_security/unified_signin.py:131
 msgid "Code or Password"
-msgstr ""
+msgstr "Code oder Passwort"
 
 #: flask_security/unified_signin.py:136 flask_security/unified_signin.py:262
 msgid "Available Methods"
-msgstr ""
+msgstr "Verfügbare Methoden"
 
 #: flask_security/unified_signin.py:137
 msgid "Via email"
-msgstr ""
+msgstr "Via E-Mail"
 
 #: flask_security/unified_signin.py:137
 msgid "Via SMS"
-msgstr ""
+msgstr "Via SMS"
 
 #: flask_security/unified_signin.py:264
 msgid "Set up using email"
-msgstr ""
+msgstr "Einrichtung via E-Mail"
 
 #: flask_security/unified_signin.py:267
 msgid "Set up using an authenticator app (e.g. google, lastpass, authy)"
-msgstr ""
+msgstr "Einrichtung via Authentifikator-App"
 
 #: flask_security/unified_signin.py:269
 msgid "Set up using SMS"
-msgstr ""
+msgstr "Einrichtung via SMS"
 
 #: flask_security/templates/security/_menu.html:2
 msgid "Menu"
@@ -488,47 +488,56 @@ msgstr "Bestätigungsanleitung erneut versenden"
 
 #: flask_security/templates/security/two_factor_setup.html:31
 msgid "Two-factor authentication adds an extra layer of security to your account"
-msgstr ""
+msgstr "Zwei-Faktor-Authentisierung bietet eine zusätzliche Sicherheitsebene für Ihr Benutzerkonto"
 
 #: flask_security/templates/security/two_factor_setup.html:32
 msgid ""
 "In addition to your username and password, you'll need to use a code that"
 " we will send you"
 msgstr ""
+"Zusätzlich zu Ihrem Benutzernamen und Passwort müssen Sie einen Code verwenden, "
+"den wir Ihnen zusenden"
 
 #: flask_security/templates/security/two_factor_setup.html:43
 msgid "To complete logging in, please enter the code sent to your mail"
 msgstr ""
+"Um die Anmeldung abzuschließen, geben Sie bitte den Code ein, "
+"denen wir an Ihre E-Mail-Adresse geschickt haben"
 
 #: flask_security/templates/security/two_factor_setup.html:49
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
+"Öffnen Sie die Authentisierungsapp z.B. auf Ihrem Smartphone und scannen Sie den "
+"folgenden QR-Code (oder geben Sie den unten stehenden Code ein), um den Empfang von Codes zu "
+"beginnen"
 
 #: flask_security/templates/security/two_factor_setup.html:52
 msgid "Two factor authentication code"
-msgstr ""
+msgstr "Zwei-Faktor-Authentisierungscode"
 
 #: flask_security/templates/security/two_factor_setup.html:60
 msgid "To Which Phone Number Should We Send Code To?"
-msgstr ""
+msgstr "An welche Telefonnummer sollen wir den Code senden?"
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
 msgid "Two-factor Authentication"
-msgstr ""
+msgstr "Zwei-Faktor-Authentisierung"
 
 #: flask_security/templates/security/two_factor_verify_code.html:7
 msgid "Please enter your authentication code"
-msgstr ""
+msgstr "Bitte geben Sie den Authentisierungscode ein"
 
 #: flask_security/templates/security/two_factor_verify_code.html:18
 msgid "The code for authentication was sent to your email address"
-msgstr ""
+msgstr "Der Authentisierungscode wurde an Ihre E-Mail-Adresse gesendet"
 
 #: flask_security/templates/security/two_factor_verify_code.html:21
 msgid "A mail was sent to us in order to reset your application account"
 msgstr ""
+"Wir haben eine E-Mail von Ihnen erhalten, "
+"um Ihnen bei der Wiederherstellung Ihres Kontos zu unterstützen"
 
 #: flask_security/templates/security/us_setup.html:36
 msgid "Setup Unified Sign In options"
@@ -538,21 +547,24 @@ msgstr ""
 #: flask_security/templates/security/us_signin.html:23
 #: flask_security/templates/security/us_verify.html:21
 msgid "Code has been sent"
-msgstr ""
+msgstr "Der Code wurde verschickt"
 
 #: flask_security/templates/security/us_setup.html:66
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving passcodes:"
 msgstr ""
+"Öffnen Sie die Authentisierungsapp z.B. auf Ihrem Smartphone und scannen Sie den "
+"folgenden QR-Code (oder geben Sie den unten stehenden Code ein), um den Empfang von "
+"Anmelde-Codes zu beginnen"
 
 #: flask_security/templates/security/us_setup.html:69
 msgid "Passwordless QRCode"
-msgstr ""
+msgstr "Passwortloser QR-Code"
 
 #: flask_security/templates/security/us_setup.html:77
 msgid "No methods have been enabled - nothing to setup"
-msgstr ""
+msgstr "Keine Methode ausgewählt – keine Einrichtung erfolgt"
 
 #: flask_security/templates/security/us_signin.html:15
 #: flask_security/templates/security/us_verify.html:13
@@ -566,23 +578,23 @@ msgstr "Bitte neu authentifizieren, um auf diese Seite zuzugreifen."
 
 #: flask_security/templates/security/verify.html:6
 msgid "Please Enter Your Password"
-msgstr ""
+msgstr "Bitte geben Sie Ihr Passwort ein"
 
 #: flask_security/templates/security/email/change_notice.html:1
 msgid "Your password has been changed."
-msgstr "Das Passwort wurde geändert."
+msgstr "Ihr Passwort wurde geändert."
 
 #: flask_security/templates/security/email/change_notice.html:3
 msgid "If you did not change your password,"
-msgstr "Falls das Passwort nicht geändert wurde"
+msgstr "Falls Sie Ihr Passwort nicht geändert haben,"
 
 #: flask_security/templates/security/email/change_notice.html:3
 msgid "click here to reset it"
-msgstr "hier klicken, um es zurückzusetzen"
+msgstr "klicken Sie hier, um es zurückzusetzen"
 
 #: flask_security/templates/security/email/change_notice.txt:3
 msgid "If you did not change your password, click the link below to reset it."
-msgstr ""
+msgstr "Wenn Sie Ihr Passwort nicht geändert haben, klicken Sie auf den unten stehenden Link."
 
 #: flask_security/templates/security/email/confirmation_instructions.html:1
 #: flask_security/templates/security/email/confirmation_instructions.txt:1
@@ -592,7 +604,7 @@ msgstr "Bitte die E-Mail-Adresse durch den Link unten bestätigen:"
 #: flask_security/templates/security/email/confirmation_instructions.html:3
 #: flask_security/templates/security/email/welcome.html:6
 msgid "Confirm my account"
-msgstr "Das Konto bestätigen"
+msgstr "Mein Konto bestätigen"
 
 #: flask_security/templates/security/email/login_instructions.html:1
 #: flask_security/templates/security/email/login_instructions.txt:1
@@ -613,34 +625,34 @@ msgstr "Jetzt anmelden"
 
 #: flask_security/templates/security/email/reset_instructions.html:1
 msgid "Click here to reset your password"
-msgstr "Hier klicken, um das Passwort zurückzusetzen"
+msgstr "Klicken Sie hier, um das Passwort zurückzusetzen"
 
 #: flask_security/templates/security/email/reset_instructions.txt:1
 msgid "Click the link below to reset your password:"
-msgstr ""
+msgstr "Klicken Sie auf den unten stehenden Link, um Ihr Passwort zurückzusetzen:"
 
 #: flask_security/templates/security/email/two_factor_instructions.html:3
 #: flask_security/templates/security/email/two_factor_instructions.txt:3
 msgid "You can log into your account using the following code:"
-msgstr ""
+msgstr "Sie können sich mit folgenden Code in Ihr Benutzerkonto anmelden:"
 
 #: flask_security/templates/security/email/two_factor_rescue.html:1
 #: flask_security/templates/security/email/two_factor_rescue.txt:1
 msgid "can not access mail account"
-msgstr ""
+msgstr "kann E-Mail-Konto nicht erreichen"
 
 #: flask_security/templates/security/email/us_instructions.html:3
 #: flask_security/templates/security/email/us_instructions.txt:3
 msgid "You can sign into your account using the following code:"
-msgstr ""
+msgstr "Sie können sich mit folgenden Code in Ihr Benutzerkonto anmelden:"
 
 #: flask_security/templates/security/email/us_instructions.html:6
 msgid "Or use the the link below:"
-msgstr ""
+msgstr "Oder nutzen Sie den folgenden Link:"
 
 #: flask_security/templates/security/email/us_instructions.txt:7
 msgid "Or use the link below:"
-msgstr ""
+msgstr "Oder nutzen Sie den folgenden Link:"
 
 #: flask_security/templates/security/email/welcome.html:4
 #: flask_security/templates/security/email/welcome.txt:4


### PR DESCRIPTION
German translation is actually outdated. This MR adds missing strings and updates some of the existing ones.

Caution: Currently, the translation file states that it avoids distinction of German "Du" and "Sie" (in English both "You"). In German "Du" is used in informal language (friends, family…) and "Sie" is formal. Since one cannot really avoid using one of them translating Flask-Security without creating really bad sounding sentences, I decided to use the formal "Sie" as this is commonly used (e.g. in Flask-User). If someone wants to use the informal "Du", he may want to add a new translation file.