### PR TITLE
Do not raise a TypeError exception if phone.data is None

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -593,8 +593,7 @@ class TwoFactorSetupForm(Form, UserEmailFormMixin):
             self.setup.errors = list()
             self.setup.errors.append(get_message("TWO_FACTOR_METHOD_NOT_AVAILABLE")[0])
             return False
-        if (self.setup.data == "sms" and
-                self.phone.data and len(self.phone.data) > 0):
+        if self.setup.data == "sms" and self.phone.data and len(self.phone.data) > 0:
             # Somewhat bizarre - but this isn't required the first time around
             # when they select "sms". Then they get a field to fill out with
             # phone number, then Submit again.

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -593,7 +593,8 @@ class TwoFactorSetupForm(Form, UserEmailFormMixin):
             self.setup.errors = list()
             self.setup.errors.append(get_message("TWO_FACTOR_METHOD_NOT_AVAILABLE")[0])
             return False
-        if self.setup.data == "sms" and len(self.phone.data) > 0:
+        if (self.setup.data == "sms" and
+                self.phone.data and len(self.phone.data) > 0):
             # Somewhat bizarre - but this isn't required the first time around
             # when they select "sms". Then they get a field to fill out with
             # phone number, then Submit again.

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -751,7 +751,8 @@ def two_factor_setup():
             "tf_state": "validating_profile",
             "tf_primary_method": pm,
         }
-        new_phone = form.phone.data if len(form.phone.data) > 0 else None
+        new_phone = form.phone.data if (form.phone.data and
+                                        len(form.phone.data) > 0) else None
         if new_phone:
             user.tf_phone_number = new_phone
             _datastore.put(user)

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -751,8 +751,9 @@ def two_factor_setup():
             "tf_state": "validating_profile",
             "tf_primary_method": pm,
         }
-        new_phone = form.phone.data if (form.phone.data and
-                                        len(form.phone.data) > 0) else None
+        new_phone = (
+            form.phone.data if (form.phone.data and len(form.phone.data) > 0) else None
+        )
         if new_phone:
             user.tf_phone_number = new_phone
             _datastore.put(user)


### PR DESCRIPTION
Running the tests on the openSUSE build service to generate
packages fails because a TypeError exception is raised.

```
TypeError: object of type 'NoneType' has no len()
```

This commit checks that phone.data is not None before calling
len() in the two lines where the exception is raised.