### PR TITLE
Continue webauthn integration with 2FA.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1330,6 +1330,34 @@ WebAuthn
 
     Default: ``"My Flask App"``
 
+.. py:data:: SECURITY_WAN_REGISTER_WITHIN
+
+    Specifies the amount of time a user has before their register
+    token expires. Always pluralize the time unit for this value.
+
+    Default: "30 minutes"
+
+.. py:data:: SECURITY_WAN_REGISTER_TIMEOUT
+
+    Specifies the timeout that is passed as part of PublicKeyCredentialCreationOptions.
+    In milliseconds.
+
+    Default: "60000"
+
+.. py:data:: SECURITY_WAN_SIGNIN_WITHIN
+
+    Specifies the amount of time a user has before their signin
+    token expires. Always pluralize the time unit for this value.
+
+    Default: "1 minutes"
+
+.. py:data:: SECURITY_WAN_SIGNIN_TIMEOUT
+
+    Specifies the timeout that is passed as part of PublicKeyCredentialRequestOptions.
+    In milliseconds.
+
+    Default: "60000"
+
 Feature Flags
 -------------
 All feature flags. By default all are 'False'/not enabled.

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -477,7 +477,7 @@ _default_messages = {
         _("%(username)s is already associated with an account."),
         "error",
     ),
