### PR TITLE
Webauthn improvements.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,13 +14,22 @@ Features
 - (:pr:`532`) Support for Python 3.10
 - (:pr:`540`) Improve Templates in support of JS required by WebAuthn
 - (:pr:`xxx`) Make roles joinedload compatible with SQLAlchemy 2.0
-- (:pr:`xxx`) Deprecate the old passwordless feature in favor of Unified Signin.
+- (:pr:`568`) Deprecate the old passwordless feature in favor of Unified Signin.
    Deprecate replacing login_manager so we can possibly vendor that in in the future.
 
 Fixes
 +++++
 
 
+DB Migration
+~~~~~~~~~~~~
+
+To use the new WebAuthn feature a new table and two new columns in the User model are required.
+To ease updates - Flask-Security will automatically create a fs_webauthn_user_handle
+upon first use for existing users.
+If you are using Alembic the schema migration is easy::
+
+    op.add_column('user', sa.Column('fs_webauthn_user_handle', sa.String(length=64), nullable=True))
 
 Version 4.1.2
 -------------

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -148,7 +148,7 @@ The `User` model needs the following additional fields:
 
 * ``webauthn`` (one-to-many to WebAuthn model).
   The reference to the registered WebAuthn credentials.
-* ``fs_webauthn_uniquifier`` (string, 64 bytes, unique).
+* ``fs_webauthn_user_handle`` (string, 64 bytes, unique).
   This is used as the `PublicKeyCredentialUserEntity` `id` value.
 
 Custom User Payload

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -523,6 +523,10 @@ _default_messages = {
         _("Credential not registered for this use (first or secondary)"),
         "error",
     ),
+    "WEBAUTHN_MISMATCH_USER_HANDLE": (
+        _("Credential user handle didn't match"),
+        "error",
+    ),
 }
 
 
@@ -783,7 +787,7 @@ class UserMixin(BaseUserMixin):
 
         .. versionchanged:: 4.0.0
             If user model has ``fs_token_uniquifier`` - use that (raise ValueError
-            if not set). Otherwise fallback to using ``fs_uniqifier``.
+            if not set). Otherwise fallback to using ``fs_uniquifier``.
         """
 
         if hasattr(self, "fs_token_uniquifier"):

--- a/flask_security/models/fsqla_v3.py
+++ b/flask_security/models/fsqla_v3.py
@@ -57,9 +57,9 @@ class FsUserMixin(FsUserMixinV2):
             "WebAuthn", backref="users", cascade="all, delete"
         )
 
-    # a unique user id (ala fs_uniquifier). This allows us to separately invalidate
-    # all webauthn registrations. Note max length 64 as specified in spec.
-    fs_webauthn_uniquifier = Column(String(64), unique=True, nullable=True)
+    # The user handle as required during registration.
+    # Note max length 64 as specified in spec.
+    fs_webauthn_user_handle = Column(String(64), unique=True)
 
     # 2FA - one time recovery codes - comma separated.
     tf_recovery_codes = Column(AsaList(1024), nullable=True)

--- a/flask_security/static/js/webauthn.js
+++ b/flask_security/static/js/webauthn.js
@@ -5,7 +5,7 @@
  * Copyright (c) 2017 Duo Security, Inc. All rights reserved.
  * with the BSD 3-Clause "New" or "Revised" License.
  * Further changes:
- *  :copyright: (c) 2021-2021 by J. Christopher Wagner (jwag).
+ *  :copyright: (c) 2021-2022 by J. Christopher Wagner (jwag).
  *  :license: MIT, see LICENSE for more details.
  */
 
@@ -181,10 +181,11 @@ const transformCredentialRequestOptions = (credentialRequestOptionsFromServer) =
  */
 const transformAssertionForServer = (newAssertion) => {
     const authData = new Uint8Array(newAssertion.response.authenticatorData);
-    const clientDataJSON = new Uint8Array(newAssertion.response.clientDataJSON);
-    const rawId = new Uint8Array(newAssertion.rawId);
-    const sig = new Uint8Array(newAssertion.response.signature);
-    const assertionClientExtensions = newAssertion.getClientExtensionResults();
+    const clientDataJSON = new Uint8Array(newAssertion.response.clientDataJSON)
+    const rawId = new Uint8Array(newAssertion.rawId)
+    const sig = new Uint8Array(newAssertion.response.signature)
+    const userHandle = new Uint8Array(newAssertion.response.userHandle)
+    const assertionClientExtensions = newAssertion.getClientExtensionResults()
 
     return {
         id: newAssertion.id,
@@ -193,7 +194,9 @@ const transformAssertionForServer = (newAssertion) => {
         response: {
           authenticatorData: b64RawEnc(authData),
           clientDataJSON: b64RawEnc(clientDataJSON),
-          signature: b64RawEnc(sig) },
+          signature: b64RawEnc(sig),
+          userHandle: b64RawEnc(userHandle)
+        },
         assertionClientExtensions: JSON.stringify(assertionClientExtensions)
     };
 };

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,7 +311,7 @@ def mongoengine_setup(request, app, tmpdir, realdburl):
     class User(db.Document, UserMixin):
         email = StringField(unique=True, max_length=255)
         fs_uniquifier = StringField(unique=True, max_length=64, required=True)
-        fs_webauthn_uniquifier = StringField(unique=True, max_length=64)
+        fs_webauthn_user_handle = StringField(unique=True, max_length=64)
         username = StringField(unique=True, required=False, sparse=True, max_length=255)
         password = StringField(required=False, max_length=255)
         security_number = IntField(unique=True, required=False, sparse=True)
@@ -458,7 +458,7 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl):
         __tablename__ = "user"
         myuserid = Column(Integer, primary_key=True)
         fs_uniquifier = Column(String(64), unique=True, nullable=False)
-        fs_webauthn_uniquifier = Column(String(64), unique=True, nullable=True)
+        fs_webauthn_user_handle = Column(String(64), unique=True, nullable=True)
         email = Column(String(255), unique=True)
         username = Column(String(255), unique=True, nullable=True)
         password = Column(String(255))
@@ -607,7 +607,7 @@ def peewee_setup(request, app, tmpdir, realdburl):
     class User(UserMixin, db.Model):
         email = TextField(unique=True, null=False)
         fs_uniquifier = TextField(unique=True, null=False)
-        fs_webauthn_uniquifier = TextField(unique=True, null=True)
+        fs_webauthn_user_handle = TextField(unique=True, null=True)
         username = TextField(unique=True, null=True)
         security_number = IntegerField(null=True)
         password = TextField(null=True)

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -82,8 +82,8 @@ def create_app():
     ]
     # app.config["SECURITY_US_ENABLED_METHODS"] = ["password"]
     # app.config["SECURITY_US_ENABLED_METHODS"] = ["authenticator", "password"]
-
     # app.config["SECURITY_US_SIGNIN_REPLACES_LOGIN"] = True
+    # app.config["SECURITY_WAN_ALLOW_USER_HINTS"] = False
 
     app.config["SECURITY_TOTP_SECRETS"] = {
         "1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"


### PR DESCRIPTION
rename fs_webauthn_uniquifier to fs_webauth_user_handle - to match the spec.
properly retrieve the user_handle from browser and pass to server.

Implement user_handle validity check, as spelled out in the spec.

If fs_webauthn_user_handle hasn't been initialized - do it on first access - this makes DB migration a lot easier.