### PR TITLE
A (hopeful) fix for possible open-redirect.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
     python: python3.8
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.0.1
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -14,16 +14,16 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.14.0
+    rev: v2.19.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/psf/black
-    rev: 21.5b0
+    rev: 21.5b1
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.1
+    rev: 3.9.2
     hooks:
       - id: flake8
         additional_dependencies:

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -221,13 +221,58 @@ These configuration keys are used globally across all features.
 .. py:data:: SECURITY_REDIRECT_ALLOW_SUBDOMAINS
 
     If ``True`` then subdomains (and the root domain) of the top-level host set
-    by Flask's ``SERVER_NAME`` configuration will be allowed as post-login redirect targets.
+    by Flask's ``SERVER_NAME`` configuration will be allowed as post-view redirect targets.
     This is beneficial if you wish to place your authentiation on one subdomain and
     authenticated content on another, for example ``auth.domain.tld`` and ``app.domain.tld``.
 
     Default: ``False``.
 
     .. versionadded:: 4.0.0
+
+.. py:data:: SECURITY_REDIRECT_VALIDATE_MODE
+
+    These 2 configuration options attempt to solve a open-redirect vulnerability
+    that can be exploited if an application sets the Werkzeug response option
+    ``autocorrect_location_header = False`` (it is ``True`` by default).
+    For numerous views (e.g. /login) Flask-Security allows callers to specify
+    a redirect upon successful completion (via the ?next parameter). So it is
+    possible for a user to be tricked into logging in to a legitimate site
+    and then redirected to a malicious site. Flask-Security attempts to
+    verify that redirects are always relative to overcome this security concern.
+    FS uses the standard Python library urlsplit() to parse the URL and verify
+    that the ``netloc`` hasn't been altered.
+    However, many browsers actually accept URLs that should be considered
+    relative and perform various stripping and conversion that can cause them
+    to be interpreted as absolute. A trivial example of this is:
+
+    .. line-block::
+        /login?next=%20///github.com
+
+    This will pass the urlsplit() test that it is relative - but many browsers
+    will simply strip off the space and interpret it as an absolute URL!
+    With the default configuration of Werkzeug this isn't an issue since it by
+    default modifies the Location Header to with the request ``netloc``. However
+    if the application sets the Werkzeug response option
+    ``autocorrect_location_header = False`` this will allow a redirect outside of
+    the application.
+
+    Setting this to ``"regex"`` will force the URL to be matched using the
+    pattern specified below. If a match occurs the URL is considered 'absolute'
+    and will be rejected.
+
+    Default: ``None``
+
+    .. versionadded:: 4.0.2
+
+.. py:data:: SECURITY_REDIRECT_VALIDATE_RE
+
+    This regex handles known patterns that can be exploited. Basically,
+    don't allow control characters or white-space followed by slashes (or
+    back slashes).
+
+    Default: ``r"^/{4,}|\\{3,}|[\s\000-\037][/\\]{2,}"``
+
+    .. versionadded:: 4.0.2
 
 .. py:data:: SECURITY_CSRF_PROTECT_MECHANISMS
 
@@ -606,12 +651,16 @@ Login/Logout
 
     Default: ``"/verify"``
 
+    .. versionadded:: 3.4.0
+
 
 .. py:data:: SECURITY_VERIFY_TEMPLATE
 
     Specifies the path to the template for the verify password page.
 
     Default: ``"security/verify.html"``.
+
+    .. versionadded:: 3.4.0
 
 .. py:data:: SECURITY_POST_VERIFY_URL
 
@@ -621,6 +670,8 @@ Login/Logout
     view (held in the ``next`` parameter) will be redirected to.
 
     Default: ``None``.
+
+    .. versionadded:: 3.4.0
 
 Registerable
 ------------

--- a/examples/fsqlalchemy1/tests/test_utils.py
+++ b/examples/fsqlalchemy1/tests/test_utils.py
@@ -41,5 +41,5 @@ def create_fake_user(user_cls, email="unittest@me.com", userid=1, roles=None):
 
 def create_fake_role(role_cls, name, permissions=None):
     if permissions:
