### PR TITLE
Revamp how babel packages are imported and used.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,10 +68,10 @@ jobs:
           run: |
             pip install -U wheel setuptools
             python -m pip install -U pip
-        - name: Style, docs, coverage
+        - name: Style, docs, coverage, nobabel
           run: |
             pip install tox coverage
-            tox -e style -e docs -e coverage
+            tox -e style -e docs -e coverage -e nobabel
         - name: Upload coverage to Codecov
           uses: codecov/codecov-action@v1
           with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,12 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.3
+    rev: v2.19.4
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/psf/black
-    rev: 21.5b2
+    rev: 21.6b0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,10 +3,13 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
-Version 4.0.2
+Version 4.1.0
 -------------
 
 Released TBD
+
+This release was bumped to 4.1.0 on the small chance that the change in the way
+babel packages are tried and used might break existing applications.
 
 Features
 ++++++++
@@ -18,6 +21,20 @@ Fixes
 - (:issue:`490`) Flask-Mail sender name can be a tuple. (hrishikeshrt)
 - (:issue:`486`) Possible open redirect vulnerability.
 - (:pr:`478`) Improve/update German translation. (sr-verde)
+- (:issue:`488`) Improve handling of Babel packages
+
+Backwards Compatibility Concerns
++++++++++++++++++++++++++++++++++
+In 4.0.0, with the addition of Flask-Babel support, Flask-Security enforced that
+if it could import either Flask-Babel or Flask-BabelEx, that those modules had
+been initialized as proper Flask extensions. Prior to 4.0.0, just Flask-BabelEx
+was supported - and that didn't require any explicit initialization. Flask-Babel
+DOES require explicit initialization. However for some applications that don't
+completely control their environment (such as system pre-installed versions of
+python) this caused applications that didn't even want translation services to
+fail on startup. With this release, Flask-Security still attempts to import
+one of the other package - however if those modules are NOT initialized,
+Flask-Security will simply ignore them and no translations will occur.
 
 Version 4.0.1
 -------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ author = "Matt Wright & Chris Wagner"
 # built documents.
 #
 # The short X.Y version.
-version = "4.0.2"
+version = "4.1.0"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -130,6 +130,14 @@ Localization
 All messages, form labels, and form strings are localizable. Flask-Security uses
 `Flask-Babel <https://pypi.org/project/Flask-Babel/>`_ or
 `Flask-BabelEx <https://pythonhosted.org/Flask-BabelEx/>`_ to manage its messages.
+
+.. tip::
+    Be sure to explicitly initialize your babel extension::
+
+        import flask_babel
+
+        flask_babel.Babel(app)
+
 All translations are tagged with a domain, as specified by the configuration variable
 ``SECURITY_I18N_DOMAIN`` (default: "flask_security"). For messages and labels all this
 works seamlessly.  For strings inside templates it is necessary to explicitly ask for
@@ -179,6 +187,9 @@ Then compile it with::
 Finally add your translations directory to your configuration::
 
     app.config["SECURITY_I18N_DIRNAME"] = [pkg_resources.resource_filename("flask_security", "translations"), "translations"]
+
+.. note::
+    This only works when using Flask-Babel since Flask-BabelEx doesn't support a list of translation directories.
 
 .. _emails_topic:
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -103,4 +103,4 @@ from .utils import (
     verify_and_update_password,
 )
 
-__version__ = "4.0.2"
+__version__ = "4.1.0"

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -27,7 +27,7 @@ from passlib.context import CryptContext
 from werkzeug.datastructures import ImmutableList
 from werkzeug.local import LocalProxy
 
