### PR TITLE
Fix an example command in the documentation

### DIFF
--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -182,7 +182,7 @@ In this example, create a file ``flask_security.po`` under a directory:
 
 Then compile it with::
 
-    pybabel compile -d translations/ -i translations/fr_FR/LC_MESSAGES/flask_security.po -l fr_FR
+    pybabel compile -d translations/ -i translations/fr_FR/LC_MESSAGES/flask_security.po -l fr_FR -D flask_security
 
 Finally add your translations directory to your configuration::
 


### PR DESCRIPTION
Hi. I found that the followin command generates messages.po. and that example in Localization doesn't work. They need to specify domain name with "-D flask_security" option. I hope this change helps others who try localization according to the customizing tutorial.
`pybabel compile -d translations/ -i translations/fr_FR/LC_MESSAGES/flask_security.po -l fr_FR`