-    "WAN_EXPIRED": (
+    "WEBAUTHN_EXPIRED": (
         _("WebAuthn operation must be completed within %(within)s. Please start over."),
         "error",
     ),
@@ -494,11 +494,11 @@ _default_messages = {
         "error",
     ),
     "WEBAUTHN_CREDENTIAL_DELETED": (
-        _("Successfully deleted WebAuthn credential with name %(name)s"),
+        _("Successfully deleted WebAuthn credential with name: %(name)s"),
         "info",
     ),
     "WEBAUTHN_REGISTER_SUCCESSFUL": (
-        _("Successfully added WebAuthn credential with name %(name)s"),
+        _("Successfully added WebAuthn credential with name: %(name)s"),
         "info",
     ),
     "WEBAUTHN_CREDENTIAL_ID_INUSE": (

--- a/flask_security/templates/security/_menu.html
+++ b/flask_security/templates/security/_menu.html
@@ -2,20 +2,37 @@
 <hr>
 <h2>{{ _fsdomain('Menu') }}</h2>
 <ul>
-  {% if not skip_login_menu %}
-  <li><a href="{{ url_for_security('login') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _fsdomain('Login') }}</a></li>
-  {% endif %}
-  {% if security.unified_signin and not skip_login_menu %}
-  <li><a href="{{ url_for_security('us_signin') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _fsdomain("Unified Sign In") }}</a><br/></li>
-  {% endif %}
-  {% if security.registerable %}
-  <li><a href="{{ url_for_security('register') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _fsdomain('Register') }}</a><br/></li>
-  {% endif %}
-  {% if security.recoverable %}
-  <li><a href="{{ url_for_security('forgot_password') }}">{{ _fsdomain('Forgot password') }}</a><br/></li>
-  {% endif %}
-  {% if security.confirmable %}
-  <li><a href="{{ url_for_security('send_confirmation') }}">{{ _fsdomain('Confirm account') }}</a></li>
+  {% if current_user and current_user.is_authenticated %}
+    {# already authenticated user #}
+    <li><a href="{{ url_for_security('logout') }}">{{ _fsdomain("Sign out") }}</a></li>
+    {% if security.changeable %}
+      <li><a href="{{ url_for_security('change_password') }}">{{ _fsdomain("Change Password") }}</li>
+    {% endif %}
+    {% if security.two_factor %}
+      <li><a href="{{ url_for_security('two_factor_setup') }}">{{ _fsdomain("Two Factor Setup") }}</li>
+    {% endif %}
+    {% if security.unified_signin %}
+      <li><a href="{{ url_for_security('us_setup') }}">{{ _fsdomain("Unified Signin Setup") }}</li>
+    {% endif %}
+    {% if security.webauthn %}
+      <li><a href="{{ url_for_security('wan_register') }}">{{ _fsdomain("WebAuthn Setup") }}</li>
+    {% endif %}
+  {% else %}
+    {% if not skip_login_menu %}
+      <li><a href="{{ url_for_security('login') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _fsdomain('Login') }}</a></li>
+    {% endif %}
+    {% if security.unified_signin and not skip_login_menu %}
+    <li><a href="{{ url_for_security('us_signin') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _fsdomain("Unified Sign In") }}</a><br/></li>
+    {% endif %}
+    {% if security.registerable %}
+    <li><a href="{{ url_for_security('register') }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}">{{ _fsdomain('Register') }}</a><br/></li>
+    {% endif %}
+    {% if security.recoverable %}
+    <li><a href="{{ url_for_security('forgot_password') }}">{{ _fsdomain('Forgot password') }}</a><br/></li>
+    {% endif %}
+    {% if security.confirmable %}
+    <li><a href="{{ url_for_security('send_confirmation') }}">{{ _fsdomain('Confirm account') }}</a></li>
+    {% endif %}
   {% endif %}
 </ul>
 {% endif %}

--- a/flask_security/templates/security/two_factor_setup.html
+++ b/flask_security/templates/security/two_factor_setup.html
@@ -21,7 +21,7 @@
 {% block content %}
     {% include "security/_messages.html" %}
     <h1>{{ _fsdomain("Two-factor authentication adds an extra layer of security to your account") }}</h1>
-    <h2>{{ _fsdomain("In addition to your username and password, you'll need to use a code that we will send you") }}</h2>
+    <h3>{{ _fsdomain("In addition to your username and password, you'll need to use a code.") }}</h3>
     <form action="{{ url_for_security("two_factor_setup") }}" method="POST" name="two_factor_setup_form">
         {{ two_factor_setup_form.hidden_tag() }}
         {% for subfield in two_factor_setup_form.setup %}
@@ -55,12 +55,22 @@
             {{ render_field(two_factor_setup_form.submit) }}
         {% endif %}
     </form>
-    <hr>
-    <form action="{{ url_for_security("two_factor_token_validation") }}" method="POST"
-          name="two_factor_verify_code_form">
-        {{ two_factor_verify_code_form.hidden_tag() }}
-        {{ render_field_with_errors(two_factor_verify_code_form.code) }}
-        {{ render_field(two_factor_verify_code_form.submit) }}
-    </form>
+    {% if security.webauthn and not chosen_method %}
+      <h3>WebAuthn</h3>
+      <div class="fs-div">
+        {{ _fsdomain("This application supports WebAuthn security keys.") }}
+        <a href="{{ url_for_security('wan_register') }}">{{ _fsdomain("You can set them up here.") }}</a>
+      </div>
+    {% endif %}
+    {% if chosen_method %}
+      {# Hide this when first setting up #}
+      <hr>
+      <form action="{{ url_for_security("two_factor_token_validation") }}" method="POST"
+            name="two_factor_verify_code_form">
+          {{ two_factor_verify_code_form.hidden_tag() }}
+          {{ render_field_with_errors(two_factor_verify_code_form.code) }}
+          {{ render_field(two_factor_verify_code_form.submit) }}
+      </form>
+    {% endif %}
     {% include "security/_menu.html" %}
 {% endblock %}

--- a/flask_security/templates/security/two_factor_verify_code.html
+++ b/flask_security/templates/security/two_factor_verify_code.html
@@ -4,24 +4,26 @@
 {% block content %}
     {% include "security/_messages.html" %}
     <h1>{{ _fsdomain("Two-factor Authentication") }}</h1>
-    <h2>{{ _fsdomain("Please enter your authentication code") }}</h2>
-    <form action="{{ url_for_security("two_factor_token_validation") }}" method="POST"
-          name="two_factor_verify_code_form">
-        {{ two_factor_verify_code_form.hidden_tag() }}
-        {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder="enter code") }}
-        {{ render_field(two_factor_verify_code_form.submit) }}
-    </form>
-    <form action="{{ url_for_security("two_factor_rescue") }}" method="POST" name="two_factor_rescue_form">
-        {{ two_factor_rescue_form.hidden_tag() }}
-        {{ render_field_with_errors(two_factor_rescue_form.help_setup) }}
-        {% if problem=="lost_device" %}
-            <div>{{ _fsdomain("The code for authentication was sent to your email address") }}</div>
-        {% endif %}
-        {% if problem=="no_mail_access" %}
-            <div>{{ _fsdomain("A mail was sent to us in order to reset your application account") }}</div>
-        {% endif %}
-        {{ render_field(two_factor_rescue_form.submit) }}
-    </form>
+    {% if chosen_method %}
+      <h2>{{ _fsdomain("Please enter your authentication code generated via: %(method)s", method=chosen_method) }}</h2>
+      <form action="{{ url_for_security("two_factor_token_validation") }}" method="POST"
+            name="two_factor_verify_code_form">
+          {{ two_factor_verify_code_form.hidden_tag() }}
+          {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder="enter code") }}
+          {{ render_field(two_factor_verify_code_form.submit) }}
+      </form>
+      <form action="{{ url_for_security("two_factor_rescue") }}" method="POST" name="two_factor_rescue_form">
+          {{ two_factor_rescue_form.hidden_tag() }}
+          {{ render_field_with_errors(two_factor_rescue_form.help_setup) }}
+          {% if problem=="lost_device" %}
+              <div>{{ _fsdomain("The code for authentication was sent to your email address") }}</div>
+          {% endif %}
+          {% if problem=="no_mail_access" %}
+              <div>{{ _fsdomain("A mail was sent to us in order to reset your application account") }}</div>
+          {% endif %}
+          {{ render_field(two_factor_rescue_form.submit) }}
+      </form>
+    {% endif %}
     {% if has_webauthn %}
       <h2>{{ _fsdomain("Use a registered WebAuthn security key") }}</h2>
       <form action="{{ url_for_security("wan_signin") }}" method="POST"

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -79,8 +79,8 @@
     {% if security.webauthn %}
       <h3>WebAuthn</h3>
       <div class="fs-div">
