### PR TITLE
bugfix: Flask-mail sender name 

### DIFF
--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -690,8 +690,13 @@ def send_mail(subject, recipient, template, **context):
     if isinstance(sender, LocalProxy):
         sender = sender._get_current_object()
 
+    if not (isinstance(sender, tuple) and len(sender) == 2):
+        sender = str(sender)
+    else:
+        sender = (str(sender[0]), str(sender[1]))
+
     _security._mail_util.send_mail(
-        template, subject, recipient, str(sender), body, html, context.get("user", None)
+        template, subject, recipient, sender, body, html, context.get("user", None)
     )
 
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -690,10 +690,11 @@ def send_mail(subject, recipient, template, **context):
     if isinstance(sender, LocalProxy):
         sender = sender._get_current_object()
 
-    if not (isinstance(sender, tuple) and len(sender) == 2):
-        sender = str(sender)
-    else:
+    # In Flask-Mail, sender can be a two element tuple -- (name, address)
+    if isinstance(sender, tuple) and len(sender) == 2:
         sender = (str(sender[0]), str(sender[1]))
+    else:
+        sender = str(sender)
 
     _security._mail_util.send_mail(
         template, subject, recipient, sender, body, html, context.get("user", None)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -434,8 +434,30 @@ def test_no_email_sender(app):
         user = TestUser("matt@lp.com")
         with app.mail.record_messages() as outbox:
             send_mail("Test Default Sender", user.email, "welcome", user=user)
-        assert 1 == len(outbox)
-        assert "test@testme.com" == outbox[0].sender
+            assert 1 == len(outbox)
+            assert "test@testme.com" == outbox[0].sender
+
+
+def test_sender_tuple(app):
+    """Verify that if sender is a (name, address) tuple,
+    in the received email sender is properly formatted as "name <address>"
+    """
+    app.config["MAIL_DEFAULT_SENDER"] = ("Test User", "test@testme.com")
+
+    class TestUser:
+        def __init__(self, email):
+            self.email = email
+
+    security = Security()
+    security.init_app(app)
+
+    with app.app_context():
+        app.try_trigger_before_first_request_functions()
+        user = TestUser("matt@lp.com")
+        with app.mail.record_messages() as outbox:
+            send_mail("Test Tuple Sender", user.email, "welcome", user=user)
+            assert 1 == len(outbox)
+            assert "Test User <test@testme.com>" == outbox[0].sender
 
 
 def test_xlation(app, client):


### PR DESCRIPTION
Flask-Mail's `MAIL_DEFAULT_SENDER` can be either a string or a tuple of length 2. 
In case it is a tuple of length 2, (name, email), it formats the sender as "name <email>".

In `utils.py`, in `send_mail` function, `str` is cast on sender before passing it forward.
Casting `str` on this object thus loses the tuple functionality, and even if a sender's name is set, it does not appear in the mails sent.
(e.g. If we set `MAIL_DEFAULT_SENDER` to `('Administrator', 'admin@domain.com')`, the mail appears from `admin@domain.com` and not from `Adminstrator <admin@domain.com>`

To fix this, a check is added to verify if it's a 2 length tuple, and if so, `str` is cast on individual items, else `str` is cast on the entire sender object (which is the current behaviour).