-from .babel import get_i18n_domain, have_babel
+from .babel import FsDomain
 from .decorators import (
     default_reauthn_handler,
     default_unauthn_handler,
@@ -584,7 +584,7 @@ def _get_state(app, datastore, anonymous_user=None, **kwargs):
             principal=_get_principal(app),
             pwd_context=_get_pwd_context(app),
             hashing_context=_get_hashing_context(app),
-            i18n_domain=get_i18n_domain(app),
+            i18n_domain=FsDomain(app),
             remember_token_serializer=_get_serializer(app, "remember"),
             login_serializer=_get_serializer(app, "login"),
             reset_serializer=_get_serializer(app, "reset"),
@@ -1176,15 +1176,6 @@ class Security:
                 current_app.after_request(csrf_cookie_handler)
                 # Add configured header to WTF_CSRF_HEADERS
                 current_app.config["WTF_CSRF_HEADERS"].append(cv("CSRF_HEADER"))
-
-        @app.before_first_request
-        def check_babel():
-            # Verify that if Flask-Babel or Flask-BabelEx is installed
-            # it has been initialized
-            if have_babel() and "babel" not in app.extensions:
-                raise ValueError(
-                    "Flask-Babel or Flask-BabelEx is installed but not initialized"
-                )
 
         state._phone_util = state.phone_util_cls(app)
         state._mail_util = state.mail_util_cls(app)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,12 @@
+[options.extras_require]
+babel=
+    babel>=2.7.0
+    flask_babel>=2.0.0
+fsqla=
+    flask_sqlalchemy>=2.4.4
+    sqlalchemy>=1.3.6
+    sqlalchemy-utils>=0.34.1
+
 [aliases]
 test=pytest
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -97,16 +97,19 @@ def app(request):
     else:
         marker_getter = request.keywords.get
     settings = marker_getter("settings")
-    babel = marker_getter("babel")
     if settings is not None:
         for key, value in settings.kwargs.items():
             app.config["SECURITY_" + key.upper()] = value
 
-    mail = Mail(app)
-    if not NO_BABEL and (babel is None or babel.args[0]):
-        Babel(app)
+    app.mail = Mail(app)
     app.json_encoder = JSONEncoder
-    app.mail = mail
+
+    # use babel marker to signify tests that need babel extension.
+    babel = marker_getter("babel")
+    if babel:
+        if NO_BABEL:
+            raise pytest.skip("Requires Babel")
+        Babel(app)
 
     @app.route("/")
     def index():

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -305,6 +305,7 @@ def test_auth_uniquifier(app):
         assert response.status_code == 200
 
 
+@pytest.mark.babel()
 def test_xlation(app, client, get_message_local):
     # Test form and email translation
     app.config["BABEL_DEFAULT_LOCALE"] = "fr_FR"
@@ -313,7 +314,7 @@ def test_xlation(app, client, get_message_local):
     authenticate(client)
 
     response = client.get("/change", follow_redirects=True)
-    with app.app_context():
+    with app.test_request_context():
         # Check header
         assert (
             f'<h1>{localize_callback("Change password")}</h1>'.encode("utf-8")
@@ -333,7 +334,7 @@ def test_xlation(app, client, get_message_local):
             follow_redirects=True,
         )
 
-    with app.app_context():
+    with app.test_request_context():
         assert get_message_local("PASSWORD_CHANGE").encode("utf-8") in response.data
         assert b"Home Page" in response.data
         assert len(outbox) == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@
 """
 
 from click.testing import CliRunner
+import pytest
 
 from flask_security.cli import (
     roles_add,
@@ -108,7 +109,15 @@ def test_cli_createuser_errors(script_info):
     assert "Email not provided" in result.output
 
 
+@pytest.mark.babel()
 def test_cli_locale(script_info):
+    # Flask_BabelEx required a request context - and click just has an app context.
+    try:
+        import flask_babelex  # noqa: F401
+
+        pytest.skip("Flask-BabelEx doesn't support app context")
+    except ImportError:
+        pass
     app = script_info.load_app()
     app.config["BABEL_DEFAULT_LOCALE"] = "fr_FR"
     runner = CliRunner()

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -116,13 +116,14 @@ def test_registerable_flag(clients, app, get_message):
 
 
 @pytest.mark.confirmable()
+@pytest.mark.babel()
 def test_xlation(app, client, get_message_local):
     # Test form and email translation
     app.config["BABEL_DEFAULT_LOCALE"] = "fr_FR"
     assert check_xlation(app, "fr_FR"), "You must run python setup.py compile_catalog"
 
     response = client.get("/register", follow_redirects=True)
-    with app.app_context():
+    with app.test_request_context():
         # Check header
         assert (
             f'<h1>{localize_callback("Register")}</h1>'.encode("utf-8") in response.data
@@ -141,7 +142,7 @@ def test_xlation(app, client, get_message_local):
             follow_redirects=True,
         )
 
-    with app.app_context():
+    with app.test_request_context():
         assert (
             get_message_local("CONFIRM_REGISTRATION", email="me@fr.com").encode("utf-8")
             in response.data
@@ -151,16 +152,6 @@ def test_xlation(app, client, get_message_local):
         assert (
             localize_callback(app.config["SECURITY_EMAIL_SUBJECT_REGISTER"])
             in outbox[0].subject
-        )
-        assert (
-            str(
-                markupsafe.escape(
-                    localize_callback(
-                        "You can confirm your email through the link below:"
-                    )
-                )
-            )
-            in outbox[0].html
         )
         assert (
             str(
@@ -466,6 +457,7 @@ def test_email_normalization_options(app, client, get_message):
     assert get_message("INVALID_EMAIL_ADDRESS") in response.data
 
 
+@pytest.mark.babel()
 def test_form_error(app, client, get_message):
     # A few form validations use ValidatorMixin which provides a lazy string
     # Since CLI doesn't render_template it was seeing those lazy strings.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,7 @@
 [tox]
 envlist =
     py{36,37,38,39,py3}-{low,release}
+    nobabel
     style
     docs
     coverage
@@ -26,6 +27,7 @@ deps =
     Flask-Mongoengine==0.9.5
     peewee==3.11.2
     argon2_cffi==19.1.0
+    babel==2.7.0
     bcrypt==3.1.5
     cryptography==2.3.1
     mongoengine==0.18.0
@@ -41,6 +43,7 @@ commands =
     python setup.py compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}
 
+# manual test to check how we're keeping up with Pallets latest
 [testenv:py38-master]
 deps =
     -r requirements/tests.txt
@@ -49,6 +52,24 @@ deps =
     git+git://github.com/pallets/flask-sqlalchemy@master#egg=flask-sqlalchemy
     git+git://github.com/pallets/jinja@master#egg=jinja2
 commands =
+    python setup.py compile_catalog
+    pytest --basetemp={envtmpdir} {posargs:tests}
+
+[testenv:nobabel]
+basepython = python3.8
+deps =
+    -r requirements/tests.txt
+commands =
+    pip uninstall -y babel flask_babel
+    pytest --basetemp={envtmpdir} {posargs:tests}
+
+# manual test to verify we still work with Flask-BabelEx
+[testenv:babelex]
+deps =
+    -r requirements/tests.txt
+    flask_babelex
+commands =
+    pip uninstall -y flask_babel
     python setup.py compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}
 


### PR DESCRIPTION
In 4.0.0, with the addition of Flask-Babel support, Flask-Security enforced that
if it could import either Flask-Babel or Flask-BabelEx, that those modules had
been initialized as proper Flask extensions. Prior to 4.0.0, just Flask-BabelEx
was supported - and that didn't require any explicit initialization. Flask-Babel
DOES require explicit initialization. However for some applications that don't
completely control their environment (such as system pre-installed versions of
python) this caused applications that didn't even want translation services to
fail on startup. With this release, Flask-Security still attempts to import
one of the other package - however if those modules are NOT initialized,
Flask-Security will simply ignore them and no translations will occur.

Changed conftest around so if a test needs translations they need to be annotated with pytest.mark.babel - otherwise babel isn't initialized.

Also - added a babel and fsqla 'extra's as part of the distribution (need to do more of these).

closes: #488