### PR TITLE
Round 2 of webauthn.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.10b0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -80,7 +80,7 @@ _default_field_labels = {
     "sendcode": _("Send Code"),
     "passcode": _("Passcode"),
     "username": _("Username"),
-    "credential_nickname": _("Nickname to associate with this WebAuthn registration"),
+    "credential_nickname": _("Nickname"),
     "delete": _("Delete"),
     "register_webauthn_credential": _("Register WebAuthn Credential"),
 }

--- a/flask_security/models/fsqla_v3.py
+++ b/flask_security/models/fsqla_v3.py
@@ -66,6 +66,9 @@ class FsWebAuthnMixin:
     public_key = Column(LargeBinary, nullable=True)
     sign_count = Column(Integer, default=0)
     transports = Column(String(255), nullable=True)  # comma separated
+
+    # a JSON string as returned from registration
+    extensions = Column(String(255), nullable=True)
     create_datetime = Column(type_=DateTime, nullable=False, server_default=func.now())
     lastuse_datetime = Column(type_=DateTime, nullable=False)
     # name is provided by user - we make sure is unique per user

--- a/flask_security/static/js/webauthn.js
+++ b/flask_security/static/js/webauthn.js
@@ -64,91 +64,42 @@ function display_errors(response, id) {
   return true
 }
 
+function clear_errors(id) {
+  const error_element = document.getElementById(id)
+  if (error_element)
+    error_element.innerHTML = ''
+}
+
 /**
  * REGISTRATION FUNCTIONS
  */
 
-/**
- * Callback after the registration form is submitted.
- * @param {Event} e
+/*
+ * handleRegister - given the return from server of credential_options,
+ * parse those and pass to browser to create new credential, and transform
+ * that new credential for passing/storing to the server.
  */