-        Your application supports WebAuthn security keys. You can set them up
-        <a href="{{ url_for_security('wan_register') }}">here.</a>
+        {{ _fsdomain("This application supports WebAuthn security keys.") }}
+        <a href="{{ url_for_security('wan_register') }}">{{ _fsdomain("You can set them up here.") }}</a>
       </div>
     {% endif %}
     {% if state %}
@@ -91,5 +91,6 @@
         {{ render_field_with_errors(us_setup_validate_form.passcode) }}
         {{ render_field(us_setup_validate_form.submit) }}
       </form>
-    {%  endif %}
+    {% endif %}
+    {% include "security/_menu.html" %}
 {% endblock %}

--- a/flask_security/templates/security/wan_register.html
+++ b/flask_security/templates/security/wan_register.html
@@ -17,6 +17,7 @@
   <h1>{{ _fsdomain("Setup New WebAuthn Security Key") }}</h1>
   {% if not credential_options %}
     {# Initial form to get CreateOptions #}
+    <div>{{ _fsdomain("Start by providing a unique name for your new security key:") }}</div>
     <form action="{{ url_for_security("wan_register") }}" method="POST"
             name="wan_register_form" id="wan-register-form">
         {{ wan_register_form.hidden_tag() }}
@@ -48,10 +49,10 @@
   {% endif %}
 
   {% if registered_credentials %}
-    <h3>Currently registered security keys:</h3>
+    <h3>{{ _fsdomain("Currently registered security keys:") }}</h3>
     <ul>
       {% for cred in registered_credentials %}
-        <li>Nickname: "{{ cred.name }}" transports: "{{ cred.transports }}" discoverable: "{{ cred.discoverable }}" last used on {{ cred.lastuse }}</li>
+        <li>Nickname: "{{ cred.name }}" transports: "{{ cred.transports|join(", ") }}" discoverable: "{{ cred.discoverable }}" last used on {{ cred.lastuse }}</li>
       {% endfor %}
     </ul>
   {% endif %}
@@ -66,4 +67,5 @@
         {{ render_field(wan_delete_form.submit) }}
       </form>
   {% endif %}
+  {% include "security/_menu.html" %}
 {% endblock %}

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -765,7 +765,7 @@ def check_and_get_token_status(
     :param token: The token to check
     :param serializer_name: The name of the serializer. Can be one of the
                        following: ``confirm``, ``login``, ``reset``, ``us_setup``
-                       ``remember``, ``two_factor_validity``
+                       ``remember``, ``two_factor_validity``, ``wan``
     :param within: max age - passed as a timedelta
 
     :return: a tuple of (expired, invalid, data)

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -943,6 +943,7 @@ def two_factor_token_validation():
             cv("TWO_FACTOR_SETUP_TEMPLATE"),
             two_factor_setup_form=setup_form,
             two_factor_verify_code_form=form,
+            chosen_method=pm,
             choices=cv("TWO_FACTOR_ENABLED_METHODS"),
             **_ctx("tf_setup"),
         )
@@ -962,6 +963,7 @@ def two_factor_token_validation():
             cv("TWO_FACTOR_VERIFY_CODE_TEMPLATE"),
             two_factor_rescue_form=rescue_form,
             two_factor_verify_code_form=form,
+            chosen_method=pm,
             has_webauthn=has_webauthn,
             wan_signin_form=wan_signin_form,
             problem=None,
@@ -1038,6 +1040,7 @@ def two_factor_rescue():
         cv("TWO_FACTOR_VERIFY_CODE_TEMPLATE"),
         two_factor_verify_code_form=code_form,
         two_factor_rescue_form=form,
+        chosen_method=user.tf_primary_method,
         rescue_mail=cv("TWO_FACTOR_RESCUE_MAIL"),
         problem=rproblem,
         **_ctx("tf_token_validation"),

--- a/flask_security/webauthn_util.py
+++ b/flask_security/webauthn_util.py
@@ -19,7 +19,7 @@ try:
         AuthenticatorSelectionCriteria,
         ResidentKeyRequirement,
     )
