### PR TITLE
Typing Part 3.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.19.4
+    rev: v2.21.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,12 +8,11 @@ Version 4.1.0
 
 Released TBD
 
-This release was bumped to 4.1.0 on the small chance that the change in the way
-babel packages are tried and used might break existing applications.
-
 Features
 ++++++++
 - (:issue:`474`) Add public API and CLI command to change a user's password.
+- (:issue:`140`) Add type hints. Please note that many of the packages that flask-security
+  depends on aren't typed yet - so there are likely errors in some of the types.
 
 Fixes
 +++++
@@ -21,10 +20,10 @@ Fixes
 - (:issue:`490`) Flask-Mail sender name can be a tuple. (hrishikeshrt)
 - (:issue:`486`) Possible open redirect vulnerability.
 - (:pr:`478`) Improve/update German translation. (sr-verde)
-- (:issue:`488`) Improve handling of Babel packages
+- (:issue:`488`) Improve handling of Babel packages.
 - (:pr:`496`) Documentation improvements, distribution extras, fix single message
-    override.
-- (:issue:`497`) Improve cookie handling and default samesite to Strict
+  override.
+- (:issue:`497`) Improve cookie handling and default ``samesite`` to ``Strict``.
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
@@ -39,8 +38,14 @@ Backwards Compatibility Concerns
   one of the other package - however if those modules are NOT initialized,
   Flask-Security will simply ignore them and no translations will occur.
 - (:issue:`497`) The CSRF_COOKIE and TWO_FACTOR_VALIDITY cookie had their defaults
-  changed to set ``samesite=Strict``. This follows the Flask-Security directive of
+  changed to set ``samesite=Strict``. This follows the Flask-Security goal of
   making things more secure out-of-the-box.
+- (:issue:`140`) Type hinting. For the most part this of course has no runtime effects.
+  However, this required a fairly major overhaul of how Flask-Security is initialized in
+  order to provide valid types for the many constructor attributes. There are no known
+  compatability concerns - however initialization used to convert all arguments into kwargs
+  then add those as attributes and merge with application constants. That no longer happens
+  and it is possible that some corner cases don't behave precisely as they did before.
 
 Version 4.0.1
 -------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -100,6 +100,7 @@ nitpicky = True
 nitpick_ignore = [
     ("py:attr", "LoginManager.unauthorized"),
     ("py:class", "flask_mongoengine.MongoEngine"),
+    ("py:class", "ResponseValue"),
     ("py:class", "function"),
 ]
 autodoc_typehints = "description"
@@ -112,7 +113,9 @@ intersphinx_mapping = {
     "itsdangerous": ("https://itsdangerous.palletsprojects.com/", None),
     "sqlalchemy": ("https://docs.sqlalchemy.org/", None),
     "wtforms": ("https://wtforms.readthedocs.io/", None),
+    "flask_wtforms": ("https://flask-wtf.readthedocs.io", None),
     "flask_sqlalchemy": ("https://flask-sqlalchemy.palletsprojects.com/", None),
+    "flask_login": ("https://flask-login.readthedocs.io/en/latest/", None),
     "passlib": ("https://passlib.readthedocs.io/en/stable", None),
 }
 

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -273,8 +273,8 @@ def auth_token_required(fn: DecoratedView) -> DecoratedView:
 
 def auth_required(
     *auth_methods: t.Union[str, t.Callable[[], t.List[str]], None],
-    within: t.Union[int, t.Callable[[], datetime.timedelta]] = -1,
-    grace: t.Optional[t.Union[int, t.Callable[[], datetime.timedelta]]] = None
+    within: t.Union[int, float, t.Callable[[], datetime.timedelta]] = -1,
+    grace: t.Optional[t.Union[int, float, t.Callable[[], datetime.timedelta]]] = None
 ) -> DecoratedView:
     """
     Decorator that protects endpoints through multiple mechanisms

--- a/flask_security/proxies.py
+++ b/flask_security/proxies.py
@@ -11,7 +11,6 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from .datastore import CanonicalUserDatastore
 
 # Convenient references
-# noinspection PyTypeChecker
 _security: "Security" = LocalProxy(  # type: ignore
     lambda: current_app.extensions["security"]
 )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,6 +7,7 @@ pymysql
 pre-commit
 tox
 sqlalchemy[mypy]
+types-requests
 
 # for dev - might not install Flask-Security - list those dependencies here
 flask

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -317,11 +317,10 @@ def test_xlation(app, client, get_message_local):
     with app.test_request_context():
         # Check header
         assert (
-            f'<h1>{localize_callback("Change password")}</h1>'.encode("utf-8")
-            in response.data
+            f'<h1>{localize_callback("Change password")}</h1>'.encode() in response.data
         )
         submit = localize_callback(_default_field_labels["change_password"])
-        assert f'value="{submit}"'.encode("utf-8") in response.data
+        assert f'value="{submit}"'.encode() in response.data
 
     with app.mail.record_messages() as outbox:
         response = client.post(

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -125,11 +125,9 @@ def test_xlation(app, client, get_message_local):
     response = client.get("/register", follow_redirects=True)
     with app.test_request_context():
         # Check header
-        assert (
-            f'<h1>{localize_callback("Register")}</h1>'.encode("utf-8") in response.data
-        )
+        assert f'<h1>{localize_callback("Register")}</h1>'.encode() in response.data
         submit = localize_callback(_default_field_labels["register"])
-        assert f'value="{submit}"'.encode("utf-8") in response.data
+        assert f'value="{submit}"'.encode() in response.data
 
     with app.mail.record_messages() as outbox:
         response = client.post(

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,7 @@ deps =
     git+git://github.com/pallets/flask-sqlalchemy@main#egg=flask-sqlalchemy
     git+git://github.com/pallets/jinja@main#egg=jinja2
     git+git://github.com/wtforms/wtforms@master#egg=wtforms
+    git+git://github.com/maxcountryman/flask-login@main#egg=flask-login
 commands =
     python setup.py compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}


### PR DESCRIPTION
This adds types to the Security constructor and init_app. This required major refactoring of how initialization happened since prior to this
all arguments were added to kwargs (including default forms, config variables, etc) then set as attributes on the instance. Not easy to provide types for each one.
We remove all that, remove the _SecurityState class and concept.

Furthermore - in many places - we change from using _securyty.attr and use config_value("xxx").

Improve performance of config_value - no reason to create a dictonary every time - just query the key!

Add typing to more tests and views to help verify the types make sense.

Fix view responses - the types should be flask.ResponsValue - not Response

Fix 'within' and 'grace' typing - then can take floats.

closes: #140