### PR TITLE
Webauthn - Add support for all datastores.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -562,6 +562,10 @@ Core - rarely need changing
 
     Default: ``"us-setup-salt"``
 
+.. py:data:: SECURITY_WAN_SALT
+
+    Default: ``"wan-salt"``
+
 .. py:data:: SECURITY_EMAIL_PLAINTEXT
 
     Sends email as plaintext using ``*.txt`` template.
@@ -742,6 +746,7 @@ Registerable
     If username is enabled, is it required as part of registration?
 
     Default: ``False``
+
     .. versionadded:: 4.1.0
 
 
@@ -763,7 +768,7 @@ Registerable
 
 .. py:data:: SECURITY_USERNAME_NORMALIZE_FORM
 
-    Usernames can be unicode normalization is performed using the Python unicodedata.normalize() method.
+    Usernames, by default, are normalized using the Python unicodedata.normalize() method.
 
     Default: ``"NFKD"``
 
@@ -1090,6 +1095,9 @@ Configuration related to the two-factor authentication feature.
 Unified Signin
 --------------
 
+    Unified sign in provides a generalized sign in endpoint that takes an `identity`
+    and a `passcode`.
+
     .. versionadded:: 3.4.0
 
 .. py:data:: SECURITY_UNIFIED_SIGNIN
@@ -1277,6 +1285,51 @@ Trackable
 
     Default: ``False``
 
