### PR TITLE
Improve/fix issues with new username support.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.21.2
+    rev: v2.24.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -726,8 +726,12 @@ Registerable
     a username field added. This requires that your user model contain the
     field ``username``. It MUST be set as 'unique' and if you don't want
     to require a username, it should be set as 'nullable'.
+    Also, if set, the LoginForm will have the 'email' input changed from
+    an EmailField (which renders as an html input=email) to a StringField.
 
-    Validation and normalization is encapsulated in the :class:`.UsernameUtil`
+    Validation and normalization is encapsulated in :class:`.UsernameUtil`.
+    Note that the default validation restricts username input to be unicode
+    letters and numbers.
 
     Default: ``False``
 
@@ -1406,5 +1410,4 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_USERNAME_ILLEGAL_CHARACTERS``
 * ``SECURITY_USERNAME_DISALLOWED_CHARACTERS``
 * ``SECURITY_USERNAME_NOT_PROVIDED``
-* ``SECURITY_USERNAME_NOT_ALLOWED``
 * ``SECURITY_USERNAME_ALREADY_ASSOCIATED``

--- a/flask_security/username_util.py
+++ b/flask_security/username_util.py
@@ -37,19 +37,6 @@ class UsernameUtil:
         """
         pass
 
-    def allowed(self) -> t.Optional[str]:
-        """
-        Is providing a username allowed?
-        We use this as a validator for the form.
-        This is critical since the form always has 'username' but we don't want to
-        look at or accept a value if it isn't enabled.
-
-        Returns None if allowed, error message if not allowed.
-        """
-        if cv("USERNAME_ENABLE"):
-            return None
-        return get_message("USERNAME_NOT_ALLOWED")[0]
-
     def check_username(self, username: str) -> t.Optional[str]:
         """
         Given a username - check for allowable character categories.
@@ -76,7 +63,6 @@ class UsernameUtil:
         if not username:
             return ""
 
-        # we allow pretty much anything - but we bleach it.
         username = bleach.clean(username.strip(), strip=True)
         if not username:
             return ""
@@ -91,6 +77,7 @@ class UsernameUtil:
         Called in app/request context.
 
         The username is first validated then normalized.
+        Input is restricted/validated via a call to check_username.
         Return value is a tuple (msg, normalized_username). msg will be None if
         properly validated.
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,6 +227,17 @@ def app(request: pytest.FixtureRequest) -> "Flask":
         else:
             return render_template("index.html", content="Fresh Only")
 
+    def revert_forms():
+        # Some forms/tests have dynamic fields - be sure to revert them.
+        if hasattr(app, "security"):
+            if hasattr(app.security.login_form, "email"):
+                del app.security.login_form.email
+            if hasattr(app.security.register_form, "username"):
+                del app.security.register_form.username
+            if hasattr(app.security.confirm_register_form, "username"):
+                del app.security.confirm_register_form.username
+
+    request.addfinalizer(revert_forms)
     return app
 
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -153,6 +153,15 @@ def test_login_form(client):
     assert re.search(b'<input[^>]*type="email"[^>]*>', response.data)
 
 
+@pytest.mark.settings(username_enable=True)
+def test_login_form_username(client):
+    # If USERNAME_ENABLE is set then login form should have a StringField, not Email
+    response = client.post("/login", data={"email": "matt@lp.com"})
+    assert b"matt@lp.com" in response.data
+    # Should be a string field - not html5 email input type
+    assert not re.search(b'<input[^>]*type="email"[^>]*>', response.data)
+
+
 def test_unprovided_username(client, get_message):
     response = authenticate(client, "")
     assert get_message("EMAIL_NOT_PROVIDED") in response.data

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -13,7 +13,7 @@ import datetime
 from pytest import raises, skip
 from tests.test_utils import init_app_with_options, get_num_queries, is_sqlalchemy
 
-from flask_security import RoleMixin, Security, UserMixin
+from flask_security import RoleMixin, Security, UserMixin, LoginForm, RegisterForm
 from flask_security.datastore import Datastore, UserDatastore
 
 
@@ -192,15 +192,24 @@ def test_access_datastore_from_app_factory_pattern(app, datastore):
 
 
 def test_init_app_kwargs_override_constructor_kwargs(app, datastore):
+    class ConLoginForm(LoginForm):
+        pass
+
+    class ConRegisterForm(RegisterForm):
+        pass
+
+    class InitLoginForm(LoginForm):
+        pass
+
     security = Security(
         datastore=datastore,
-        login_form="__init__login_form",
-        register_form="__init__register_form",
+        login_form=ConLoginForm,
+        register_form=ConRegisterForm,
     )
-    security.init_app(app, login_form="init_app_login_form")
+    security.init_app(app, login_form=InitLoginForm)
 
-    assert security.login_form == "init_app_login_form"
-    assert security.register_form == "__init__register_form"
+    assert security.login_form == InitLoginForm
+    assert security.register_form == ConRegisterForm
 
 
 def test_create_user_with_roles_and_permissions(app, datastore):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1120,7 +1120,7 @@ def test_post_security_with_application_root_and_views(app, sqlalchemy_datastore
 def test_validate_redirect(app, sqlalchemy_datastore):
     """
     Test various possible URLs that urlsplit() shows as relative but
-    many browsers will interpret as absolute - and this have a
+    many browsers will interpret as absolute - and thus have a
     open-redirect vulnerability. Note this vulnerability only
     is viable if the application sets autocorrect_location_header = False
     """

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -598,16 +598,6 @@ def test_username_errors(app, client, get_message):
 
 
 def test_username_not_enabled(app, client, get_message):
-    data = dict(
-        email="dude@lp.com",
-        username="dud",
-        password="awesome sunset",
-    )
-    response = client.post(
-        "/register", json=data, headers={"Content-Type": "application/json"}
-    )
-    assert response.status_code == 400
-    assert (
-        get_message("USERNAME_NOT_ALLOWED")
-        in response.json["response"]["errors"]["username"][0].encode()
-    )
+    response = client.get("/register")
+    assert b"username" not in response.data
+    assert not hasattr(RegisterForm, "username")

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -62,7 +62,7 @@ class FlashMail:
 
 def create_app():
     # Use real templates - not test templates...
-    app = Flask(__name__, template_folder="../")
+    app = Flask("view_scaffold", template_folder="../")
     app.config["DEBUG"] = True
     # SECRET_KEY generated using: secrets.token_urlsafe()
     app.config["SECRET_KEY"] = "pf9Wkove4IKEAXvy-cQkeDPhv9Cb3Ag-wyJILbq_dFw"


### PR DESCRIPTION
For login form, add either EmailField or StringField at app init time based on config variable USERNAME_ENABLE.
For registration form - add username field at app init time if USERNAME_ENABLE is set.

This greatly simplifies logic and we can get rid of the 'username_allowed' validator and error message.

Improve documentation around what the default username input rules are (letters and numbers).

Note that one possible downside to this change is that since we are dynamically changing the LoginForm and RegistrationForm classes - if a process had multiple flask apps with different USERNAME_ENABLE configurations - that won't work.

closes: #512, #513, #516