### PR TITLE
Add webauthn configuration options.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
     python: python3.9
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.1.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.29.1
+    rev: v2.31.0
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1335,28 +1335,58 @@ WebAuthn
     Specifies the amount of time a user has before their register
     token expires. Always pluralize the time unit for this value.
 
-    Default: "30 minutes"
+    Default: ``"30 minutes"``
 
 .. py:data:: SECURITY_WAN_REGISTER_TIMEOUT
 
     Specifies the timeout that is passed as part of PublicKeyCredentialCreationOptions.
     In milliseconds.
 
-    Default: "60000"
+    Default: ``60000``
 
 .. py:data:: SECURITY_WAN_SIGNIN_WITHIN
 
     Specifies the amount of time a user has before their signin
     token expires. Always pluralize the time unit for this value.
 
-    Default: "1 minutes"
+    Default: ``"1 minutes"``
 
 .. py:data:: SECURITY_WAN_SIGNIN_TIMEOUT
 
     Specifies the timeout that is passed as part of PublicKeyCredentialRequestOptions.
     In milliseconds.
 
-    Default: "60000"
+    Default: ``60000``
+
+.. py:data:: SECURITY_WAN_ALLOW_AS_FIRST_FACTOR
+
+    If True then a WebAuthn credential/key may be used as the first (or only)
+    authentication factor. This will set the default ``AuthenticatorSelectionCriteria``
+    to require a cross-platform key.
+
+    Default: ``True``
+
+.. py:data:: SECURITY_WAN_ALLOW_AS_MULTI_FACTOR
+
+    If True then a WebAuthn credential/key can be used
+    as both a primary and a secondary factor. This requires that the key
+    supports 'UserVerification'.
+
+    Default: ``True``
+
+.. py:data:: SECURITY_WAN_ALLOW_USER_HINTS
+
+    If True then an unauthenticated user can request a list of registered
+    WebAuthn credentials/keys. This allows the use of non-resident (non-discoverable)
+    keys, but has the possible security concern that it allows 'user discovery'.
+    Look at https://www.w3.org/TR/2021/REC-webauthn-2-20210408/#sctn-username-enumeration
+    for a good writeup.
+
+    If this is ``False`` and :py:data:`SECURITY_WAN_ALLOW_AS_FIRST_FACTOR` is ``True``
+    (the default) then by default, ``AuthenticatorSelectionCriteria`` will be set
+    to require a Resident key.
+
+    Default: ``False``
 
 Feature Flags
 -------------

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -320,6 +320,9 @@ _default_config: t.Dict[str, t.Any] = {
     "WAN_SIGNIN_URL": "/wan-signin",
     "WAN_SIGNIN_WITHIN": "1 minutes",
     "WAN_DELETE_URL": "/wan-delete",
+    "WAN_ALLOW_AS_FIRST_FACTOR": True,
+    "WAN_ALLOW_AS_MULTI_FACTOR": True,
+    "WAN_ALLOW_USER_HINTS": False,
 }
 
 #: Default Flask-Security messages

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -227,19 +227,22 @@ def tf_validity_token_status(token):
     )
 
 
-def tf_verify_validility_token(token, fs_uniquifier):
-    """Returns the status of the Two-Factor Validity token
+def tf_verify_validity_token(fs_uniquifier: str) -> bool:
+    """Returns the status of the Two-Factor Validity token based on the current
+    request.
 
-    :param token: The Two-Factor Validity token
     :param fs_uniquifier: The ``fs_uniquifier`` of the submitting user.
     """
+    if request.is_json and request.content_length:
+        token = request.get_json().get("tf_validity_token", None)  # type: ignore
+    else:
+        token = request.cookies.get("tf_validity", default=None)
+
     if token is None:
         return False
 
     expired, invalid, uniquifier = tf_validity_token_status(token)
-
     if expired or invalid or (fs_uniquifier != uniquifier):
-
         return False
 
     return True

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -75,7 +75,7 @@ from .twofactor import (
     tf_disable,
     tf_login,
     tf_set_validity_token_cookie,
-    tf_verify_validility_token,
+    tf_verify_validity_token,
 )
 from .utils import (
     base_render_json,
@@ -170,18 +170,11 @@ def login() -> "ResponseValue":
     if form.validate_on_submit():
         remember_me = form.remember.data if "remember" in form else None
         if cv("TWO_FACTOR"):
-            if request.is_json and request.content_length:
-                tf_validity_token = request.get_json().get(  # type: ignore
-                    "tf_validity_token", None
-                )
-            else:
-                tf_validity_token = request.cookies.get("tf_validity", default=None)
-
-            tf_validity_token_is_valid = tf_verify_validility_token(
-                tf_validity_token, form.user.fs_uniquifier
+            tf_validity_token_is_valid = tf_verify_validity_token(
+                form.user.fs_uniquifier
             )
 
-            if cv("TWO_FACTOR_REQUIRED") or (is_tf_setup(form.user)):
+            if cv("TWO_FACTOR_REQUIRED") or is_tf_setup(form.user):
                 if cv("TWO_FACTOR_ALWAYS_VALIDATE") or (not tf_validity_token_is_valid):
 
                     return tf_login(

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r docs.txt
 -r tests.txt
-mypy==0.921
+mypy
 wheel
 psycopg2
 pymysql

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,9 +60,14 @@ if t.TYPE_CHECKING:  # pragma: no cover
     from flask.testing import FlaskClient
 
 
+class SecurityFixture(Flask):
+    security: Security
+    mail: Mail
+
+
 @pytest.fixture()
-def app(request: pytest.FixtureRequest) -> "Flask":
-    app = Flask(__name__)
+def app(request: pytest.FixtureRequest) -> "SecurityFixture":
+    app = SecurityFixture(__name__)
     app.response_class = Response
     app.debug = True
     app.config["SECRET_KEY"] = "secret"
@@ -720,11 +725,11 @@ def pony_setup(request, app, tmpdir, realdburl):
 
 @pytest.fixture()
 def sqlalchemy_app(
-    app: "Flask", sqlalchemy_datastore: SQLAlchemyUserDatastore
-) -> t.Callable[[], "Flask"]:
-    def create() -> "Flask":
+    app: SecurityFixture, sqlalchemy_datastore: SQLAlchemyUserDatastore
+) -> t.Callable[[], SecurityFixture]:
+    def create() -> SecurityFixture:
         security = Security(app, datastore=sqlalchemy_datastore)
-        app.security = security  # type: ignore
+        app.security = security
         return app
 
     return create

--- a/tox.ini
+++ b/tox.ini
@@ -106,7 +106,7 @@ commands =
 deps =
     -r requirements/tests.txt
     types-setuptools
-    mypy==0.910
+    mypy
     sqlalchemy[mypy]
 commands =
     mypy --install-types --non-interactive flask_security tests


### PR DESCRIPTION
Added - ALLOW_USER_HINTS - which enables fetching registered credentials while unauthenticated - defaults to False. This affects the
default registration options - when False, then require a resident key.

Added ALLOW_AS_FIRST_FACTOR - default True - if false then wan-signin will return 404 if not part of a second factor. If this is True (the default) then register options requires a cross-platform key.

Added ALLOW_AS_MULTI_FACTOR - not implemented yet - this made it clear we need to augment the model so that particular credentials are tagged as either first or secondary allowed.

Improve typing of unit tests.

Changed tf_verify_validity_token to use current request and remove 3-4 copies of same code.