-except ImportError:
+except ImportError:  # pragma: no cover
     pass
 
 
@@ -29,6 +29,16 @@ if t.TYPE_CHECKING:  # pragma: no cover
 
 
 class WebauthnUtil:
+    """
+    Utility class allowing an application to fine-tune various Relying Party
+    attributes.
+
+    To provide your own implementation, pass in the class as ``webauthn_util_cls``
+    at init time.  Your class will be instantiated once as part of app initialization.
+
+    .. versionadded:: 4.2.0
+    """
+
     def __init__(self, app: "flask.Flask"):
         """Instantiate class.
 
@@ -48,15 +58,19 @@ class WebauthnUtil:
         """
         Part of the registration ceremony is providing information about what kind
         of authenticators the app is interested in.
-        See: https://www.w3.org/TR/2021/REC-webauthn-2-20210408
-        /#dictionary-authenticatorSelection
+        See: https://www.w3.org/TR/2021/REC-webauthn-2-20210408/#dictionary-authenticatorSelection
 
-        Simply - if the key isn't resident then it isn't discoverable which means that
+        The main options are:
+            - whether you want a ResidentKey (discoverable)
+            - Attachment - platform or cross-platform
+            - Does the key have to provide user-verification
+
+        Note1 - if the key isn't resident then it isn't discoverable which means that
         the user won't be able to use that key unless they identify themselves
         (use the key as a second factor OR type in their identity). If they are forced
         to type in their identity PRIOR to be authenticated, then there is the
         possibility that the app will leak username information.
