### PR TITLE
Webauthn - first pass unit tests.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -185,6 +185,11 @@ Utils
   :members:
   :special-members: __init__
 
+.. autoclass:: flask_security.WebauthnUtil
+  :members:
+  :special-members: __init__
+
+
 .. autoclass:: flask_security.SmsSenderBaseClass
   :members: send_sms
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,6 +102,7 @@ nitpick_ignore = [
     ("py:class", "flask_mongoengine.MongoEngine"),
     ("py:class", "ResponseValue"),
     ("py:class", "function"),
+    ("py:class", "AuthenticatorSelectionCriteria"),
 ]
 autodoc_typehints = "description"
 # autodoc_mock_imports = ["flask_sqlalchemy"]

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -6,7 +6,7 @@
     security via Flask-Login, Flask-Principal, Flask-WTF, and passlib.
 
     :copyright: (c) 2012-2019 by Matt Wright.
-    :copyright: (c) 2019-2020 by J. Christopher Wagner.
+    :copyright: (c) 2019-2021 by J. Christopher Wagner.
     :license: MIT, see LICENSE for more details.
 """
 
@@ -104,5 +104,6 @@ from .utils import (
     verify_password,
     verify_and_update_password,
 )
+from .webauthn_util import WebauthnUtil
 
 __version__ = "4.2.0"

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -72,6 +72,7 @@ from .webauthn import (
     WebAuthnSigninForm,
     WebAuthnSigninResponseForm,
 )
+from .webauthn_util import WebauthnUtil
 from .username_util import UsernameUtil
 from .totp import Totp
 from .utils import _
@@ -488,8 +489,16 @@ _default_messages = {
         _("%(name)s is already associated with a credential."),
         "error",
     ),
+    "WEBAUTHN_NAME_NOT_FOUND": (
+        _("%(name)s not registered with current user."),
+        "error",
+    ),
+    "WEBAUTHN_CREDENTIAL_DELETED": (
+        _("Successfully deleted WebAuthn credential with name %(name)s"),
+        "info",
+    ),
     "WEBAUTHN_REGISTER_SUCCESSFUL": (
-        _("Successfully added WebAuthn Security Key with name %(name)s"),
+        _("Successfully added WebAuthn credential with name %(name)s"),
         "info",
     ),
     "WEBAUTHN_CREDENTIAL_ID_INUSE": (
@@ -505,7 +514,7 @@ _default_messages = {
         "error",
     ),
     "WEBAUTHN_NO_VERIFY": (
-        _("Could not verify WebAuthn credential."),
+        _("Could not verify WebAuthn credential: %(cause)s."),
         "error",
     ),
 }
@@ -1027,6 +1036,8 @@ class Security:
         ``wan_register_form``, ``wan_register_response_form``,
          ``webauthn_signin_form``, ``wan_signin_response_form``,
          ``webauthn_delete_form``.
+    .. versionadded:: 4.2.0
+        ``WebauthnUtil`` class.
 
     """
 
@@ -1065,6 +1076,7 @@ class Security:
         render_template: t.Callable[..., str] = default_render_template,
         totp_cls: t.Type["Totp"] = Totp,
         username_util_cls: t.Type["UsernameUtil"] = UsernameUtil,
+        webauthn_util_cls: t.Type["WebauthnUtil"] = WebauthnUtil,
         **kwargs: t.Any,
     ):
 
@@ -1109,6 +1121,7 @@ class Security:
         self.render_template = render_template
         self.totp_cls = totp_cls
         self.username_util_cls = username_util_cls
