### PR TITLE
Two factor improvements.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,6 +103,7 @@ nitpick_ignore = [
     ("py:class", "ResponseValue"),
     ("py:class", "function"),
     ("py:class", "AuthenticatorSelectionCriteria"),
+    ("py:class", "UserVerificationRequirement"),
 ]
 autodoc_typehints = "description"
 # autodoc_mock_imports = ["flask_sqlalchemy"]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1360,7 +1360,7 @@ WebAuthn
 
 .. py:data:: SECURITY_WAN_ALLOW_AS_FIRST_FACTOR
 
-    If True then a WebAuthn credential/key may be used as the first (or only)
+    If True then a WebAuthn credential/key may be registered for use as the first (or only)
     authentication factor. This will set the default ``AuthenticatorSelectionCriteria``
     to require a cross-platform key.
 
@@ -1386,7 +1386,7 @@ WebAuthn
     (the default) then by default, ``AuthenticatorSelectionCriteria`` will be set
     to require a Resident key.
 
-    Default: ``False``
+    Default: ``True``
 
 Feature Flags
 -------------
@@ -1523,8 +1523,19 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_US_SPECIFY_IDENTITY``
 * ``SECURITY_MSG_USE_CODE``
 * ``SECURITY_MSG_USER_DOES_NOT_EXIST``
-* ``SECURITY_USERNAME_INVALID_LENGTH``
-* ``SECURITY_USERNAME_ILLEGAL_CHARACTERS``
-* ``SECURITY_USERNAME_DISALLOWED_CHARACTERS``
-* ``SECURITY_USERNAME_NOT_PROVIDED``
-* ``SECURITY_USERNAME_ALREADY_ASSOCIATED``
+* ``SECURITY_MSG_USERNAME_INVALID_LENGTH``
+* ``SECURITY_MSG_USERNAME_ILLEGAL_CHARACTERS``
+* ``SECURITY_MSG_USERNAME_DISALLOWED_CHARACTERS``
+* ``SECURITY_MSG_USERNAME_NOT_PROVIDED``
+* ``SECURITY_MSG_USERNAME_ALREADY_ASSOCIATED``
+* ``SECURITY_MSG_WEBAUTHN_EXPIRED``
+* ``SECURITY_MSG_WEBAUTHN_NAME_REQUIRED``
+* ``SECURITY_MSG_WEBAUTHN_NAME_INUSE``
+* ``SECURITY_MSG_WEBAUTHN_NAME_NOT_FOUND``
+* ``SECURITY_MSG_WEBAUTHN_CREDENTIAL_DELETED``
+* ``SECURITY_MSG_WEBAUTHN_REGISTER_SUCCESSFUL``
+* ``SECURITY_MSG_WEBAUTHN_CREDENTIAL_ID_INUSE``
+* ``SECURITY_MSG_WEBAUTHN_UNKNOWN_CREDENTIAL_ID``
+* ``SECURITY_MSG_WEBAUTHN_ORPHAN_CREDENTIAL_ID``
+* ``SECURITY_MSG_WEBAUTHN_NO_VERIFY``
+* ``SECURITY_MSG_WEBAUTHN_CREDENTIAL_WRONG_USAGE``

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -159,6 +159,16 @@ If you disable the freshness check then sessions aren't required.
     * Registration and Confirmation only work with email - so while you can enable multiple
       authentication methods, you still have to register with email.
 
+.. _webauthn:
+
+WebAuthn
+---------------
+**This feature is in Beta - mostly due to it being brand new and little to no production soak time**
+
+WebAuthn is a standardized protocol that connects authenticators (such as YubiKey and mobile biometrics)
+with websites. Flask-Security supports using WebAuthn keys as either 'first' or 'secondary'
+authenticators.
+
 Email Confirmation
 ------------------
 
@@ -243,6 +253,7 @@ JSON is supported for the following operations:
 * Passwordless login requests
 * Two-factor login requests
 * Change two-factor method requests
