### PR TITLE
Webauthn - next steps

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,12 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.0
+    rev: v2.29.1
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/psf/black
-    rev: 21.10b0
+    rev: 21.11b1
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -504,6 +504,10 @@ _default_messages = {
         _("WebAuthn credential doesn't below to any user."),
         "error",
     ),
+    "WEBAUTHN_NO_VERIFY": (
+        _("Could not verify WebAuthn credential."),
+        "error",
+    ),
 }
 
 

--- a/flask_security/static/js/webauthn.js
+++ b/flask_security/static/js/webauthn.js
@@ -23,6 +23,12 @@ function b64RawEnc(buf) {
     .replace(/\//g, "_");
 }
 
+function encode(attr) {
+  return Uint8Array.from(
+    atob(attr.replace(/_/g, "/").replace(/-/g, "+")),
+    c => c.charCodeAt(0));
+}
+
 async function fetch_json(url, options) {
     const response = await fetch(url, options);
     const body = await response.json();
@@ -37,39 +43,6 @@ async function fetch_json(url, options) {
     return body;
 }
 
-/*
- * Flask-Security API JSON response has:
- * ["response"]["error"] = str OR
- * ["response"]["errors"]["<field_name>"] = list of str
- *
- * Given a response - look for errors and insert them into an element
- *  - and return True if there were some.
- */
-function display_errors(response, id) {
-  if (!("error" in response) && !("errors" in response))
-    return false
-
-  const error_element = document.getElementById(id)
-  if (error_element) {
-    if ("error" in response) {
-      error_element.innerHTML = `<b>ERROR</b>: <em>${response["error"]}</em`
-    } else if ("errors" in response) {
-      error_element.innerHTML = "<b>ERRORS</b>:<ul>"
-      for (const field_name in response["errors"]) {
-        error_element.innerHTML += `<li>${field_name}: <em>${response["errors"][field_name][0]}</em></li>`
-      }
-      error_element.innerHTML += "</ul>"
-    }
-  }
-  return true
-}
-
-function clear_errors(id) {
-  const error_element = document.getElementById(id)
-  if (error_element)
-    error_element.innerHTML = ''
-}
-
 /**
  * REGISTRATION FUNCTIONS
  */
@@ -79,27 +52,26 @@ function clear_errors(id) {
  * parse those and pass to browser to create new credential, and transform
  * that new credential for passing/storing to the server.
  */
-async function handleRegister(credential_options, error_elmid) {
-  const credentialCreateOptionsFromServer = JSON.parse(credential_options);
+async function handleRegister(credential_options) {
+  const credentialCreateOptionsFromServer = JSON.parse(credential_options)
 
   // convert certain members of the PublicKeyCredentialCreateOptions into
   // byte arrays as expected by the spec.
   const publicKeyCredentialCreateOptions = transformCredentialCreateOptions(credentialCreateOptionsFromServer)
 
   // request the authenticator(s) to create a new credential keypair.
-  let credential;
-  clear_errors(error_elmid)
+  let credential, error_msg
   try {
       credential = await navigator.credentials.create({
           publicKey: publicKeyCredentialCreateOptions
       })
       // we now have a new credential! We now need to encode the byte arrays
       // in the credential into strings, for posting to our server.
-      return JSON.stringify(transformNewAssertionForServer(credential))
+      credential = JSON.stringify(transformNewAssertionForServer(credential))
   } catch (err) {
-    const err_msg = `Error creating credential: ${err}`
-    display_errors({error: err_msg}, error_elmid)
+    error_msg = `Error when creating credential: ${err}`
   }
+  return {"credential": credential, "error_msg": error_msg}
 }
 
 /**
@@ -108,26 +80,23 @@ async function handleRegister(credential_options, error_elmid) {
  * @param {Object} credentialCreateOptionsFromServer
  */
 const transformCredentialCreateOptions = (credentialCreateOptionsFromServer) => {
-    let {challenge, user} = credentialCreateOptionsFromServer;
-    user.id = Uint8Array.from(
-        atob(credentialCreateOptionsFromServer.user.id
-            .replace(/_/g, "/")
-            .replace(/-/g, "+")
-            ),
-        c => c.charCodeAt(0));
+    let {challenge, user, excludeCredentials} = credentialCreateOptionsFromServer
+    user.id = encode(credentialCreateOptionsFromServer.user.id)
+    challenge = encode(credentialCreateOptionsFromServer.challenge)
 
-    challenge = Uint8Array.from(
-        atob(credentialCreateOptionsFromServer.challenge
-            .replace(/_/g, "/")
-            .replace(/-/g, "+")
-            ),
-        c => c.charCodeAt(0));
+    excludeCredentials = excludeCredentials.map(credentialDescriptor => {
+      let {id} = credentialDescriptor;
+      id = encode(id)
+      return Object.assign({}, credentialDescriptor, {id})
+    })
 
     const transformedCredentialCreateOptions = Object.assign(
-            {}, credentialCreateOptionsFromServer,
-            {challenge, user});
+      {},
+      credentialCreateOptionsFromServer,
+      {challenge, user, excludeCredentials}
+    )
 
-    return transformedCredentialCreateOptions;
+    return transformedCredentialCreateOptions
 }
 
 /**
@@ -152,7 +121,7 @@ const transformNewAssertionForServer = (newAssertion) => {
         response: {"attestationObject": b64enc(attObj), "clientDataJSON": b64enc(clientDataJSON)},
         extensions: JSON.stringify(registrationClientExtensions),
         transports: newAssertion.response.getTransports(),
-    };
+    }
 }
 
 
@@ -162,7 +131,7 @@ const transformNewAssertionForServer = (newAssertion) => {
  */
 
 
-async function handleSignin(response, error_elmid) {
+async function handleSignin(response) {
   const credentialRequestOptionsFromServer = JSON.parse(response)
   // convert certain members of the PublicKeyCredentialRequestOptions into
   // byte arrays as expected by the spec.
@@ -171,41 +140,38 @@ async function handleSignin(response, error_elmid) {
 
   // request the authenticator to create an assertion signature using the
   // credential private key
-  let assertion
-  clear_errors(error_elmid)
+  let assertion, credential, error_msg
   try {
     assertion = await navigator.credentials.get({
         publicKey: transformedCredentialRequestOptions,
     })
     // we now have an authentication assertion! encode the byte arrays contained
     // in the assertion data as strings for posting to the server
-    return JSON.stringify(transformAssertionForServer(assertion))
+    credential = JSON.stringify(transformAssertionForServer(assertion))
   } catch (err) {
-    const err_msg = `Error when creating credential: ${err}`
-    display_errors({error: err_msg}, error_elmid)
+    error_msg = `Error when retrieving credential: ${err}`
   }
+  return {"credential": credential, "error_msg": error_msg}
 }
 
 const transformCredentialRequestOptions = (credentialRequestOptionsFromServer) => {
-    let {challenge, allowCredentials} = credentialRequestOptionsFromServer;
+    let {challenge, allowCredentials} = credentialRequestOptionsFromServer
 
-    challenge = Uint8Array.from(
-        atob(challenge.replace(/_/g, "/").replace(/-/g, "+")), c => c.charCodeAt(0));
-
+    challenge = encode(challenge)
     allowCredentials = allowCredentials.map(credentialDescriptor => {
-        let {id} = credentialDescriptor;
-        id = id.replace(/_/g, "/").replace(/-/g, "+");
-        id = Uint8Array.from(atob(id), c => c.charCodeAt(0));
-        return Object.assign({}, credentialDescriptor, {id});
-    });
+      let {id} = credentialDescriptor
+      id = encode(id)
+      return Object.assign({}, credentialDescriptor, {id})
+    })
 
     const transformedCredentialRequestOptions = Object.assign(
-        {},
-        credentialRequestOptionsFromServer,
-        {challenge, allowCredentials});
+      {},
+      credentialRequestOptionsFromServer,
+      {challenge, allowCredentials}
+    )
 
-    return transformedCredentialRequestOptions;
-};
+    return transformedCredentialRequestOptions
+}
 
 
 

--- a/flask_security/templates/security/two_factor_verify_code.html
+++ b/flask_security/templates/security/two_factor_verify_code.html
@@ -22,5 +22,14 @@
         {% endif %}
         {{ render_field(two_factor_rescue_form.submit) }}
     </form>
+    {% if has_webauthn %}
+      <h2>{{ _fsdomain("Use a registered WebAuthn security key") }}</h2>
+      <form action="{{ url_for_security("wan_signin") }}" method="POST"
+            name="wan_signin_form">
+        {{ wan_signin_form.hidden_tag() }}
+        {{ render_field_with_errors(wan_signin_form.identity) }}
+        {{ render_field(wan_signin_form.submit, value="Authenticate") }}
+      </form>
+    {% endif %}
     {% include "security/_menu.html" %}
 {% endblock %}

--- a/flask_security/templates/security/us_signin.html
+++ b/flask_security/templates/security/us_signin.html
@@ -29,8 +29,7 @@
     <hr class="fs-gap">
     <h3>Use WebAuthn to Sign In</h3>
     <div>
-      <form method="POST" id="wan-signin-form" name="wan_signin_form">
-        {{ us_signin_form.hidden_tag() }}
+      <form method="GET" id="wan-signin-form" name="wan_signin_form">
         <input id="wan_signin" name="wan_signin" type="submit" value="Sign in with WebAuthn"
           formaction="{{ url_for_security("wan_signin") }}">
       </form>

--- a/flask_security/templates/security/wan_register.html
+++ b/flask_security/templates/security/wan_register.html
@@ -27,22 +27,28 @@
     <form action="{{ url_for_security("wan_register_response", token=wan_state) }}" method="POST"
           name="wan_register_response_form" id="wan-register-response-form">
       {{ wan_register_response_form.hidden_tag() }}
+      <div id="wan-errors"></div>
     </form>
       <script type="text/javascript">
-        handleRegister('{{ credential_options|safe }}', "credential")
-        .then((credential) => {
-          document.getElementById("credential").value = credential
-          {# We auto-submit this form - there is a Submit button on the
-             form we could use - but there really isn't any reason to force the
-             user to click yet another button
-           #}
-          document.forms["wan-register-response-form"].submit()
-        })
+        handleRegister('{{ credential_options|safe }}')
+          .then((result) => {
+            if (result.credential) {
+              document.getElementById("credential").value = result.credential
+              {# We auto-submit this form - there is a Submit button on the
+                 form we could use - but there really isn't any reason to force the
+                 user to click yet another button
+               #}
+              document.forms["wan-register-response-form"].submit()
+            } else {
+              const error_element = document.getElementById("wan-errors")
+              error_element.innerHTML = `<em>${result.error_msg}</em`
+            }
+          })
       </script>
   {% endif %}
 
   {% if registered_credentials %}
-    <h3>Currently registered credentials:</h3>
+    <h3>Currently registered security keys:</h3>
     <ul>
       {% for name, value in registered_credentials.items() %}
         <li>Nickname: "{{ name }}" transports: "{{ value.transports }}" discoverable: "{{ value.discoverable }}" last used on {{ value.lastuse }}</li>

--- a/flask_security/templates/security/wan_signin.html
+++ b/flask_security/templates/security/wan_signin.html
@@ -19,6 +19,7 @@
     <form action="{{ url_for_security("wan_signin") }}" method="POST"
           name="wan_signin_form" id="wan-signin-form">
       {{ wan_signin_form.hidden_tag() }}
+      {{ render_field_with_errors(wan_signin_form.identity) }}
       {{ render_field_with_errors(wan_signin_form.remember) }}
       {{ render_field_errors(wan_signin_form.credential) }}
       {{ render_field(wan_signin_form.submit) }}
@@ -27,16 +28,22 @@
     <form action="{{ url_for_security("wan_signin_response", token=wan_state) }}" method="POST"
           name="wan_signin_response_form" id="wan-signin-response-form">
       {{ wan_signin_response_form.hidden_tag() }}
+      <div id="wan-errors"></div>
     </form>
       <script type="text/javascript">
-        handleSignin('{{ credential_options|safe }}', "credential")
-        .then((credential) => {
-          document.getElementById("credential").value = credential
-          {# We auto-submit this form - there is a Submit button on the
-             form we could use - but there really isn't any reason to force the
-             user to click yet another button
-           #}
-          document.forms["wan-signin-response-form"].submit()
+        handleSignin('{{ credential_options|safe }}')
+        .then((result) => {
+          if (result.credential) {
+            document.getElementById("credential").value = result.credential
+            {# We auto-submit this form - there is a Submit button on the
+               form we could use - but there really isn't any reason to force the
+               user to click yet another button
+             #}
+            document.forms["wan-signin-response-form"].submit()
+          } else {
+            const error_element = document.getElementById("wan-errors")
+            error_element.innerHTML = `<em>${result.error_msg}</em`
+          }
         })
       </script>
   {% endif %}

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -61,13 +61,6 @@ from .unified_signin import (
     us_verify_link,
     us_verify_send_code,
 )
-from .webauthn import (
-    webauthn_delete,
-    webauthn_register,
-    webauthn_register_response,
-    webauthn_signin,
-    webauthn_signin_response,
-)
 from .recoverable import (
     reset_password_token_status,
     send_reset_password_instructions,
@@ -104,6 +97,14 @@ from .utils import (
     suppress_form_csrf,
     url_for_security,
     view_commit,
+)
+from .webauthn import (
+    has_webauthn_tf,
+    webauthn_delete,
+    webauthn_register,
+    webauthn_register_response,
+    webauthn_signin,
+    webauthn_signin_response,
 )
 
 if get_quart_status():  # pragma: no cover
@@ -950,10 +951,19 @@ def two_factor_token_validation():
     else:
         rescue_form = _security.two_factor_rescue_form()
 
+        wan_signin_form = None
+        has_webauthn = has_webauthn_tf(form.user)
+        if has_webauthn:
+            wan_signin_form = _security.wan_signin_form(
+                identity=form.user.calc_username()
+            )
+
         return _security.render_template(
             cv("TWO_FACTOR_VERIFY_CODE_TEMPLATE"),
             two_factor_rescue_form=rescue_form,
             two_factor_verify_code_form=form,
+            has_webauthn=has_webauthn,
+            wan_signin_form=wan_signin_form,
             problem=None,
             **_ctx("tf_token_validation"),
         )

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{36,37,38,39,310,py3}-{low,release}
     mypy
+    nowebauthn
     nobabel
     style
     docs
@@ -60,6 +61,14 @@ deps =
     git+git://github.com/maxcountryman/flask-login@main#egg=flask-login
 commands =
     python setup.py compile_catalog
+    pytest --basetemp={envtmpdir} {posargs:tests}
+
+[testenv:nowebauthn]
+basepython = python3.9
+deps =
+    -r requirements/tests.txt
+commands =
+    pip uninstall -y webauthn
     pytest --basetemp={envtmpdir} {posargs:tests}
 
 [testenv:nobabel]


### PR DESCRIPTION
Fix issues with mypy bytes/strings that broke entire app.

Add support for providing identity and returning allowedCredentials
Add support for excludeCredentials during registration.

Initial hookup to 2FA - can use webauthn as a second factor.

COntinue to fine-tune webauthn.js - it just does conversions and talk to browser now - all DOM related stuff is pushed into the templates.