+        self.webauthn_util_cls = webauthn_util_cls
 
         # Attributes not settable from init.
         self._unauthn_handler: t.Callable[
@@ -1361,6 +1374,7 @@ class Security:
         self._mail_util = self.mail_util_cls(app)
         self._password_util = self.password_util_cls(app)
         self._username_util = self.username_util_cls(app)
+        self._webauthn_util = self.webauthn_util_cls(app)
         rvre = cv("REDIRECT_VALIDATE_RE", app=app)
         if rvre:
             self._redirect_validate_re = re.compile(rvre)

--- a/flask_security/templates/security/wan_register.html
+++ b/flask_security/templates/security/wan_register.html
@@ -50,8 +50,8 @@
   {% if registered_credentials %}
     <h3>Currently registered security keys:</h3>
     <ul>
-      {% for name, value in registered_credentials.items() %}
-        <li>Nickname: "{{ name }}" transports: "{{ value.transports }}" discoverable: "{{ value.discoverable }}" last used on {{ value.lastuse }}</li>
+      {% for cred in registered_credentials %}
+        <li>Nickname: "{{ cred.name }}" transports: "{{ cred.transports }}" discoverable: "{{ cred.discoverable }}" last used on {{ cred.lastuse }}</li>
       {% endfor %}
     </ul>
   {% endif %}

--- a/flask_security/webauthn_util.py
+++ b/flask_security/webauthn_util.py
@@ -1,0 +1,62 @@
+"""
+    flask_security.webauthn_util
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Utility class providing methods controlling various aspects of webauthn.
+
+    :copyright: (c) 2020-2021 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+
+"""
+
+import secrets
+import typing as t
+
+from flask import request
+
+try:
+    from webauthn.helpers.structs import (
+        AuthenticatorSelectionCriteria,
+        ResidentKeyRequirement,
+    )
+except ImportError:
+    pass
+
+
+if t.TYPE_CHECKING:  # pragma: no cover
+    import flask
+    from .datastore import User
+
+
+class WebauthnUtil:
+    def __init__(self, app: "flask.Flask"):
+        """Instantiate class.
+
+        :param app: The Flask application being initialized.
+        """
+        pass
+
+    def generate_challenge(self, nbytes: t.Optional[int] = None) -> str:
+        # Mostly override this for testing so we can have a 'constant' challenge.
+        return secrets.token_urlsafe(nbytes)
+
+    def origin(self) -> str:
+        # Return the RP origin - normally this is just the URL of the application.
+        return request.host_url.rstrip("/")
+
+    def authenticator_selection(self, user: "User") -> "AuthenticatorSelectionCriteria":
+        """
+        Part of the registration ceremony is providing information about what kind
+        of authenticators the app is interested in.
+        See: https://www.w3.org/TR/2021/REC-webauthn-2-20210408
+        /#dictionary-authenticatorSelection
+
+        Simply - if the key isn't resident then it isn't discoverable which means that
+        the user won't be able to use that key unless they identify themselves
+        (use the key as a second factor OR type in their identity). If they are forced
+        to type in their identity PRIOR to be authenticated, then there is the
+        possibility that the app will leak username information.
+        """
+        return AuthenticatorSelectionCriteria(
+            resident_key=ResidentKeyRequirement.PREFERRED
+        )

--- a/pytest.ini
+++ b/pytest.ini
@@ -11,3 +11,4 @@ markers =
     passwordless
     trackable
     unified_signin
+    webauthn

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -12,6 +12,7 @@ bleach
 check-manifest
 coverage
 cryptography
+python-dateutil
 mongoengine
 mongomock
 msgcheck

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,6 +92,7 @@ def app(request: pytest.FixtureRequest) -> "Flask":
         "confirmable",
         "two_factor",
         "unified_signin",
+        "webauthn",
     ]:
         app.config["SECURITY_" + opt.upper()] = opt in request.keywords
 
@@ -314,7 +315,7 @@ def sqlalchemy_datastore(request, app, tmpdir, realdburl):
 def sqlalchemy_setup(request, app, tmpdir, realdburl):
     pytest.importorskip("flask_sqlalchemy")
     from flask_sqlalchemy import SQLAlchemy
-    from flask_security.models import fsqla_v2 as fsqla
+    from flask_security.models import fsqla_v3 as fsqla
 
     if realdburl:
         db_url, db_info = _setup_realdb(realdburl)
@@ -338,6 +339,9 @@ def sqlalchemy_setup(request, app, tmpdir, realdburl):
             # Make sure we still properly hook up to flask JSONEncoder
             return {"email": str(self.email), "last_update": self.update_datetime}
 
+    class WebAuthn(db.Model, fsqla.FsWebAuthnMixin):
+        pass
+
     with app.app_context():
         db.create_all()
 
@@ -348,7 +352,7 @@ def sqlalchemy_setup(request, app, tmpdir, realdburl):
 
     request.addfinalizer(tear_down)
 