-        """
+        """  # noqa: E501
         return AuthenticatorSelectionCriteria(
             resident_key=ResidentKeyRequirement.PREFERRED
         )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r docs.txt
 -r tests.txt
-mypy
+mypy==0.910
 wheel
 psycopg2
 pymysql

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -362,14 +362,14 @@ def test_two_factor_flag(app, client):
     response = client.post("/tf-validate", data=dict(code=wrong_code))
     assert b"Invalid Token" in response.data
 
-    # sumbit right token and show appropriate response
+    # submit right token and show appropriate response
     response = client.post("/tf-validate", data=dict(code=code), follow_redirects=True)
     assert b"Your token has been confirmed" in response.data
 
-    # Upon completion, session cookie shouldnt have any two factor stuff in it.
+    # Upon completion, session cookie shouldn't have any two factor stuff in it.
     assert not tf_in_session(get_session(response))
 
-    # Test change two_factor view to from sms to mail
+    # Test change two_factor view from sms to mail
     with app.mail.record_messages() as outbox:
         setup_data = dict(setup="email")
         response = client.post("/tf-setup", data=setup_data, follow_redirects=True)
@@ -379,10 +379,11 @@ def test_two_factor_flag(app, client):
         # Fetch token validate form
         response = client.get("/tf-validate")
         assert response.status_code == 200
+        # make sure two_factor_verify_code_form is set
         assert b'name="code"' in response.data
 
     code = outbox[0].body.split()[-1]
-    # sumbit right token and show appropriate response
+    # submit right token and show appropriate response
     response = client.post("/tf-validate", data=dict(code=code), follow_redirects=True)
     assert b"You successfully changed your two-factor method" in response.data
 
@@ -449,7 +450,7 @@ def test_two_factor_flag(app, client):
     assert b"Open an authenticator app on your device" in response.data
     assert b"data:image/svg+xml;base64," in response.data
 
-    # check appearence of setup page when sms picked and phone number entered
+    # check appearance of setup page when sms picked and phone number entered
     sms_sender = SmsSenderFactory.createSender("test")
     data = dict(setup="sms", phone="+442083661177")
     response = client.post("/tf-setup", data=data, follow_redirects=True)

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -141,7 +141,7 @@ def create_app():
 
     # Setup Flask-Security
     user_datastore = SQLAlchemyUserDatastore(db, User, Role, WebAuthn)
-    Security(app, user_datastore, webauthn_util_cls=TestWebauthnUtil)
+    security = Security(app, user_datastore, webauthn_util_cls=TestWebauthnUtil)
 
     try:
         import flask_babel
@@ -221,9 +221,13 @@ def create_app():
     @login_required
     def home():
         return render_template_string(
-            "{% include 'security/_messages.html' %}"
-            "{{ _fsdomain('Welcome') }} {{email}} !",
+            """
+            {% include 'security/_messages.html' %}
+            {{ _fsdomain('Welcome') }} {{email}} !
+            {% include "security/_menu.html" %}
+            """,
             email=current_user.email,
+            security=security,
         )
 
     @app.route("/basicauth")

--- a/tox.ini
+++ b/tox.ini
@@ -106,7 +106,7 @@ commands =
 deps =
     -r requirements/tests.txt
     types-setuptools
-    mypy
+    mypy==0.910
     sqlalchemy[mypy]
 commands =
     mypy --install-types --non-interactive flask_security tests


### PR DESCRIPTION
Many of these changes are in templates:
- improve menu to have appropriate options based on authenticated or not
- 2FA can now have more than one option - the 'old' way (SMS, email, authenticator) and webauthn. Have the templates take that into account.

Still more todo - we need to somehow ask user WHICH 2FA mechanism they want if there is more than one configured.

Add option in tf-setup template to register a webauthn key.

Fix tf forms to call super-class validate so that errors gets initialized appropriately - both those forms had an email element that was never used - removed that.

webauthn - fix transports and added test so we don't break it again.

webauthn - lots more unit tests.