+* WebAuthn registration and signin requests
 
 In addition, Single-Page-Applications (like those built with Vue, Angular, and
 React) are supported via customizable redirect links.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Flask application. They include:
 10. User registration (optional)
 11. Login tracking (optional)
 12. JSON/Ajax Support
+13. WebAuthn Support (optional)
 
 Many of these features are made possible by integrating various Flask extensions
 and libraries. They include:
@@ -37,6 +38,7 @@ and libraries. They include:
 * `itsdangerous <https://pypi.org/project/itsdangerous/>`_
 * `passlib <https://pypi.org/project/passlib/>`_
 * `PyQRCode <https://pypi.org/project/PyQRCode/>`_
+* `webauthn <https://pypi.org/project/webauthn/>`_
 
 Additionally, it assumes you'll be using a common library for your database
 connections and model definitions. Flask-Security supports the following Flask

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -126,16 +126,17 @@ Flask-Security must be able to locate a User record based on a credential id.
     It is important that you maintain data consistency when deleting WebAuthn
     records or users.
 
-A new model 'WebAuthn' requires the following fields:
+The 'WebAuthn' model requires the following fields:
 
 * ``id`` (primary key)
 * ``credential_id`` (binary, 1024 bytes, indexed, non-nullable, unique)
 * ``public_key`` (binary, 1024 bytes, non-nullable)
-* ``sign_count`` (integer, default=0)
-* ``transports`` (string, 255 bytes)
+* ``sign_count`` (integer, default=0, non-nullable)
+* ``transports`` (list of string)
 * ``extensions`` (string, 255 bytes)
 * ``lastuse_datetime`` (datetime, non-nullable)
 * ``name`` (string, 64 bytes, non-nullable)
+* ``usage`` (string, 64 bytes, non-nullable)
 
 It also needs a reference to the owning `User` record. The shipped datastore
 implementations depend on the following:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -59,7 +59,7 @@ possible using Flask-SQLAlchemy and the built-in model mixins:
     from flask import Flask, render_template_string
     from flask_sqlalchemy import SQLAlchemy
     from flask_security import Security, SQLAlchemyUserDatastore, auth_required, hash_password
-    from flask_security.models import fsqla_v2 as fsqla
+    from flask_security.models import fsqla_v3 as fsqla
 
     # Create app
     app = Flask(__name__)

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -322,7 +322,7 @@ _default_config: t.Dict[str, t.Any] = {
     "WAN_DELETE_URL": "/wan-delete",
     "WAN_ALLOW_AS_FIRST_FACTOR": True,
     "WAN_ALLOW_AS_MULTI_FACTOR": True,
-    "WAN_ALLOW_USER_HINTS": False,
+    "WAN_ALLOW_USER_HINTS": True,
 }
 
 #: Default Flask-Security messages
@@ -518,6 +518,10 @@ _default_messages = {
     ),
     "WEBAUTHN_NO_VERIFY": (
         _("Could not verify WebAuthn credential: %(cause)s."),
+        "error",
+    ),
+    "WEBAUTHN_CREDENTIAL_WRONG_USAGE": (
+        _("Credential not registered for this use (first or secondary)"),
         "error",
     ),
 }

