### PR TITLE
Fix help truncation issue for create users subcommand

### DIFF
--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -91,12 +91,12 @@ def roles():
 
 @users.command(
     "create",
-    help="Create a new user with one or more attributes using the syntax:"
+    short_help=("Create a new user with one or more attributes using the syntax:"
     " attr:value. If attr isn't set 'email' is presumed."
     " Identity attribute values will be validated using the configured"
     " confirm_register_form;"
     " however, any ADDITIONAL attribute:value pairs will be sent to"
-    " datastore.create_user",
+    " datastore.create_user"),
 )
 @click.argument(
     "attributes",


### PR DESCRIPTION
This is the display of help information for `users` command  provided by flask-security before this code fix:
```
$ flask users --help
Usage: flask users [OPTIONS] COMMAND [ARGS]...

  User commands.

  For commands that require a USER - pass in any identity attribute.

Options:
  --help  Show this message and exit.

Commands:
  activate      Activate a user.
  create        Create a new user with one or more attributes using the...
  deactivate    Deactivate a user.
  reset_access  Reset all authentication credentials for user.
```
You can see that the help of the subcommand `create` is truncated.

And this is the display after this code fix:
```
$ flask users --help
Usage: flask users [OPTIONS] COMMAND [ARGS]...

  User commands.

  For commands that require a USER - pass in any identity attribute.

Options:
  --help  Show this message and exit.

Commands:
  activate      Activate a user.
  create        Create a new user with one or more attributes using the
                syntax: attr:value. If attr isn't set 'email' is presumed.
                Identity attribute values will be validated using the
                configured confirm_register_form; however, any ADDITIONAL
                attribute:value pairs will be sent to datastore.create_user
  deactivate    Deactivate a user.
  reset_access  Reset all authentication credentials for user.
```