-    return SQLAlchemyUserDatastore(db, User, Role)
+    return SQLAlchemyUserDatastore(db, User, Role, WebAuthn)
 
 
 @pytest.fixture()

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -1,0 +1,379 @@
+"""
+    test_webauthn
+    ~~~~~~~~~~~~~~~~~~~
+
+    WebAuthn tests
+
+    :copyright: (c) 2021-2021 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+
+"""
+import datetime
+from dateutil import parser
+import json
+import re
+import typing as t
+
+import pytest
+from tests.test_utils import (
+    authenticate,
+    capture_flashes,
+    logout,
+)
+
+from flask_security import (
+    WebauthnUtil,
+    user_authenticated,
+)
+
+pytest.importorskip("webauthn")
+
+pytestmark = pytest.mark.webauthn()
+
+# We can't/don't test the actual client-side javascript and browser APIs - so
+# to create reproducible tests, use view_scaffold, set breakpoints in the browser and
+# cut-and-paste the responses. That requires that 'challenge' and 'rp_origin' be
+# identical between view_scaffold and tests here.
+CHALLENGE = "smCCiy_k2CqQydSQ_kPEjV5a2d0ApfatcpQ1aXDmQPo"
+REG_DATA1 = {
+    "id": "wUUqNOjY35dcT-vpikZpZx-T91NjIe4PqrV8j7jYPOc",
+    "rawId": "wUUqNOjY35dcT-vpikZpZx-T91NjIe4PqrV8j7jYPOc",
+    "type": "public-key",
+    "response": {
+        "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVikSZYN5YgOjGh0NB"
+        "cPZHZgW4_krrmihjLHmVzzuoMdl2NFAAAAAQAAAAAAAAAAAAAAAAAAA"
+        "AAAIMFFKjTo2N-XXE_r6YpGaWcfk_dTYyHuD6q1fI-42DznpQECAy"
+        "YgASFYIFRipoWMEiDuCtLUvSlqCFZBqxvUuNqZKavlWgvN2BK8Il"
+        "ggLOV4eez9k0det5oIZGyKanGkmWa0hygnjjFmf8Rep6c",
+        "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoiYzIxR"
+        "FEybDVYMnN5UTNGUmVXUlRVVjlyVUVWcVZqVmhNbVF3UVhCbVlYUmpjRk"
+        "V4WVZoRWJWRlFidyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6NT"
+        "AwMSIsImNyb3NzT3JpZ2luIjpmYWxzZX0",
+    },
+    "extensions": '{"credProps": {}}',
+    "transports": ["usb"],
+}
+SIGNIN_DATA1 = {
+    "id": "wUUqNOjY35dcT-vpikZpZx-T91NjIe4PqrV8j7jYPOc",
+    "rawId": "wUUqNOjY35dcT-vpikZpZx-T91NjIe4PqrV8j7jYPOc",
+    "type": "public-key",
+    "response": {
+        "authenticatorData": "SZYN5YgOjGh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2MBAAAABQ==",
+        "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uZ2V0IiwiY2hhbGxlbmdlIjoiYzIxRFEy"
+        "bDVYMnN5UTNGUmVXUlRVVjlyVUVWcVZqVmhNbVF3UVhCbVlYUmpjRkV4"
+        "WVZoRWJWRlFidyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6NTAw"
+        "MSIsImNyb3NzT3JpZ2luIjpmYWxzZX0=",
+        "signature": "MEUCIH5VdRXxfnoxfrVk72gvWAn91QH-l2UrIohk5YOWi9XpAiEAn6f9oHtFS"
+        "68HVf6K_Ku0L33C0sID2HzpJWSiTNgJlbU=",
+    },
+    "assertionClientExtensions": "{}",
+}
+REG_DATA2 = {
+    "id": "lpMv8FTVHVSxteQJ3N4azlSxXiBJADA7IK-NleETceZYODy51_Cqt7Rx6pfVP1BI",
+    "rawId": "lpMv8FTVHVSxteQJ3N4azlSxXiBJADA7IK-NleETceZYODy51_Cqt7Rx6pfVP1BI",
+    "type": "public-key",
+    "response": {
+        "attestationObject": "o2NmbXRkbm9uZWdhdHRTdG10oGhhdXRoRGF0YVjCSZYN5YgOj"
+        "Gh0NBcPZHZgW4_krrmihjLHmVzzuoMdl2PFAAAAAgAAAAAAAAAAA"
+        "AAAAAAAAAAAMJaTL_BU1R1UsbXkCdzeGs5UsV4gSQAwOyCvjZXhE3"
+        "HmWDg8udfwqre0ceqX1T9QSKUBAgMmIAEhWCCWky_wVNUdVL"
+        "G15AncLU8mBQCtY10BjnSDoOUlRjkU1CJYIIA1U9vNDpZ"
+        "TihC2x0CxRZ-trF_zazYosuEqYdHSOIjZoWtjcmVkUHJvdGVjdAI",
+        "clientDataJSON": "eyJ0eXBlIjoid2ViYXV0aG4uY3JlYXRlIiwiY2hhbGxlbmdlIjoi"
+        "YzIxRFEybDVYMnN5UTNGUmVXUlRVVjlyVUVWcVZqVmhNbVF3UV"
+        "hCbVlYUmpjRkV4WVZoRWJWRlFidyIsIm9yaWdpbiI6Imh0dHA6L"
+        "y9sb2NhbGhvc3Q6NTAwMSIsImNyb3NzT3JpZ2luIjpmYWxzZX0",
+    },
+    "extensions": '{"credProps": {"rk": True}}',
+    "transports": ["nfc", "usb"],
+}
+
+
+class TestWebauthnUtil(WebauthnUtil):
+    def generate_challenge(self, nbytes: t.Optional[int] = None) -> str:
+        return CHALLENGE
+
+    def origin(self):
+        # This is from view_scaffold
+        return "http://localhost:5001"
+
+
+def _register_start(client, name="testr1"):
+    response = client.post("wan-register", data=dict(name=name))
+    matcher = re.match(
+        r".*handleRegister\(\'(.*)\'\).*",
+        response.data.decode("utf-8"),
+        re.IGNORECASE | re.DOTALL,
+    )
+    register_options = json.loads(matcher.group(1))
+
+    action_matcher = re.match(
+        r'.*<form action="([^\s]*)".*',
+        response.data.decode("utf-8"),
+        re.IGNORECASE | re.DOTALL,
+    )
+    response_url = action_matcher.group(1)
+    return register_options, response_url
+
+
+def _register_start_json(client, name="testr1"):
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+
+    response = client.post("wan-register", headers=headers, json=dict(name=name))
+    register_options = response.json["response"]["credential_options"]
+    response_url = f'wan-register/{response.json["response"]["wan_state"]}'
+    return register_options, response_url
+
+
+def _signin_start(client, identity=None):
+    response = client.post("wan-signin", data=dict(identity=identity))
+    matcher = re.match(
+        r".*handleSignin\(\'(.*)\'\).*",
+        response.data.decode("utf-8"),
+        re.IGNORECASE | re.DOTALL,
+    )
+    signin_options = json.loads(matcher.group(1))
+
+    action_matcher = re.match(
+        r'.*<form action="([^\s]*)".*',
+        response.data.decode("utf-8"),
+        re.IGNORECASE | re.DOTALL,
+    )
+    response_url = action_matcher.group(1)
+    return signin_options, response_url
+
+
+def _signin_start_json(client, identity=None):
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+
+    response = client.post("wan-signin", headers=headers, json=dict(identity=identity))
+    signin_options = response.json["response"]["credential_options"]
+    response_url = f'wan-signin/{response.json["response"]["wan_state"]}'
+    return signin_options, response_url
+
+
+@pytest.mark.settings(webauthn_util_cls=TestWebauthnUtil)
+def test_basic(app, client, get_message):
+    clients = client
+    auths = []
+
+    @user_authenticated.connect_via(app)
+    def authned(myapp, user, **extra_args):
+        auths.append((user.email, extra_args["authn_via"]))
+
+    authenticate(clients)
+
+    response = clients.get("/wan-register")
+
+    # post with no name
+    response = clients.post("/wan-register", data=dict())
+    assert get_message("WEBAUTHN_NAME_REQUIRED") in response.data
+
+    register_options, response_url = _register_start(clients)
+    assert register_options["rp"]["name"] == "My Flask App"
+    assert register_options["user"]["name"] == "matt@lp.com"
+    assert not register_options["excludeCredentials"]
+    assert register_options["authenticatorSelection"]["residentKey"] == "preferred"
+    assert register_options["extensions"]["credProps"]
+
+    # Register using the static data above
+    response = clients.post(
+        response_url, data=dict(credential=json.dumps(REG_DATA1)), follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert get_message("WEBAUTHN_REGISTER_SUCCESSFUL", name="testr1") in response.data
+    assert b"testr1" in response.data
+
+    # sign in - simple case use identity so we get back allowCredentials
+    logout(clients)
+    signin_options, response_url = _signin_start(clients, "matt@lp.com")
+    assert signin_options["timeout"] == app.config["SECURITY_WAN_SIGNIN_TIMEOUT"]
+    assert signin_options["userVerification"] == "discouraged"
+    allow_credentials = signin_options["allowCredentials"]
+    assert len(allow_credentials) == 1
+    assert allow_credentials[0]["id"] == REG_DATA1["id"]
+
+    response = clients.post(
+        response_url,
+        data=dict(credential=json.dumps(SIGNIN_DATA1)),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b"Welcome matt@lp.com" in response.data
+    assert len(auths) == 2
+    assert auths[1][1] == ["webauthn"]
+
+    # verify actually logged in
+    response = clients.get("/profile", follow_redirects=False)
+    assert response.status_code == 200
+
+
+@pytest.mark.settings(webauthn_util_cls=TestWebauthnUtil)
+def test_basic_json(app, client, get_message):
+    clients = client
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+
+    auths = []
+
+    @user_authenticated.connect_via(app)
+    def authned(myapp, user, **extra_args):
+        auths.append((user.email, extra_args["authn_via"]))
+
+    authenticate(clients)
+
+    # post with no name
+    response = clients.post("/wan-register", json=dict())
+    assert response.status_code == 400
+    assert response.json["response"]["errors"]["name"][0].encode(
+        "utf-8"
+    ) == get_message("WEBAUTHN_NAME_REQUIRED")
+
+    register_options, response_url = _register_start_json(clients)
+    assert register_options["rp"]["name"] == "My Flask App"
+    assert register_options["user"]["name"] == "matt@lp.com"
+
+    # Register using the static data above
+    response = clients.post(response_url, json=dict(credential=json.dumps(REG_DATA1)))
+    assert response.status_code == 200
+
+    # reset lastuse_datatime so we can verify signing in correctly alters it
+    fake_dt = datetime.datetime(2020, 4, 7, 9, 27)
+    with app.app_context():
+        user = app.security.datastore.find_user(email="matt@lp.com")
+        cred = user.webauthn[0]
+        cred.lastuse_datetime = fake_dt
+        app.security.datastore.put(cred)
+        app.security.datastore.commit()
+
+    response = clients.get("/wan-register", headers=headers)
+    active_creds = response.json["response"]["registered_credentials"]
+    assert active_creds[0]["name"] == "testr1"
+    assert parser.parse(active_creds[0]["lastuse"]) == fake_dt
+
+    # sign in - simple case use identity so we get back allowCredentials
+    logout(clients)
+    signin_options, response_url = _signin_start_json(clients, "matt@lp.com")
+    assert signin_options["userVerification"] == "discouraged"
+    allow_credentials = signin_options["allowCredentials"]
+    assert len(allow_credentials) == 1
+    assert allow_credentials[0]["id"] == REG_DATA1["id"]
+
+    response = clients.post(
+        response_url,
+        json=dict(credential=json.dumps(SIGNIN_DATA1)),
+    )
+    assert response.status_code == 200
+    assert auths[1][1] == ["webauthn"]
+
+    # verify actually logged in
+    response = clients.get("/profile", follow_redirects=False)
+    assert response.status_code == 200
+
+    # fetch credentials and verify lastuse was updated
+    response = clients.get("/wan-register", headers=headers)
+    active_creds = response.json["response"]["registered_credentials"]
+    assert parser.parse(active_creds[0]["lastuse"]) != fake_dt
+
+
+@pytest.mark.settings(webauthn_util_cls=TestWebauthnUtil)
+def test_constraints(app, client, get_message):
+    """Test that nickname is unique for a given user but different users
+    can have the same nickname.
+    Also that credential_id is unique across the app.
+    """
+    clients = client
+
+    authenticate(clients)
+    register_options, response_url = _register_start_json(clients, name="testr3")
+    response = clients.post(response_url, json=dict(credential=json.dumps(REG_DATA1)))
+    assert response.status_code == 200
+
+    # register same name again
+    response = client.post("wan-register", json=dict(name="testr3"))
+    assert response.status_code == 400
+    assert response.json["response"]["errors"]["name"][0].encode(
+        "utf-8"
+    ) == get_message("WEBAUTHN_NAME_INUSE", name="testr3")
+
+    logout(clients)
+
+    # Different user - should get credential id in use error
+    authenticate(clients, email="joe@lp.com")
+    register_options, response_url = _register_start_json(clients, name="testr3")
+    response = clients.post(response_url, json=dict(credential=json.dumps(REG_DATA2)))
+    assert response.status_code == 200
+
+    # Try to register with identical credential ID as other user
+    register_options, response_url = _register_start_json(clients, name="testr4")
+    response = clients.post(response_url, json=dict(credential=json.dumps(REG_DATA1)))
+    assert response.status_code == 400
+    assert response.json["response"]["errors"]["credential"][0].encode(
+        "utf-8"
+    ) == get_message("WEBAUTHN_CREDENTIAL_ID_INUSE")
+
+
+@pytest.mark.settings(webauthn_util_cls=TestWebauthnUtil)
+def test_delete(app, client, get_message):
+    clients = client
+
+    authenticate(client)
+    register_options, response_url = _register_start(clients, name="testr3")
+    response = clients.post(
+        response_url, data=dict(credential=json.dumps(REG_DATA1)), follow_redirects=True
+    )
+    assert response.status_code == 200
+    assert get_message("WEBAUTHN_REGISTER_SUCCESSFUL", name="testr3") in response.data
+
+    response = clients.get("/wan-register")
+    assert b"testr3" in response.data
+
+    """
+    response = clients.post("/wan-delete")
+    assert get_message("WEBAUTHN_NAME_REQUIRED") in response.data
+
+    response = clients.post("/wan-delete", data=dict(name="testr1"))
+    assert response.status_code == 200
+    assert get_message("WEBAUTHN_NAME_NOT_FOUND", name="testr1") in response.data
+    """
+
+    with capture_flashes() as flashes:
+        response = clients.post(
+            "/wan-delete", data=dict(name="testr3"), follow_redirects=True
+        )
+    assert flashes[0]["category"] == "info"
+    assert flashes[0]["message"].encode("utf-8") == get_message(
+        "WEBAUTHN_CREDENTIAL_DELETED", name="testr3"
+    )
+    response = clients.get("/wan-register")
+    assert b"testr3" not in response.data
+
+
+@pytest.mark.settings(webauthn_util_cls=TestWebauthnUtil)
+def test_delete_json(app, client, get_message):
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+
+    clients = client
+
+    authenticate(client)
+    register_options, response_url = _register_start_json(clients, name="testr3")
+    response = clients.post(response_url, json=dict(credential=json.dumps(REG_DATA1)))
+    assert response.status_code == 200
+
+    response = clients.get("/wan-register", headers=headers)
+    active_creds = response.json["response"]["registered_credentials"]
+    assert active_creds[0]["name"] == "testr3"
+
+    response = clients.post("/wan-delete", json=dict())
+    assert response.status_code == 400
+    assert response.json["response"]["errors"]["name"][0].encode(
+        "utf=8"
+    ) == get_message("WEBAUTHN_NAME_REQUIRED")
+
+    response = clients.post("/wan-delete", json=dict(name="testr1"))
+    assert response.status_code == 400
+    assert response.json["response"]["errors"]["name"][0].encode(
+        "utf=8"
+    ) == get_message("WEBAUTHN_NAME_NOT_FOUND", name="testr1")
+
+    response = clients.post("/wan-delete", json=dict(name="testr3"))
+    assert response.status_code == 200

--- a/tox.ini
+++ b/tox.ini
@@ -32,7 +32,10 @@ deps =
     babel==2.7.0
     bcrypt==3.2.0
     bleach==3.2.2
-    cryptography==3.0.0
+    # These 2 come from webauthn requirements
+    cryptography==3.0.0;python_version<'3.8'
+    cryptography==3.4.7;python_version>='3.8'
+    python-dateutil==2.8.2
     # next 2 come from minimums from Flask 1.1.2 and need newer jinja2 for 3.10
     jinja2==2.11.0
     itsdangerous==1.1.0
@@ -43,6 +46,7 @@ deps =
     pyqrcode==1.2
     sqlalchemy==1.3.19
     sqlalchemy-utils==0.36.5
+    webauthn==1.0.0;python_version>='3.8'
     werkzeug==0.16.1
     zxcvbn==4.4.28
 commands =


### PR DESCRIPTION
Make sure can run unit tests w/o webauthn module.

Added WebauthnUtil class to allow for app overriding various parameters - such as 'AuthenticatorSelection'.

We also use it to enable unit tests to be repeatable by allowing a constant challenage and override the origin.

Change returned value of registered_credentials to be a list rather than a dict - to match the WebAuthn spec of allow/excludeCredential.

Return message from verification errors - although these aren't i18n it's really difficult to debug w/o them.

Fix validation of 'name' - must be unique per user - not per application!