### PR TITLE
Remove 36 support, add CI support for 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,16 +21,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - {python: '3.6', tox: 'py36-release'}
-          - {python: '3.6', tox: 'py36-low'}
           - {python: '3.7', tox: 'py37-release'}
           - {python: '3.7', tox: 'py37-low'}
           - {python: '3.8', tox: 'py38-release'}
           - {python: '3.8', tox: 'py38-low'}
           - {python: '3.9', tox: 'py39-release'}
           - {python: '3.9', tox: 'py39-low'}
-          - {python: 'pypy3', tox: 'pypy3-release'}
-          - {python: 'pypy3', tox: 'pypy3-low'}
+          - {python: '3.10', tox: 'py310-release'}
+          - {python: '3.10', tox: 'py310-low'}
+          - {python: 'pypy-3.8', tox: 'pypy38-release'}
+          - {python: 'pypy-3.8', tox: 'pypy38-low'}
 
     steps:
       - uses: actions/checkout@v2
@@ -63,21 +63,21 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-python@v2
           with:
-            python-version: "3.8"
+            python-version: "3.9"
         - name: update pip
           run: |
             pip install -U wheel setuptools
             python -m pip install -U pip
-        - name: Style, docs, mypy, nobabel
+        - name: Style, docs, mypy, nobabel, nowebauthn
           run: |
             pip install tox
-            tox -e style -e docs -e nobabel -e mypy
+            tox -e style -e docs -e nobabel -e mypy -e nowebauthn
         - name: Coverage
           run: |
             pip install tox coverage
             tox -e coverage
         - name: Upload coverage to Codecov
-          uses: codecov/codecov-action@v1
+          uses: codecov/codecov-action@v2
           with:
             fail_ci_if_error: false
   realdb:
@@ -103,7 +103,7 @@ jobs:
         - uses: actions/checkout@v2
         - uses: actions/setup-python@v2
           with:
-            python-version: "3.8"
+            python-version: "3.9"
         - name: update pip
           run: |
             pip install -U wheel setuptools

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-    python: python3.8
+    python: python3.9
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.0.1
@@ -17,9 +17,9 @@ repos:
     rev: v2.29.1
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/psf/black
-    rev: 21.11b1
+    rev: 21.12b0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -44,7 +44,6 @@ if get_quart_status():  # pragma: no cover
 
         return functools.update_wrapper(decorator, f)
 
-
 else:
     import flask.cli
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -100,7 +100,6 @@ if get_quart_status():  # pragma: no cover
         _datastore.commit()
         return response
 
-
 else:
 
     def view_commit(response=None):

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -69,6 +69,7 @@ try:
         AuthenticationCredential,
         AuthenticatorTransport,
         PublicKeyCredentialDescriptor,
+        PublicKeyCredentialType,
         RegistrationCredential,
         UserVerificationRequirement,
     )
@@ -597,7 +598,7 @@ def create_credential_list(user: "User") -> t.List["PublicKeyCredentialDescripto
 
     for cred in user.webauthn:
         descriptor = PublicKeyCredentialDescriptor(
-            type="public-key", id=cred.credential_id
+            type=PublicKeyCredentialType.PUBLIC_KEY, id=cred.credential_id
         )
         if cred.transports:
             tlist = cred.transports.split(",")

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms="any",
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=install_requires,
     classifiers=[
         "Environment :: Web Environment",
@@ -54,13 +54,12 @@ setup(
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39,310,py3}-{low,release}
+    py{37,38,39,310,py38}-{low,release}
     mypy
     nowebauthn
     nobabel
@@ -10,14 +10,14 @@ envlist =
     makedist
 skip_missing_interpreters = true
 
-[testenv:py{36,37,38,39,310,py3}-release]
+[testenv:py{37,38,39,310,py38}-release]
 deps =
     -r requirements/tests.txt
 commands =
     python setup.py compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}
 
-[testenv:py{36,37,38,39,310,py3}-low]
+[testenv:py{37,38,39,310,py38}-low]
 deps =
     pytest
 
@@ -73,10 +73,11 @@ deps =
     -r requirements/tests.txt
 commands =
     pip uninstall -y webauthn
+    python setup.py compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}
 
 [testenv:nobabel]
-basepython = python3.8
+basepython = python3.9
 deps =
     -r requirements/tests.txt
 commands =


### PR DESCRIPTION
Had forgotten to add 3.10 to github actions.

Remove 3.6 - it is EOL in a few weeks - and having some issues with test failures.

Mark Flask-Security as Production.