--- a/flask_security/models/fsqla_v3.py
+++ b/flask_security/models/fsqla_v3.py
@@ -1,5 +1,5 @@
 """
-Copyright 2021 by J. Christopher Wagner (jwag). All rights reserved.
+Copyright 2021-2022 by J. Christopher Wagner (jwag). All rights reserved.
 :license: MIT, see LICENSE for more details.
 
 
@@ -16,12 +16,27 @@ This is Version 3:
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, LargeBinary, String
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.sql import func
+import sqlalchemy.types as types
 
 
 from .fsqla_v2 import FsModels as FsModelsV2
 from .fsqla_v2 import FsUserMixin as FsUserMixinV2
 from .fsqla_v2 import FsRoleMixin as FsRoleMixinV2
 from flask_security import WebAuthnMixin
+
+
+class AsaList(types.TypeDecorator):
+    impl = types.String
+
+    def process_bind_param(self, value, dialect):
+        if value:
+            return ",".join(value)
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value:
+            return value.split(",")
+        return value
 
 
 class FsModels(FsModelsV2):
@@ -47,7 +62,7 @@ class FsUserMixin(FsUserMixinV2):
     fs_webauthn_uniquifier = Column(String(64), unique=True, nullable=True)
 
     # 2FA - one time recovery codes - comma separated.
-    tf_recovery_codes = Column(String(1024), nullable=True)
+    tf_recovery_codes = Column(AsaList(1024), nullable=True)
 
     # This is repeated since I couldn't figure out how to have it reference the
     # new version of FsModels.
@@ -67,7 +82,7 @@ class FsWebAuthnMixin(WebAuthnMixin):
     credential_id = Column(LargeBinary(1024), index=True, unique=True, nullable=False)
     public_key = Column(LargeBinary, nullable=False)
     sign_count = Column(Integer, default=0)
-    transports = Column(String(255), nullable=True)  # comma separated
+    transports = Column(AsaList(255), nullable=True)  # comma separated
 
     # a JSON string as returned from registration
     extensions = Column(String(255), nullable=True)
@@ -75,6 +90,9 @@ class FsWebAuthnMixin(WebAuthnMixin):
     lastuse_datetime = Column(type_=DateTime, nullable=False)
     # name is provided by user - we make sure is unique per user
     name = Column(String(64), nullable=False)
+
+    # Usage - a credential can EITHER be for first factor or secondary factor
+    usage = Column(String(64), nullable=False)
 
     @declared_attr
     def user_id(cls):

--- a/flask_security/templates/security/wan_register.html
+++ b/flask_security/templates/security/wan_register.html
@@ -22,6 +22,9 @@
             name="wan_register_form" id="wan-register-form">
         {{ wan_register_form.hidden_tag() }}
         {{ render_field_with_errors(wan_register_form.name) }}
+        {% if security.wan_allow_as_first_factor %}
+          {{ render_field_with_errors(wan_register_form.usage) }}
+        {% endif %}
         {{ render_field(wan_register_form.submit) }}
     </form>
   {% else %}
@@ -52,7 +55,7 @@
     <h3>{{ _fsdomain("Currently registered security keys:") }}</h3>
     <ul>
       {% for cred in registered_credentials %}
-        <li>Nickname: "{{ cred.name }}" transports: "{{ cred.transports|join(", ") }}" discoverable: "{{ cred.discoverable }}" last used on {{ cred.lastuse }}</li>
+        <li>Nickname: "{{ cred.name }}" Usage: "{{ cred.usage }}" transports: "{{ cred.transports|join(", ") }}" discoverable: "{{ cred.discoverable }}" last used on {{ cred.lastuse }}</li>
       {% endfor %}
     </ul>
   {% endif %}

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -132,9 +132,12 @@ def tf_disable(user):
     tf_disabled.send(app._get_current_object(), user=user)
 
 
-def is_tf_setup(user):
+def is_tf_setup(user, include_webauthn=True):
     """Return True is user account is setup for 2FA."""
-    return (user.tf_totp_secret and user.tf_primary_method) or has_webauthn_tf(user)
+    if include_webauthn:
+        return (user.tf_totp_secret and user.tf_primary_method) or has_webauthn_tf(user)
+    else:
+        return user.tf_totp_secret and user.tf_primary_method
 
 
 def tf_login(user, remember=None, primary_authn_via=None):

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -4,7 +4,7 @@
 
     Flask-Security Unified Signin module
 
-    :copyright: (c) 2019-2020 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 
     This implements a unified sign in endpoint - allowing
@@ -70,7 +70,6 @@ from .utils import (
     url_for_security,
     view_commit,
 )
-from .webauthn import has_webauthn_tf
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from flask.typing import ResponseValue
@@ -666,7 +665,7 @@ def us_verify_link() -> "ResponseValue":
     if (
         cv("TWO_FACTOR")
         and "email" in cv("US_MFA_REQUIRED")
-        and (cv("TWO_FACTOR_REQUIRED") or is_tf_setup(user) or has_webauthn_tf(user))
+        and (cv("TWO_FACTOR_REQUIRED") or is_tf_setup(user))
     ):
         # tf_login doesn't know anything about "spa" etc. In general two-factor
         # isn't quite ready for SPA. So we return an error via a redirect rather

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,3 @@
 Pallets-Sphinx-Themes~=2.0
 Sphinx~=4.3
-sphinx-issues~=1.2
+sphinx-issues==2.0.0

--- a/requirements_low/tests.txt
+++ b/requirements_low/tests.txt
@@ -1,5 +1,5 @@
 # Lowest supported versions
-Flask==1.1.2
+Flask==1.1.4
 Flask-SQLAlchemy==2.4.4
 Flask-Babel==2.0.0
 Flask-Mail==0.9.1
@@ -13,7 +13,7 @@ bleach==3.2.2
 cryptography==3.0.0;python_version<'3.8'
 cryptography==3.4.7;python_version>='3.8'
 python-dateutil==2.8.2
-# next 2 come from minimums from Flask 1.1.2 and need newer jinja2 for 3.10
+# next 2 come from minimums from Flask 1.1.4 and need newer jinja2 for 3.10
 jinja2==2.11.0
 itsdangerous==1.1.0
 mongoengine==0.22.1
@@ -21,8 +21,8 @@ mongomock==3.22.0
 pony==0.7.14;python_version<'3.10'
 phonenumberslite==8.11.1
 pyqrcode==1.2
-sqlalchemy==1.3.19
-sqlalchemy-utils==0.36.5
+sqlalchemy==1.3.24
+sqlalchemy-utils==0.37.1
 webauthn==1.2.0;python_version>='3.8'
 werkzeug==0.16.1
 zxcvbn==4.4.28

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -465,6 +465,7 @@ def test_webauthn(app, datastore):
             sign_count=0,
             transports=None,
             extensions=None,
+            usage="first",
         )
         datastore.commit()
         cred = datastore.find_webauthn(b"1")
@@ -496,6 +497,7 @@ def test_webauthn_cascade(app, datastore):
             sign_count=0,
             transports=None,
             extensions=None,
+            usage="first",
         )
         datastore.create_webauthn(
             user,
@@ -505,6 +507,7 @@ def test_webauthn_cascade(app, datastore):
             sign_count=0,
             transports=None,
             extensions=None,
+            usage="secondary",
         )
         datastore.commit()
 

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -94,7 +94,7 @@ def create_app():
 
     class TestWebauthnUtil(WebauthnUtil):
         def generate_challenge(self, nbytes: t.Optional[int] = None) -> str:
-            # Use a constant Challenge so we can us this app to generate gold
+            # Use a constant Challenge so we can use this app to generate gold
             # responses for use in unit testing. See test_webauthn.
             # NEVER NEVER NEVER do this in production
             return "smCCiy_k2CqQydSQ_kPEjV5a2d0ApfatcpQ1aXDmQPo"


### PR DESCRIPTION
Add 'usage' to model - each webauthn security key must be designated as either a 'first' or 'secondary' key.
This makes it possible to discern which if any webauthn keys might be used as a second factor.

Improve the DB models so that from a API perspective we use lists for say extensions, and convert to comma separated as part of the model (if required).

Add support for using webauthn as 'first' authentication and using other TF for second.

Start more documentation for WebAuthn.

Refactored UserVerification out of signin and made that configurable from webauthn_util.