### PR TITLE
Fix a small BC issue with login_manager.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,12 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.24.0
+    rev: v2.25.0
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/psf/black
-    rev: 21.7b0
+    rev: 21.8b0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8


### PR DESCRIPTION
We allow re-use of the Security object (for testing) - since Flask-Login attaches itself to the app
upon initialization - we pretty much always re-init the login_manager so that it gets registered.

closes: #518