-const didClickRegister = async (e) => {
-    e.preventDefault();
+async function handleRegister(credential_options, error_elmid) {
+  const credentialCreateOptionsFromServer = JSON.parse(credential_options);
 
-    // gather the data in the form
-    const form = document.querySelector('#wan-register-form');
-    const formData = new FormData(form);
+  // convert certain members of the PublicKeyCredentialCreateOptions into
+  // byte arrays as expected by the spec.
+  const publicKeyCredentialCreateOptions = transformCredentialCreateOptions(credentialCreateOptionsFromServer)
 
-    // post the data to the server to generate the PublicKeyCredentialCreateOptions
-    let credentialCreateOptionsFromServer, csrf_token;
-    try {
-        const resp = await getCredentialCreateOptionsFromServer(
-          formData.get('url'),
-          formData);
-        if (display_errors(resp["response"], "wan-error")) {
-          return
-        }
-        csrf_token = resp["response"]["csrf_token"]
-        credentialCreateOptionsFromServer = JSON.parse(resp["response"]["credential_options"]);
-    } catch (err) {
-        return console.error("Failed to generate credential request options:", err);
-    }
-
-    // convert certain members of the PublicKeyCredentialCreateOptions into
-    // byte arrays as expected by the spec.
-    const publicKeyCredentialCreateOptions = transformCredentialCreateOptions(credentialCreateOptionsFromServer);
-
-    // request the authenticator(s) to create a new credential keypair.
-    let credential;
-    try {
-        credential = await navigator.credentials.create({
-            publicKey: publicKeyCredentialCreateOptions
-        });
-    } catch (err) {
-      const err_msg = `Error creating credential: ${err}`
-      display_errors({error: err_msg}, "wan-error")
-      return
-    }
-
-    // we now have a new credential! We now need to encode the byte arrays
-    // in the credential into strings, for posting to our server.
-    const newAssertionForServer = transformNewAssertionForServer(credential);
-
-    // post the transformed credential data to the server for validation
-    // and storing the public key
-    try {
-        const resp = await postNewAssertionToServer(
-          formData.get('name'),
-          csrf_token,
-          formData.get('response_url'),
-          newAssertionForServer);
-        if (display_errors(resp["response"], "wan-error")) {
-          return
-        }
-    } catch (err) {
-        return console.error("Server validation of credential failed:", err);
-    }
-
-    // reload the page after a successful result
-    window.location.reload();
-}
-
-/**
- * Get PublicKeyCredentialRequestOptions for this user from the server
- * formData of the registration form
- * @param {FormData} formData
- */
-const getCredentialCreateOptionsFromServer = async (url, formData) => {
-    return await fetch_json(
-        url,
-        {
-            method: "POST",
-            body: formData,
-            headers: {
-              "Accept": "application/json"
-            },
-        }
-    );
+  // request the authenticator(s) to create a new credential keypair.
+  let credential;
+  clear_errors(error_elmid)
+  try {
+      credential = await navigator.credentials.create({
+          publicKey: publicKeyCredentialCreateOptions
+      })
+      // we now have a new credential! We now need to encode the byte arrays
+      // in the credential into strings, for posting to our server.
+      return JSON.stringify(transformNewAssertionForServer(credential))
+  } catch (err) {
+    const err_msg = `Error creating credential: ${err}`
+    display_errors({error: err_msg}, error_elmid)
+  }
 }
 
 /**
@@ -160,15 +111,15 @@ const transformCredentialCreateOptions = (credentialCreateOptionsFromServer) => 
     let {challenge, user} = credentialCreateOptionsFromServer;
     user.id = Uint8Array.from(
         atob(credentialCreateOptionsFromServer.user.id
-            .replace(/\_/g, "/")
-            .replace(/\-/g, "+")
+            .replace(/_/g, "/")
+            .replace(/-/g, "+")
             ),
         c => c.charCodeAt(0));
 
     challenge = Uint8Array.from(
         atob(credentialCreateOptionsFromServer.challenge
-            .replace(/\_/g, "/")
-            .replace(/\-/g, "+")
+            .replace(/_/g, "/")
+            .replace(/-/g, "+")
             ),
         c => c.charCodeAt(0));
 
@@ -199,27 +150,9 @@ const transformNewAssertionForServer = (newAssertion) => {
         rawId: b64enc(rawId),
         type: newAssertion.type,
         response: {"attestationObject": b64enc(attObj), "clientDataJSON": b64enc(clientDataJSON)},
-        extensions: JSON.stringify(registrationClientExtensions)
+        extensions: JSON.stringify(registrationClientExtensions),
+        transports: newAssertion.response.getTransports(),
     };
-}
-
-/**
- * Posts the new credential data to the server for validation and storage.
- * @param {Object} credentialDataForServer
- */
-const postNewAssertionToServer = async (name, csrf_token, response_url, credentialDataForServer) => {
-    credentialDataForServer['name'] = name;
-    credentialDataForServer["csrf_token"] = csrf_token
-
-    return await fetch_json(
-        response_url, {
-        method: "POST",
-        body: JSON.stringify(credentialDataForServer),
-        headers: {
-          "Accept": "application/json",
-          "Content-Type": "application/json"
-        },
-    });
 }
 
 
@@ -229,96 +162,39 @@ const postNewAssertionToServer = async (name, csrf_token, response_url, credenti
  */
 
 
-/**
- * Callback executed after submitting login form
- * @param {Event} e
- */
-const didClickLogin = async (e) => {
-    e.preventDefault()
-    // gather the data in the form
-    const form = document.querySelector('#wan-signin-form')
-    const formData = new FormData(form)
+async function handleSignin(response, error_elmid) {
+  const credentialRequestOptionsFromServer = JSON.parse(response)
+  // convert certain members of the PublicKeyCredentialRequestOptions into
+  // byte arrays as expected by the spec.
+  const transformedCredentialRequestOptions = transformCredentialRequestOptions(
+      credentialRequestOptionsFromServer)
 
-    // post the login data to the server to retrieve the PublicKeyCredentialRequestOptions
-    let credentialRequestOptionsFromServer, csrf_token
-    try {
-      const resp = await getCredentialRequestOptionsFromServer(formData.get('url'), formData)
-        if (display_errors(resp["response"], "wan-error")) {
-          return
-        }
-        csrf_token = resp["response"]["csrf_token"]
-        credentialRequestOptionsFromServer = JSON.parse(resp["response"]["credential_options"])
-    } catch (err) {
-        return console.error("Error when getting request options from server:", err)
-    }
-
-    // convert certain members of the PublicKeyCredentialRequestOptions into
-    // byte arrays as expected by the spec.
-    const transformedCredentialRequestOptions = transformCredentialRequestOptions(
-        credentialRequestOptionsFromServer)
-
-    // request the authenticator to create an assertion signature using the
-    // credential private key
-    let assertion
-    try {
-        assertion = await navigator.credentials.get({
-            publicKey: transformedCredentialRequestOptions,
-        })
-    } catch (err) {
-      const err_msg = `Error when creating credential: ${err}`
-      display_errors({error: err_msg}, "wan-error")
-      return
-    }
-
+  // request the authenticator to create an assertion signature using the
+  // credential private key
+  let assertion
+  clear_errors(error_elmid)
+  try {
+    assertion = await navigator.credentials.get({
+        publicKey: transformedCredentialRequestOptions,
+    })
     // we now have an authentication assertion! encode the byte arrays contained
     // in the assertion data as strings for posting to the server
-    const transformedAssertionForServer = transformAssertionForServer(assertion)
-
-    // post the assertion to the server for verification.
-    try {
-        const resp = await postAssertionToServer(
-          formData.get('response_url'), csrf_token,
-          transformedAssertionForServer);
-        if (display_errors(resp["response"], "wan-error")) {
-          return
-        }
-        if ("post_login_url" in resp["response"]) {
-          window.location.assign(resp["response"]["post_login_url"])
-        }
-    } catch (err) {
-        return console.error("Error when validating assertion on server:", err)
-    }
-
-    //window.location.reload();
-};
-
-/**
- * Get PublicKeyCredentialRequestOptions for this user from the server
- * formData of the registration form
- * @param {FormData} formData
- */
-const getCredentialRequestOptionsFromServer = async (url, formData) => {
-    return await fetch_json(
-        url,
-        {
-            method: "POST",
-            body: formData,
-            headers: {
-              "Accept": "application/json"
-            },
-        }
-    );
+    return JSON.stringify(transformAssertionForServer(assertion))
+  } catch (err) {
+    const err_msg = `Error when creating credential: ${err}`
+    display_errors({error: err_msg}, error_elmid)
+  }
 }
 
 const transformCredentialRequestOptions = (credentialRequestOptionsFromServer) => {
     let {challenge, allowCredentials} = credentialRequestOptionsFromServer;
 
     challenge = Uint8Array.from(
-        atob(challenge.replace(/\_/g, "/").replace(/\-/g, "+")), c => c.charCodeAt(0));
+        atob(challenge.replace(/_/g, "/").replace(/-/g, "+")), c => c.charCodeAt(0));
 
     allowCredentials = allowCredentials.map(credentialDescriptor => {
         let {id} = credentialDescriptor;
-        id = id.replace(/\_/g, "/").replace(/\-/g, "+");
+        id = id.replace(/_/g, "/").replace(/-/g, "+");
         id = Uint8Array.from(atob(id), c => c.charCodeAt(0));
         return Object.assign({}, credentialDescriptor, {id});
     });
@@ -355,33 +231,3 @@ const transformAssertionForServer = (newAssertion) => {
         assertionClientExtensions: JSON.stringify(assertionClientExtensions)
     };
 };
-
-/**
- * Post the assertion to the server for validation and logging the user in.
- * @param {Object} assertionDataForServer
- */
-const postAssertionToServer = async (url, csrf_token, assertionDataForServer) => {
-    assertionDataForServer["csrf_token"] = csrf_token
-
-    return await fetch_json(
-        url, {
-        method: "POST",
-        body: JSON.stringify(assertionDataForServer),
-        headers: {
-          "Accept": "application/json",
-          "Content-Type": "application/json"
-        },
-    });
-}
-
-
-document.addEventListener("DOMContentLoaded", e => {
-  const reg = document.querySelector('#wan_register')
-  if (reg) {
-    reg.addEventListener('click', didClickRegister);
-  }
-  const signin = document.querySelector('#wan_signin')
-  if (signin) {
-    signin.addEventListener('click', didClickLogin);
-  }
-});

--- a/flask_security/templates/security/_macros.html
+++ b/flask_security/templates/security/_macros.html
@@ -1,5 +1,5 @@
 {% macro render_field_with_errors(field) %}
-  <div class="fs-div" id="{{ field.id|default('fs-field') }} ">
+  <div class="fs-div" id="{{ field.id|default('fs-field') }}">
     {{ field.label }} {{ field(**kwargs)|safe }}
     {% if field.errors %}
       <ul>

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -76,6 +76,13 @@
         <h3>{{ _fsdomain("No methods have been enabled - nothing to setup") }}</h3>
       {% endif %}
     </form>
+    {% if security.webauthn %}
+      <h3>WebAuthn</h3>
+      <div class="fs-div">
+        Your application supports WebAuthn security keys. You can set them up
+        <a href="{{ url_for_security('wan_register') }}">here.</a>
+      </div>
+    {% endif %}
     {% if state %}
       <hr>
       <form action="{{ url_for_security("us_setup_validate", token=state) }}" method="POST"

--- a/flask_security/templates/security/us_signin.html
+++ b/flask_security/templates/security/us_signin.html
@@ -12,7 +12,7 @@
       {{ render_field_with_errors(us_signin_form.remember) }}
       {{ render_field(us_signin_form.submit) }}
       {% if code_methods %}
-        <h4>{{  _fsdomain("Request one-time code be sent") }}</h4>
+        <h4>{{ _fsdomain("Request one-time code be sent") }}</h4>
         {% for subfield in us_signin_form.chosen_method %}
           {% if subfield.data in code_methods %}
             {{ render_field_with_errors(subfield) }}
@@ -25,5 +25,16 @@
         {{ render_field(us_signin_form.submit_send_code, formaction=url_for_security('us_signin_send_code')) }}
       {% endif %}
       </form>
+  {% if security.webauthn %}
+    <hr class="fs-gap">
+    <h3>Use WebAuthn to Sign In</h3>
+    <div>
+      <form method="POST" id="wan-signin-form" name="wan_signin_form">
+        {{ us_signin_form.hidden_tag() }}
+        <input id="wan_signin" name="wan_signin" type="submit" value="Sign in with WebAuthn"
+          formaction="{{ url_for_security("wan_signin") }}">
+      </form>
+    </div>
+  {% endif %}
   {% include "security/_menu.html" %}
 {% endblock %}

--- a/flask_security/templates/security/wan_register.html
+++ b/flask_security/templates/security/wan_register.html
@@ -15,28 +15,49 @@
 {% block content %}
   {% include "security/_messages.html" %}
   <h1>{{ _fsdomain("Setup New WebAuthn Security Key") }}</h1>
+  {% if not credential_options %}
+    {# Initial form to get CreateOptions #}
     <form action="{{ url_for_security("wan_register") }}" method="POST"
-          name="wan_register_form" id="wan-register-form">
-      {{ wan_register_form.hidden_tag() }}
-      {{ render_field_with_errors(wan_register_form.name) }}
-      {{ render_field(wan_register_form.submit) }}
-      <span id="wan-error"></span>
-      <input type="hidden" name="url" value="{{ url_for_security("wan_register") }}" readonly>
-      <input type="hidden" name="response_url" value="{{ url_for_security("wan_register_response") }}" readonly>
+            name="wan_register_form" id="wan-register-form">
+        {{ wan_register_form.hidden_tag() }}
+        {{ render_field_with_errors(wan_register_form.name) }}
+        {{ render_field(wan_register_form.submit) }}
     </form>
-  <h3>Currently registered credentials:</h3>
+  {% else %}
+    <form action="{{ url_for_security("wan_register_response", token=wan_state) }}" method="POST"
+          name="wan_register_response_form" id="wan-register-response-form">
+      {{ wan_register_response_form.hidden_tag() }}
+    </form>
+      <script type="text/javascript">
+        handleRegister('{{ credential_options|safe }}', "credential")
+        .then((credential) => {
+          document.getElementById("credential").value = credential
+          {# We auto-submit this form - there is a Submit button on the
+             form we could use - but there really isn't any reason to force the
+             user to click yet another button
+           #}
+          document.forms["wan-register-response-form"].submit()
+        })
+      </script>
+  {% endif %}
+
+  {% if registered_credentials %}
+    <h3>Currently registered credentials:</h3>
     <ul>
       {% for name, value in registered_credentials.items() %}
-        <li>{{ name }} with id of "{{ value.credential_id }}" last used on {{ value.lastuse }}</li>
+        <li>Nickname: "{{ name }}" transports: "{{ value.transports }}" discoverable: "{{ value.discoverable }}" last used on {{ value.lastuse }}</li>
       {% endfor %}
     </ul>
+  {% endif %}
 
-  <hr>
-  <h2>{{ _fsdomain("Delete existing WebAuthn Security Key") }}</h2>
-    <form action="{{ url_for_security("wan_delete") }}" method="POST"
-          name="wan_delete_form">
-      {{ wan_delete_form.hidden_tag() }}
-      {{ render_field_with_errors(wan_delete_form.name) }}
-      {{ render_field(wan_delete_form.submit) }}
-    </form>
+  {% if wan_delete_form %}
+    <hr>
+    <h2>{{ _fsdomain("Delete existing WebAuthn Security Key") }}</h2>
+      <form action="{{ url_for_security("wan_delete") }}" method="POST"
+            name="wan_delete_form">
+        {{ wan_delete_form.hidden_tag() }}
+        {{ render_field_with_errors(wan_delete_form.name) }}
+        {{ render_field(wan_delete_form.submit) }}
+      </form>
+  {% endif %}
 {% endblock %}

--- a/flask_security/templates/security/wan_signin.html
+++ b/flask_security/templates/security/wan_signin.html
@@ -13,15 +13,31 @@
 {% endblock head_scripts %}
 
 {% block content %}
-    {% include "security/_messages.html" %}
-    <h1>{{ _fsdomain("Sign in using WebAuthn Security Key") }}</h1>
+  {% include "security/_messages.html" %}
+  <h1>{{ _fsdomain("Sign in using WebAuthn Security Key") }}</h1>
+  {% if not credential_options %}
     <form action="{{ url_for_security("wan_signin") }}" method="POST"
           name="wan_signin_form" id="wan-signin-form">
       {{ wan_signin_form.hidden_tag() }}
       {{ render_field_with_errors(wan_signin_form.remember) }}
+      {{ render_field_errors(wan_signin_form.credential) }}
       {{ render_field(wan_signin_form.submit) }}
-      <span id="wan-error"></span>
-      <input type="hidden" name="url" value="{{ url_for_security("wan_signin") }}" readonly>
-      <input type="hidden" name="response_url" value="{{ url_for_security("wan_signin_response") }}" readonly>
     </form>
+  {% else %}
+    <form action="{{ url_for_security("wan_signin_response", token=wan_state) }}" method="POST"
+          name="wan_signin_response_form" id="wan-signin-response-form">
+      {{ wan_signin_response_form.hidden_tag() }}
+    </form>
+      <script type="text/javascript">
+        handleSignin('{{ credential_options|safe }}', "credential")
+        .then((credential) => {
+          document.getElementById("credential").value = credential
+          {# We auto-submit this form - there is a Submit button on the
+             form we could use - but there really isn't any reason to force the
+             user to click yet another button
+           #}
+          document.forms["wan-signin-response-form"].submit()
+        })
+      </script>
+  {% endif %}
 {% endblock %}

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -52,6 +52,8 @@ from .signals import user_authenticated
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from flask import Flask, Response
+    from flask.typing import ResponseValue
+    from flask_wtf import FlaskForm
     from .datastore import User
 
 SB = t.Union[str, bytes]
@@ -958,12 +960,12 @@ def csrf_cookie_handler(response: "Response") -> "Response":
 
 
 def base_render_json(
-    form,
-    include_user=True,
-    include_auth_token=False,
-    additional=None,
-    error_status_code=400,
-):
+    form: "FlaskForm",
+    include_user: bool = True,
+    include_auth_token: bool = False,
+    additional: t.Optional[t.Dict[str, t.Any]] = None,
+    error_status_code: int = 400,
+) -> "ResponseValue":
     """
     This method is called by all views that return JSON responses.
     This fills in the response and then calls :meth:`.Security.render_json`

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -1159,18 +1159,23 @@ def create_blueprint(app, state, import_name, json_encoder=None):
 
     if state.webauthn:
         bp.route(
-            state.wan_register_start_url,
+            state.wan_register_url,
             methods=["GET", "POST"],
             endpoint="wan_register",
         )(webauthn_register)
         bp.route(
-            state.wan_register_url, methods=["POST"], endpoint="wan_register_response"
+            state.wan_register_url
+            + slash_url_suffix(state.wan_register_url, "<token>"),
+            methods=["POST"],
+            endpoint="wan_register_response",
         )(webauthn_register_response)
+        bp.route(state.wan_signin_url, methods=["GET", "POST"], endpoint="wan_signin")(
+            webauthn_signin
+        )
         bp.route(
-            state.wan_signin_start_url, methods=["GET", "POST"], endpoint="wan_signin"
-        )(webauthn_signin)
-        bp.route(
-            state.wan_signin_url, methods=["POST"], endpoint="wan_signin_response"
+            state.wan_signin_url + slash_url_suffix(state.wan_signin_url, "<token>"),
+            methods=["POST"],
+            endpoint="wan_signin_response",
         )(webauthn_signin_response)
         bp.route(state.wan_delete_url, methods=["POST"], endpoint="wan_delete")(
             webauthn_delete

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -12,6 +12,9 @@
     Check out: https://golb.hplar.ch/2019/08/webauthn.html
     for some ideas on recovery and adding additional authenticators.
 
+    For testing - you can see your YubiKey (or other) resident keys in chrome!
+    chrome://settings/securityKeys
+
     TODO:
         - deal with fs_webauthn_uniquifier for existing users
         - add webauthn to other datastores
@@ -27,23 +30,30 @@
           but make this an option since it enables leaking of user info.
         - update/add examples to support webauthn
         - does remember me make sense?
-        - transports?
         - should we store things like user verified in 'last use'...
+        - config for allow as Primary, allow as Primary/MFA
+        - some options to request user verification and check on register - i.e.
+          'I want a two-factor capable key'
 
 """
 
 import datetime
+import json
 import secrets
 import typing as t
 
 
-from flask import after_this_request, request, session
+from flask import after_this_request, request
 from flask_login import current_user
 from werkzeug.datastructures import MultiDict
-from wtforms import BooleanField, StringField, SubmitField, ValidationError
+from wtforms import BooleanField, HiddenField, StringField, SubmitField
 
 try:
     import webauthn
+    from webauthn.authentication.verify_authentication_response import (
+        VerifiedAuthentication,
+    )
+    from webauthn.registration.verify_registration_response import VerifiedRegistration
     from webauthn.helpers.exceptions import (
         InvalidAuthenticationResponse,
         InvalidRegistrationResponse,
@@ -65,11 +75,13 @@ from .proxies import _security, _datastore
 from .quart_compat import get_quart_status
 from .utils import (
     base_render_json,
+    check_and_get_token_status,
     config_value as cv,
     do_flash,
     json_error_response,
     get_message,
     get_post_login_redirect,
+    get_within_delta,
     login_user,
     suppress_form_csrf,
     url_for_security,
@@ -102,6 +114,53 @@ class WebAuthnRegisterForm(Form):
         return True
 
 
+class WebAuthnRegisterResponseForm(Form):
+    credential = HiddenField()
+    submit = SubmitField(label=get_form_field_label("submit"))
+
+    # from state
+    challenge: str
+    name: str
+    # this is returned to caller (not part of the client form)
+    registration_verification: "VerifiedRegistration"
+    transports: t.List[str] = []
+    extensions: str
+
+    def validate(self) -> bool:
+        if not super().validate():
+            return False
+        if _datastore.find_webauthn(name=self.name):
+            msg = get_message("WEBAUTHN_NAME_INUSE", name=self.name)[0]
+            self.credential.errors.append(msg)
+            return False
+        try:
+            reg_cred = RegistrationCredential.parse_raw(self.credential.data)
+        except ValueError:
+            self.credential.errors.append(get_message("API_ERROR"))
+            return False
+        try:
+            self.registration_verification = webauthn.verify_registration_response(
+                credential=reg_cred,
+                expected_challenge=self.challenge.encode(),
+                expected_origin=request.host_url.rstrip("/"),
+                expected_rp_id=request.host.split(":")[0],
+                require_user_verification=True,
+            )
+            if _datastore.find_webauthn(credential_id=reg_cred.raw_id):
+                msg = get_message("WEBAUTHN_CREDENTIALID_INUSE")[0]
+                self.credential.errors.append(msg)
+                return False
+        except InvalidRegistrationResponse:
+            self.credential.errors.append(get_message("API_ERROR"))
+            return False
+        self.transports = reg_cred.transports
+        # Alas py_webauthn doesn't support extensions yet - so we have to dig in
+        response_full = json.loads(self.credential.data)
+        # TODO - verify this is JSON
+        self.extensions = response_full.get("extensions", None)
+        return True
+
+
 class WebAuthnSigninForm(Form):
 
     remember = BooleanField(get_form_field_label("remember_me"))
@@ -113,6 +172,50 @@ class WebAuthnSigninForm(Form):
 
     def validate(self):
         if not super().validate():
+            return False
+        return True
+
+
+class WebAuthnSigninResponseForm(Form):
+    submit = SubmitField(label=get_form_field_label("submit"))
+    credential = HiddenField()
+
+    # returned to caller
+    authentication_verification: "VerifiedAuthentication"
+    user = None
+    cred = None
+
+    def validate(self) -> bool:
+        if not super().validate():
+            return False
+        try:
+            auth_cred = AuthenticationCredential.parse_raw(self.credential.data)
+        except ValueError:
+            self.credential.errors.append(get_message("API_ERROR"))
+            return False
+
+        # Look up credential Id (raw_id) and user.
+        self.cred = _datastore.find_webauthn(credential_id=auth_cred.raw_id)
+        if not self.cred:
+            self.credential.errors.append(get_message("WEBAUTHN_UNKNOWN_CREDENTIAL_ID"))
+            return False
+        self.user = _datastore.find_user(id=self.cred.user_id)
+        if not self.user:
+            self.credential.errors.append(get_message("WEBAUTHN_ORPHAN_CREDENTIAL_ID"))
+            return False
+
+        try:
+            self.authentication_verification = webauthn.verify_authentication_response(
+                credential=auth_cred,
+                expected_challenge=self.challenge.encode(),
+                expected_origin=request.host_url.rstrip("/"),
+                expected_rp_id=request.host.split(":")[0],
+                credential_public_key=self.cred.public_key,
+                credential_current_sign_count=self.cred.sign_count,
+                require_user_verification=True,
+            )
+        except InvalidAuthenticationResponse:
+            self.credential.errors.append(get_message("API_ERROR"))
             return False
         return True
 
@@ -130,7 +233,11 @@ class WebAuthnDeleteForm(Form):
         return True
 
 
-@auth_required(lambda: cv("API_ENABLED_METHODS"))
+@auth_required(
+    lambda: cv("API_ENABLED_METHODS"),
+    within=lambda: cv("FRESHNESS"),
+    grace=lambda: cv("FRESHNESS_GRACE_PERIOD"),
+)
 def webauthn_register() -> "ResponseValue":
     """Start Registration for an existing authenticated user
 
@@ -140,8 +247,9 @@ def webauthn_register() -> "ResponseValue":
     Also - this requires that the user already be logged in - so we can provide info
     as part of the GET that could otherwise be considered leaking user info.
     """
+    payload: t.Dict[str, t.Any]
 
-    form_class = WebAuthnRegisterForm
+    form_class: t.Type[WebAuthnRegisterForm] = _security.wan_register_form
     if request.is_json:
         if request.content_length:
             form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
@@ -152,8 +260,10 @@ def webauthn_register() -> "ResponseValue":
 
     if form.validate_on_submit():
         challenge = secrets.token_urlsafe(cv("WAN_CHALLENGE_BYTES"))
-        session["fs_wan_challenge"] = challenge
+        state = {"challenge": challenge, "name": form.name.data}
 
+        # TODO make authenticator selection a call back so app can set whatever
+        # it needs?
         credential_options = webauthn.generate_registration_options(
             challenge=challenge,
             rp_name=cv("WAN_RP_NAME"),
@@ -162,29 +272,44 @@ def webauthn_register() -> "ResponseValue":
             user_name=current_user.calc_username(),
             timeout=cv("WAN_REGISTER_TIMEOUT"),
             authenticator_selection=AuthenticatorSelectionCriteria(
-                resident_key=ResidentKeyRequirement.REQUIRED,
+                resident_key=ResidentKeyRequirement.DISCOURAGED,
             ),
         )
+        #
+        co_json = json.loads(webauthn.options_to_json(credential_options))
+        co_json["extensions"] = {"credProps": True}
 
-        co_json = webauthn.options_to_json(credential_options)
+        state_token = _security.wan_serializer.dumps(state)
+
         if _security._want_json(request):
-            payload = {"credential_options": co_json}
+            payload = {
+                "credential_options": json.dumps(co_json),
+                "wan_state": state_token,
+            }
             return base_render_json(form, include_user=False, additional=payload)
 
-        # TODO - fix this add registered credentials?
         return _security.render_template(
             cv("WAN_REGISTER_TEMPLATE"),
             wan_register_form=form,
-            wan_delete_form=_security.wan_delete_form(),
-            credential_options=co_json,
+            wan_register_response_form=WebAuthnRegisterResponseForm(),
+            wan_state=state_token,
+            credential_options=json.dumps(co_json),
         )
 
     current_creds = {}
     for cred in current_user.webauthn:
         current_creds[cred.name] = {
             "credential_id": bytes_to_base64url(cred.credential_id),
+            "transports": cred.transports,
             "lastuse": cred.lastuse_datetime.isoformat(),
         }
+        # TODO: i18n
+        discoverable = "Unknown"
+        if cred.extensions:
+            extensions = json.loads(cred.extensions)
+            if "credProps" in extensions:
+                discoverable = extensions["credProps"].get("rk", "Unknown")
+        current_creds[cred.name]["discoverable"] = discoverable
 
     payload = {"registered_credentials": current_creds}
     if _security._want_json(request):
@@ -199,15 +324,12 @@ def webauthn_register() -> "ResponseValue":
 
 
 @auth_required(lambda: cv("API_ENABLED_METHODS"))
-def webauthn_register_response() -> "ResponseValue":
-    """Response from browser.
-    This comes via javascript and is JSON only...
-    However we want all Flask-Security endpoints to have basic CSRF protection
-    afforded by FlaskWTF (and not rely on the application to enable CSRFProtect).
-    That happens magically when validating a form with a 'csrf_token' field.
-    """
+def webauthn_register_response(token: str) -> "ResponseValue":
+    """Response from browser."""
 
-    form_class = WebAuthnRegisterForm
+    form_class: t.Type[
+        WebAuthnRegisterResponseForm
+    ] = _security.wan_register_response_form
     if request.is_json:
         if request.content_length:
             form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
@@ -216,67 +338,56 @@ def webauthn_register_response() -> "ResponseValue":
     else:
         form = form_class(meta=suppress_form_csrf())
 
-    challenge = session.get("fs_wan_challenge", None)
-    if not challenge:
-        # TODO - either add this to validate or handle forms.
-        form.name.errors.append(get_message("API_ERROR")[0])
-        return base_render_json(form, include_user=False)
+    expired, invalid, state = check_and_get_token_status(
+        token, "wan", get_within_delta("WAN_REGISTER_WITHIN")
+    )
+    if invalid:
+        m, c = get_message("API_ERROR")
+    if expired:
+        m, c = get_message("WAN_EXPIRED", within=cv("WAN_REGISTER_WITHIN"))
+    if invalid or expired:
+        if _security._want_json(request):
+            payload = json_error_response(errors=m)
+            return _security._render_json(payload, 400, None, None)
+        do_flash(m, c)
+        return redirect(url_for_security("wan_register"))
 
+    form.challenge = state["challenge"]
+    form.name = state["name"]
     if form.validate_on_submit():
-        try:
-            # TODO should this be in the form validate?
-            try:
-                reg_cred = RegistrationCredential.parse_raw(request.data)
-            except ValueError:
-                raise ValidationError(message="API_ERROR")
-            try:
-                registration_verification = webauthn.verify_registration_response(
-                    credential=reg_cred,
-                    expected_challenge=challenge.encode(),
-                    expected_origin=request.host_url.rstrip("/"),
-                    expected_rp_id=request.host.split(":")[0],
-                    require_user_verification=True,
-                )
 
-                # store away successful registration
-                after_this_request(view_commit)
-                _datastore.create_webauthn(
-                    current_user,
-                    name=form.name.data,
-                    credential_id=registration_verification.credential_id,
-                    public_key=registration_verification.credential_public_key,
-                    sign_count=registration_verification.sign_count,
-                )
+        # store away successful registration
+        after_this_request(view_commit)
 
-                if _security._want_json(request):
-                    return base_render_json(form)
-                msg, c = get_message(
-                    "WEBAUTHN_REGISTER_SUCCESSFUL", name=form.name.data
-                )
-                do_flash(msg, c)
-                return redirect(url_for_security("wan_register"))
+        # convert transports to comma separated
+        transports = ",".join(tr.value for tr in form.transports)
 
-            except InvalidRegistrationResponse:
-                raise ValidationError(message="API_ERROR")
-        except ValidationError as e:
-            msg, c = get_message(e.args[0])
-            # Here on some error
-            if _security._want_json(request):
-                payload = json_error_response(errors=msg)
-                return _security._render_json(payload, 400, None, None)
-            return _security.render_template(
-                cv("WAN_REGISTER_TEMPLATE"), wan_register_form=form
-            )
+        _datastore.create_webauthn(
+            current_user,
+            name=state["name"],
+            credential_id=form.registration_verification.credential_id,
+            public_key=form.registration_verification.credential_public_key,
+            sign_count=form.registration_verification.sign_count,
+            transports=transports,
+            extensions=form.extensions,
+        )
+
+        if _security._want_json(request):
+            return base_render_json(form)
+        msg, c = get_message("WEBAUTHN_REGISTER_SUCCESSFUL", name=state["name"])
+        do_flash(msg, c)
+        return redirect(url_for_security("wan_register"))
 
     if _security._want_json(request):
         return base_render_json(form)
+    # TODO flash error....
     return redirect(url_for_security("wan_register"))
 
 
 @anonymous_user_required
 @unauth_csrf(fall_through=True)
 def webauthn_signin() -> "ResponseValue":
-    form_class = WebAuthnSigninForm
+    form_class: t.Type[WebAuthnSigninForm] = _security.wan_signin_form
     if request.is_json:
         if request.content_length:
             form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
@@ -287,7 +398,9 @@ def webauthn_signin() -> "ResponseValue":
 
     if form.validate_on_submit():
         challenge = secrets.token_urlsafe(cv("WAN_CHALLENGE_BYTES"))
-        session["fs_wan_challenge"] = challenge
+        state = {
+            "challenge": challenge,
+        }
 
         options = webauthn.generate_authentication_options(
             rp_id=request.host.split(":")[0],
@@ -297,29 +410,32 @@ def webauthn_signin() -> "ResponseValue":
         )
 
         o_json = webauthn.options_to_json(options)
+        state_token = _security.wan_serializer.dumps(state)
         if _security._want_json(request):
-            payload = {"credential_options": o_json}
+            payload = {"credential_options": o_json, "wan_state": state_token}
             return base_render_json(form, include_user=False, additional=payload)
 
         return _security.render_template(
-            cv("WAN_SIGNIN_TEMPLATE"), wan_signin_form=form, credential_options=o_json
+            cv("WAN_SIGNIN_TEMPLATE"),
+            wan_signin_form=form,
+            wan_signin_response_form=WebAuthnSigninResponseForm(),
+            wan_state=state_token,
+            credential_options=o_json,
         )
 
     if _security._want_json(request):
         return base_render_json(form)
-    return _security.render_template(cv("WAN_SIGNIN_TEMPLATE"), wan_signin_form=form)
+    return _security.render_template(
+        cv("WAN_SIGNIN_TEMPLATE"),
+        wan_signin_form=form,
+        wan_signin_response_form=WebAuthnSigninResponseForm(),
+    )
 
 
 @anonymous_user_required
 @unauth_csrf(fall_through=True)
-def webauthn_signin_response() -> "ResponseValue":
-    """
-    This comes via javascript and is JSON only...
-    However we want all Flask-Security endpoints to have basic CSRF protection
-    afforded by FlaskWTF (and not rely on the application to enable CSRFProtect.
-    That happens magically when validating a form with a 'csrf_token' field.
-    """
-    form_class = WebAuthnSigninForm
+def webauthn_signin_response(token: str) -> "ResponseValue":
+    form_class: t.Type[WebAuthnSigninResponseForm] = _security.wan_signin_response_form
     if request.is_json:
         if request.content_length:
             form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
@@ -328,83 +444,62 @@ def webauthn_signin_response() -> "ResponseValue":
     else:
         form = form_class(meta=suppress_form_csrf())
 
-    challenge = session.get("fs_wan_challenge", None)
-    if not challenge:
-        # TODO - either add this to validate or handle forms.
-        payload = json_error_response(errors=get_message("API_ERROR")[0])
-        return _security._render_json(payload, 400, None, None)
+    expired, invalid, state = check_and_get_token_status(
+        token, "wan", get_within_delta("WAN_SIGNIN_WITHIN")
+    )
+    if invalid:
+        m, c = get_message("API_ERROR")
+    if expired:
+        m, c = get_message("WAN_EXPIRED", within=cv("WAN_SIGNIN_WITHIN"))
+    if invalid or expired:
+        if _security._want_json(request):
+            payload = json_error_response(errors=m)
+            return _security._render_json(payload, 400, None, None)
+        do_flash(m, c)
+        return redirect(url_for_security("wan_signin"))
+
+    form.challenge = state["challenge"]
 
     if form.validate_on_submit():
         remember_me = form.remember.data if "remember" in form else None
 
-        try:
-            # TODO should this be in the form validate?
-            try:
-                auth_cred = AuthenticationCredential.parse_raw(request.data)
-            except ValueError:
-                raise ValidationError(message="API_ERROR")
+        # update last use and sign count
+        after_this_request(view_commit)
+        form.cred.lastuse_datetime = datetime.datetime.utcnow()
+        form.cred.sign_count = form.authentication_verification.new_sign_count
+        _datastore.put(form.cred)
 
-            # Look up credential Id (raw_id) and user.
-            cred = _datastore.find_webauthn(credential_id=auth_cred.raw_id)
-            if not cred:
-                raise ValidationError(message="WEBAUTHN_UNKNOWN_CREDENTIAL_ID")
-            user = _datastore.find_user(id=cred.user_id)
-            if not user:
-                raise ValidationError(message="WEBAUTHN_ORPHAN_CREDENTIAL_ID")
+        # login user
+        login_user(form.user, remember=remember_me, authn_via=["webauthn"])
 
-            try:
-                authentication_verification = webauthn.verify_authentication_response(
-                    credential=auth_cred,
-                    expected_challenge=challenge.encode(),
-                    expected_origin=request.host_url.rstrip("/"),
-                    expected_rp_id=request.host.split(":")[0],
-                    credential_public_key=cred.public_key,
-                    credential_current_sign_count=cred.sign_count,
-                    require_user_verification=True,
-                )
-
-                # update last use and sign count
-                after_this_request(view_commit)
-                cred.lastuse_datetime = datetime.datetime.utcnow()
-                cred.sign_count = authentication_verification.new_sign_count
-                # TODO - store away authenticator DataFlags of this use?
-                _datastore.put(cred)
-
-                # login user
-                login_user(user, remember=remember_me, authn_via=["webauthn"])
-
-                goto_url = get_post_login_redirect()
-                if _security._want_json(request):
-                    # Tell caller where we would go if forms based - they can use it or
-                    # not.
-                    payload = {"post_login_url": goto_url}
-                    return base_render_json(
-                        form, include_auth_token=True, additional=payload
-                    )
-
-                return redirect(goto_url)
-
-            except InvalidAuthenticationResponse:
-                raise ValidationError(message="API_ERROR")
-        except ValidationError as e:
-            msg, c = get_message(e.args[0])
-            # Here on some error
-            if _security._want_json(request):
-                payload = json_error_response(errors=msg)
-                return _security._render_json(payload, 400, None, None)
-            do_flash(msg, c)
-            return redirect(url_for_security("wan_signin"))
+        goto_url = get_post_login_redirect()
+        if _security._want_json(request):
+            # Tell caller where we would go if forms based - they can use it or
+            # not.
+            payload = {"post_login_url": goto_url}
+            return base_render_json(form, include_auth_token=True, additional=payload)
+        return redirect(goto_url)
 
     if _security._want_json(request):
         return base_render_json(form)
-    return _security.render_template(cv("WAN_SIGNIN_TEMPLATE"), wan_register_form=form)
+
+    # Here on validate error - since the response is auto submitted - we go back to
+    # signin form - for now use flash.
+    # TODO set into a special form element error?
+    signin_form = _security.wan_signin_form()
+    if form.credential.errors:
+        m, c = form.credential.errors[0]
+        do_flash(m, c)
+    return _security.render_template(
+        cv("WAN_SIGNIN_TEMPLATE"), wan_signin_form=signin_form
+    )
 
 
 @auth_required(lambda: cv("API_ENABLED_METHODS"))
 def webauthn_delete() -> "ResponseValue":
     """Deletes an existing registered credential."""
 
-    form_class = WebAuthnDeleteForm
+    form_class: t.Type[WebAuthnDeleteForm] = _security.wan_delete_form
     if request.is_json:
         if request.content_length:
             form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
@@ -418,6 +513,6 @@ def webauthn_delete() -> "ResponseValue":
         if cred:
             after_this_request(view_commit)
             _datastore.delete_webauthn(cred)
-        # TODO - errors, json
+        # TODO - errors, json, flash
 
     return redirect(url_for_security("wan_register"))


### PR DESCRIPTION
Refactor to be more aligned with how other APIs work in FS.

Don't use session - use state token.

Separate out initial register/signin from responses (separate forms/API)

Refactor js file to be more modular and hopefully more reusable for other clients.

Add support for transports.

Add support (and changed model) to store extension results.

Simple template support for using webauthn to sign in as part of unified signin.