-        permissions = ",".join([p.strip() for p in permissions.split(",")])
+        permissions = ",".join(p.strip() for p in permissions.split(","))
     return role_cls(name=name, permissions=permissions)

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -7,11 +7,12 @@
     :copyright: (c) 2012 by Matt Wright.
     :copyright: (c) 2017 by CERN.
     :copyright: (c) 2017 by ETH Zurich, Swiss Data Science Center.
-    :copyright: (c) 2019-2020 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2021 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
 from datetime import datetime, timedelta
+import re
 import warnings
 
 import pkg_resources
@@ -156,6 +157,8 @@ _default_config = {
     "REDIRECT_HOST": None,
     "REDIRECT_BEHAVIOR": None,
     "REDIRECT_ALLOW_SUBDOMAINS": False,
+    "REDIRECT_VALIDATE_MODE": None,
+    "REDIRECT_VALIDATE_RE": r"^/{4,}|\\{3,}|[\s\000-\037][/\\]{2,}",
     "FORGOT_PASSWORD_TEMPLATE": "security/forgot_password.html",
     "LOGIN_USER_TEMPLATE": "security/login_user.html",
     "REGISTER_USER_TEMPLATE": "security/register_user.html",
@@ -593,6 +596,8 @@ def _get_state(app, datastore, anonymous_user=None, **kwargs):
             _unauthz_handler=default_unauthz_handler,
         )
     )
+    if "redirect_validate_re" in kwargs:
+        kwargs["_redirect_validate_re"] = re.compile(kwargs["redirect_validate_re"])
 
     if "login_manager" not in kwargs:
         kwargs["login_manager"] = _get_login_manager(app, anonymous_user)

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -319,7 +319,7 @@ class UserDatastore:
                 perms = ",".join(perms)
             elif isinstance(perms, str):
                 # squash spaces.
-                perms = ",".join([p.strip() for p in perms.split(",")])
+                perms = ",".join(p.strip() for p in perms.split(","))
             kwargs["permissions"] = perms
 
         role = self.role_model(**kwargs)

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -504,7 +504,7 @@ def roles_accepted(*roles):
     def wrapper(fn):
         @wraps(fn)
         def decorated_view(*args, **kwargs):
-            perm = Permission(*[RoleNeed(role) for role in roles])
+            perm = Permission(*(RoleNeed(role) for role in roles))
             if perm.can():
                 return fn(*args, **kwargs)
             if _security._unauthorized_callback:
@@ -578,7 +578,7 @@ def permissions_accepted(*fsperms):
     def wrapper(fn):
         @wraps(fn)
         def decorated_view(*args, **kwargs):
-            perm = Permission(*[FsPermNeed(fsperm) for fsperm in fsperms])
+            perm = Permission(*(FsPermNeed(fsperm) for fsperm in fsperms))
             if perm.can():
                 return fn(*args, **kwargs)
             if _security._unauthorized_callback:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,3 @@
-Pallets-Sphinx-Themes
-Sphinx
-sphinx-issues
+Pallets-Sphinx-Themes~=2.0
+Sphinx~=4.0
+sphinx-issues~=1.2

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -159,6 +159,14 @@ def create_app():
             add_user(user_datastore, test_acct, "password", ["admin"])
             print("Created User: {} with password {}".format(test_acct, "password"))
 
+    @app.after_request
+    def allow_absolute_redirect(r):
+        # This is JUST to test odd possible redirects that look relative but are
+        # interpreted by browsers as absolute.
+        # DON'T SET THIS IN YOUR APPLICATION!
+        r.autocorrect_location_header = False
+        return r
+
     @user_registered.connect_via(app)
     def on_user_registered(myapp, user, confirm_token, **extra):
         flash(f"To confirm {user.email} - go to /confirm/{confirm_token}")


### PR DESCRIPTION
While this is only an issue if the application sets the Werkzeug response variable:
autocorrect_location_header = False - it none the less poses a small security concern.

Closes #486