+WebAuthn
+--------------
+
+    .. versionadded:: 4.2.0
+
+.. py:data:: SECURITY_WEBAUTHN
+
+    To enable this feature - set this to ``True``. Please see :ref:`models` for
+    required additions to your database models.
+
+    Default: ``False``
+
+.. py:data:: SECURITY_WAN_REGISTER_URL
+
+    Endpoint for registering WebAuthn credentials.
+
+    Default: ``"/wan-register"``
+
+.. py:data:: SECURITY_WAN_SIGNIN_URL
+
+    Endpoint for signing in using a WebAuthn credential.
+
+    Default: ``"/wan-signin"``
+
+.. py:data:: SECURITY_WAN_DELETE_URL
+
+    Endpoint for removing a WebAuthn credential.
+
+    Default: ``"/wan-delete"``
+
+.. py:data:: SECURITY_WAN_REGISTER_TEMPLATE
+
+    Default: ``"security/wan_register.html"``
+
+.. py:data:: SECURITY_WAN_SIGNIN_TEMPLATE
+
+    Default: ``"security/wan_signin.html"``
+
+.. py:data:: SECURITY_WAN_RP_NAME
+
+    The Relying Party (that's us!) name passed as part of credential
+    creation. Defined in the `spec <https://www.w3.org/TR/2021/REC-webauthn-2-20210408/#dictionary-pkcredentialentity>`_.
+
+    Default: ``"My Flask App"``
+
 Feature Flags
 -------------
 All feature flags. By default all are 'False'/not enabled.
@@ -1289,6 +1342,7 @@ All feature flags. By default all are 'False'/not enabled.
 * ``SECURITY_CHANGEABLE``
 * ``SECURITY_TWO_FACTOR``
 * :py:data:`SECURITY_UNIFIED_SIGNIN`
+* :py:data:`SECURITY_WEBAUTHN`
 
 URLs and Views
 --------------
@@ -1322,6 +1376,9 @@ A list of all URLs and Views:
 * :py:data:`SECURITY_US_VERIFY_URL`
 * :py:data:`SECURITY_US_VERIFY_SEND_CODE_URL`
 * :py:data:`SECURITY_US_POST_SETUP_VIEW`
+* :py:data:`SECURITY_WAN_REGISTER_URL`
+* :py:data:`SECURITY_WAN_SIGNIN_URL`
+* :py:data:`SECURITY_WAN_DELETE_URL`
 
 Template Paths
 --------------
@@ -1340,6 +1397,8 @@ A list of all templates:
 * :py:data:`SECURITY_US_SIGNIN_TEMPLATE`
 * :py:data:`SECURITY_US_SETUP_TEMPLATE`
 * :py:data:`SECURITY_US_VERIFY_TEMPLATE`
+* :py:data:`SECURITY_WAN_REGISTER_TEMPLATE`
+* :py:data:`SECURITY_WAN_SIGNIN_TEMPLATE`
 
 Messages
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ extensions out of the box for data persistence:
 1. `Flask-SQLAlchemy <https://pypi.python.org/pypi/flask-sqlalchemy/>`_
 2. `Flask-MongoEngine <https://pypi.python.org/pypi/flask-mongoengine/>`_
 3. `Peewee Flask utils <https://docs.peewee-orm.com/en/latest/peewee/playhouse.html#flask-utils>`_
-4. `PonyORM <https://pypi.python.org/pypi/pony/>`_
+4. `PonyORM <https://pypi.python.org/pypi/pony/>`_ - NOTE: not currently supported.
 5. `SQLAlchemy sessions <https://docs.sqlalchemy.org/en/14/orm/session_basics.html>`_
 
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -12,7 +12,14 @@
 
 # flake8: noqa: F401
 from .changeable import admin_change_password
-from .core import Security, RoleMixin, UserMixin, AnonymousUser, current_user
+from .core import (
+    Security,
+    RoleMixin,
+    UserMixin,
+    WebAuthnMixin,
+    AnonymousUser,
+    current_user,
+)
 from .datastore import (
     UserDatastore,
     SQLAlchemyUserDatastore,

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -733,12 +733,6 @@ class MongoEngineUserDatastore(MongoEngineDatastore, UserDatastore):
                 obj = self.user_model.objects(query).first()
         except ValidationError:  # pragma: no cover
             return None
-        if obj and "webauthn" in obj:
-            # Alas py-webauthn used Pydantic that doesn't allow sub-classing
-            # and Mongoengine returns a Binary(bytes) instance.
-            for w in obj.webauthn:
-                w.credential_id = bytes(w.credential_id)
-                w.public_key = bytes(w.public_key)
         return obj
 
     def find_role(self, role):
@@ -751,9 +745,6 @@ class MongoEngineUserDatastore(MongoEngineDatastore, UserDatastore):
         obj = self.webauthn_model.objects(  # type: ignore
             credential_id=credential_id
         ).first()
-        if obj:
-            obj.credential_id = bytes(obj.credential_id)
-            obj.public_key = bytes(obj.public_key)
         return obj
 
     def create_webauthn(self, user: "User", **kwargs: t.Any) -> None:

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -133,6 +133,11 @@ class UserDatastore:
         datastore (by calling self.put(<object>). If the datastore is session based
         (such as for SQLAlchemyDatastore) it is up to caller to actually
         commit the transaction by calling datastore.commit().
+
+
+    .. note::
+        You must implement get_user_mapping in your WebAuthn model
+        if your User model doesn't have a primary key Column called 'id'
     """
 
     def __init__(
@@ -168,18 +173,15 @@ class UserDatastore:
 
         return kwargs
 
-    def find_user(
-        self, case_insensitive: bool = False, **kwargs: t.Any
-    ) -> t.Union["User", None]:
-        """Returns a user matching the provided parameters."""
+    def find_user(self, **kwargs: t.Any) -> t.Union["User", None]:
+        """Returns a user matching the provided parameters.
+        Besides keyword arguments used to filter the results,
+        'case_insensitive' can be passed (defaults to False)
+        """
         raise NotImplementedError
 
     def find_role(self, role: str) -> t.Union["Role", None]:
         """Returns a role matching the provided name."""
-        raise NotImplementedError
-
-    def find_webauthn(self, **kwargs: t.Any) -> t.Union["WebAuthn", None]:
-        """Returns a credential matching the id."""
         raise NotImplementedError
 
     def add_role_to_user(self, user: "User", role: t.Union["Role", str]) -> bool:
@@ -556,27 +558,35 @@ class UserDatastore:
     def create_webauthn(self, user: "User", **kwargs: t.Any) -> None:
         """
         Create a new webauthn registration record.
+        Note that we need to find webauthn records per user as well as
+        find a user from a given webauthn (credential_id) record.
 
         .. versionadded: 4.2.0
         """
-
-        if not hasattr(self, "webauthn_model") or not self.webauthn_model:
-            raise NotImplementedError
-        if not all(
-            k in kwargs for k in ["name", "credential_id", "public_key", "sign_count"]
-        ):
-            raise ValueError("Missing kwarg for webauthn registration")
-        webauthn = self.webauthn_model(
-            lastuse_datetime=datetime.datetime.utcnow(), **kwargs
-        )
-        user.webauthn.append(webauthn)
-        self.put(user)  # type: ignore
+        raise NotImplementedError
 
     def delete_webauthn(self, webauthn: "WebAuthn") -> None:
         """
         .. versionadded: 4.2.0
         """
         self.delete(webauthn)  # type: ignore
+
+    def find_webauthn(self, credential_id: bytes) -> t.Union["WebAuthn", None]:
+        """Returns a credential matching the id.
+
+        .. versionadded: 4.2.0
+        """
+        raise NotImplementedError
+
+    def find_user_from_webauthn(self, webauthn: "WebAuthn") -> t.Union["User", None]:
+        """Returns user associated with this webauthn credential
+
+        .. versionadded: 4.2.0
+        """
+        if not self.webauthn_model:
+            raise NotImplementedError
+        user_filter = webauthn.get_user_mapping()
+        return self.find_user(**user_filter)
 
 
 class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
@@ -629,8 +639,20 @@ class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
     def find_role(self, role: str) -> t.Union["Role", None]:
         return self.role_model.query.filter_by(name=role).first()  # type: ignore
 
-    def find_webauthn(self, **kwargs: t.Any) -> t.Union["WebAuthn", None]:
-        return self.webauthn_model.query.filter_by(**kwargs).first()  # type: ignore
+    def find_webauthn(self, credential_id: bytes) -> t.Union["WebAuthn", None]:
+        return self.webauthn_model.query.filter_by(  # type: ignore
+            credential_id=credential_id
+        ).first()
+
+    def create_webauthn(self, user: "User", **kwargs: t.Any) -> None:
+        if not hasattr(self, "webauthn_model") or not self.webauthn_model:
+            raise NotImplementedError
+        webauthn = self.webauthn_model(
+            lastuse_datetime=datetime.datetime.utcnow(), **kwargs
+        )
+        user.webauthn.append(webauthn)
+        self.put(webauthn)  # type: ignore
+        self.put(user)  # type: ignore
 
 
 class SQLAlchemySessionUserDatastore(SQLAlchemyUserDatastore, SQLAlchemyDatastore):
@@ -704,16 +726,47 @@ class MongoEngineUserDatastore(MongoEngineDatastore, UserDatastore):
                     raise ValueError("Case insensitive option only supports single key")
                 attr, identifier = kwargs.popitem()
                 query = {f"{attr}__iexact": identifier}
-                return self.user_model.objects(**query).first()
+                obj = self.user_model.objects(**query).first()
             else:
                 queries = map(lambda i: Q(**{i[0]: i[1]}), kwargs.items())
                 query = QCombination(QCombination.AND, queries)
-                return self.user_model.objects(query).first()
+                obj = self.user_model.objects(query).first()
         except ValidationError:  # pragma: no cover
             return None
+        if obj and "webauthn" in obj:
+            # Alas py-webauthn used Pydantic that doesn't allow sub-classing
+            # and Mongoengine returns a Binary(bytes) instance.
+            for w in obj.webauthn:
+                w.credential_id = bytes(w.credential_id)
+                w.public_key = bytes(w.public_key)
+        return obj
 
     def find_role(self, role):
         return self.role_model.objects(name=role).first()
+
+    def find_webauthn(self, credential_id: bytes) -> t.Union["WebAuthn", None]:
+        if not self.webauthn_model:
+            raise NotImplementedError
+
+        obj = self.webauthn_model.objects(  # type: ignore
+            credential_id=credential_id
+        ).first()
+        if obj:
+            obj.credential_id = bytes(obj.credential_id)
+            obj.public_key = bytes(obj.public_key)
+        return obj
+
+    def create_webauthn(self, user: "User", **kwargs: t.Any) -> None:
+        if not hasattr(self, "webauthn_model") or not self.webauthn_model:
+            raise NotImplementedError
+        webauthn = self.webauthn_model(
+            lastuse_datetime=datetime.datetime.utcnow(),
+            user=user,
+            **kwargs,
+        )
+        user.webauthn.append(webauthn)
+        self.put(webauthn)  # type: ignore
+        self.put(user)  # type: ignore
 
 
 class PeeweeUserDatastore(PeeweeDatastore, UserDatastore):
@@ -722,12 +775,6 @@ class PeeweeUserDatastore(PeeweeDatastore, UserDatastore):
     `Peewee Flask utils \
        <https://docs.peewee-orm.com/en/latest/peewee/playhouse.html#flask-utils>`_
     for datastore transactions.
-
-    :param db:
-    :param user_model: See :ref:`Models <models_topic>`.
-    :param role_model: See :ref:`Models <models_topic>`.
-    :param role_link:
-    :param webauthn_model: See :ref:`Models <models_topic>`.
     """
 
     def __init__(self, db, user_model, role_model, role_link, webauthn_model=None):
@@ -736,6 +783,7 @@ class PeeweeUserDatastore(PeeweeDatastore, UserDatastore):
         :param user_model: A user model class definition
         :param role_model: A role model class definition
         :param role_link: A model implementing the many-to-many user-role relation
+        :param webauthn_model: A webauthn model class definition
 
         """
         PeeweeDatastore.__init__(self, db)
@@ -812,6 +860,24 @@ class PeeweeUserDatastore(PeeweeDatastore, UserDatastore):
             return True
         else:
             return False
+
+    def find_webauthn(self, credential_id):
+        if not self.webauthn_model:
+            raise NotImplementedError
+        try:
+            return self.webauthn_model.filter(credential_id=credential_id).get()
+        except self.webauthn_model.DoesNotExist:
+            return None
+
+    def create_webauthn(self, user: "User", **kwargs: t.Any) -> None:
+        if not hasattr(self, "webauthn_model") or not self.webauthn_model:
+            raise NotImplementedError
+        webauthn = self.webauthn_model(
+            lastuse_datetime=datetime.datetime.utcnow(),
+            user=user,
+            **kwargs,
+        )
+        self.put(webauthn)  # type: ignore
 
 
 class PonyUserDatastore(PonyDatastore, UserDatastore):
@@ -916,9 +982,8 @@ if t.TYPE_CHECKING:  # pragma: no cover
         public_key: bytes
         sign_count: int
         transports: t.Optional[str]
-        create_datetime: datetime.datetime
         lastuse_datetime: datetime.datetime
-        user_id: str
+        user_id: int
 
         def __init__(self, **kwargs):
             ...

--- a/flask_security/models/fsqla_v3.py
+++ b/flask_security/models/fsqla_v3.py
@@ -21,6 +21,7 @@ from sqlalchemy.sql import func
 from .fsqla_v2 import FsModels as FsModelsV2
 from .fsqla_v2 import FsUserMixin as FsUserMixinV2
 from .fsqla_v2 import FsRoleMixin as FsRoleMixinV2
+from flask_security import WebAuthnMixin
 
 
 class FsModels(FsModelsV2):
@@ -37,7 +38,9 @@ class FsUserMixin(FsUserMixinV2):
     # List of WebAuthn registrations
     @declared_attr
     def webauthn(cls):
-        return FsModels.db.relationship("WebAuthn", backref="users")
+        return FsModels.db.relationship(
+            "WebAuthn", backref="users", cascade="all, delete"
+        )
 
     # a unique user id (ala fs_uniquifier). This allows us to separately invalidate
     # all webauthn registrations. Note max length 64 as specified in spec.
@@ -57,11 +60,11 @@ class FsUserMixin(FsUserMixinV2):
         )
 
 
-class FsWebAuthnMixin:
+class FsWebAuthnMixin(WebAuthnMixin):
     """WebAuthn"""
 
     id = Column(Integer, primary_key=True)
-    credential_id = Column(LargeBinary(1024), unique=True, nullable=False)
+    credential_id = Column(LargeBinary(1024), index=True, unique=True, nullable=False)
     public_key = Column(LargeBinary, nullable=False)
     sign_count = Column(Integer, default=0)
     transports = Column(String(255), nullable=True)  # comma separated

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -26,6 +26,6 @@ pytest-cov
 pytest
 sqlalchemy
 sqlalchemy-utils
-webauthn>=1.0.0;python_version>='3.8'
+webauthn>=1.2.0;python_version>='3.8'
 werkzeug
 zxcvbn

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -17,7 +17,7 @@ mongoengine
 mongomock
 msgcheck
 passlib
-pony>=0.7.11;python_version<'3.9'
+pony>=0.7.14;python_version<'3.10'
 phonenumberslite
 pydocstyle
 pyqrcode

--- a/requirements/tests_low.txt
+++ b/requirements/tests_low.txt
@@ -23,6 +23,6 @@ phonenumberslite==8.11.1
 pyqrcode==1.2
 sqlalchemy==1.3.19
 sqlalchemy-utils==0.36.5
-webauthn==1.0.0;python_version>='3.8'
+webauthn==1.2.0;python_version>='3.8'
 werkzeug==0.16.1
 zxcvbn==4.4.28

--- a/requirements/tests_low.txt
+++ b/requirements/tests_low.txt
@@ -1,0 +1,28 @@
+# Lowest supported versions
+Flask==1.1.2
+Flask-SQLAlchemy==2.4.4
+Flask-Babel==2.0.0
+Flask-Mail==0.9.1
+Flask-Mongoengine==1.0.0
+peewee==3.11.2
+argon2_cffi==20.1.0
+babel==2.7.0
+bcrypt==3.2.0
+bleach==3.2.2
+# These 2 come from webauthn requirements
+cryptography==3.0.0;python_version<'3.8'
+cryptography==3.4.7;python_version>='3.8'
+python-dateutil==2.8.2
+# next 2 come from minimums from Flask 1.1.2 and need newer jinja2 for 3.10
+jinja2==2.11.0
+itsdangerous==1.1.0
+mongoengine==0.22.1
+mongomock==3.22.0
+pony==0.7.14;python_version<'3.10'
+phonenumberslite==8.11.1
+pyqrcode==1.2
+sqlalchemy==1.3.19
+sqlalchemy-utils==0.36.5
+webauthn==1.0.0;python_version>='3.8'
+werkzeug==0.16.1
+zxcvbn==4.4.28

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -451,6 +451,8 @@ def test_uuid(app, request, tmpdir, realdburl):
 
 def test_webauthn(app, datastore):
     importorskip("webauthn")
+    if not datastore.webauthn_model:
+        skip("No WebAuthn model defined")
     init_app_with_options(app, datastore)
 
     with app.app_context():
@@ -480,6 +482,8 @@ def test_webauthn(app, datastore):
 
 def test_webauthn_cascade(app, datastore):
     importorskip("webauthn")
+    if not datastore.webauthn_model:
+        skip("No WebAuthn model defined")
     init_app_with_options(app, datastore)
 
     with app.app_context():

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -10,7 +10,7 @@
 """
 
 import datetime
-from pytest import raises, skip
+from pytest import raises, skip, importorskip
 from tests.test_utils import init_app_with_options, get_num_queries, is_sqlalchemy
 
 from flask_security import RoleMixin, Security, UserMixin, LoginForm, RegisterForm
@@ -450,8 +450,7 @@ def test_uuid(app, request, tmpdir, realdburl):
 
 
 def test_webauthn(app, datastore):
-    if not datastore.webauthn_model:
-        skip("Skipping - no webauthn model defined")
+    importorskip("webauthn")
     init_app_with_options(app, datastore)
 
     with app.app_context():
@@ -480,8 +479,7 @@ def test_webauthn(app, datastore):
 
 
 def test_webauthn_cascade(app, datastore):
-    if not datastore.webauthn_model:
-        skip("Skipping - no webauthn model defined")
+    importorskip("webauthn")
     init_app_with_options(app, datastore)
 
     with app.app_context():

--- a/tox.ini
+++ b/tox.ini
@@ -20,35 +20,7 @@ commands =
 [testenv:py{37,38,39,310,py38}-low]
 deps =
     pytest
-
-    # Lowest supported versions
-    Flask==1.1.2
-    Flask-SQLAlchemy==2.4.4
-    Flask-Babel==2.0.0
-    Flask-Mail==0.9.1
-    Flask-Mongoengine==1.0.0
-    peewee==3.11.2
-    argon2_cffi==20.1.0
-    babel==2.7.0
-    bcrypt==3.2.0
-    bleach==3.2.2
-    # These 2 come from webauthn requirements
-    cryptography==3.0.0;python_version<'3.8'
-    cryptography==3.4.7;python_version>='3.8'
-    python-dateutil==2.8.2
-    # next 2 come from minimums from Flask 1.1.2 and need newer jinja2 for 3.10
-    jinja2==2.11.0
-    itsdangerous==1.1.0
-    mongoengine==0.22.1
-    mongomock==3.22.0
-    pony==0.7.14;python_version<'3.10'
-    phonenumberslite==8.11.1
-    pyqrcode==1.2
-    sqlalchemy==1.3.19
-    sqlalchemy-utils==0.36.5
-    webauthn==1.0.0;python_version>='3.8'
-    werkzeug==0.16.1
-    zxcvbn==4.4.28
+    -r requirements/tests_low.txt
 commands =
     python setup.py compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}


### PR DESCRIPTION
Also - started documentation!

Updated to latest black.

Added tests to make sure that webauthn records are deleted when user record is deleted.

Add index to credential_id for fsqla.

Extract out 'get_user_mapping' method that returns the filter needed by find_user to find a user based on a webauthn record - this should make it easier for applications to override this.

Factor 'low' requirements from tox.ini into separate requirements file - makes it easier to install outside of tox environment.