### PR TITLE
Integrate webauthn with reauthentication/verify.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -220,6 +220,7 @@ Forms
 .. autoclass:: flask_security.WebAuthnSigninForm
 .. autoclass:: flask_security.WebAuthnSigninResponseForm
 .. autoclass:: flask_security.WebAuthnDeleteForm
+.. autoclass:: flask_security.WebAuthnVerifyForm
 
 .. _signals_topic:
 
@@ -343,4 +344,4 @@ sends the following signals.
 
     .. versionadded:: 4.2.0
 
-.. _Flask documentation on signals: https://flask.palletsprojects.com/en/1.1.x/signals/
+.. _Flask documentation on signals: https://flask.palletsprojects.com/en/2.0.x/signals/

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -493,11 +493,21 @@ These are used by the Two-Factor and Unified Signin features.
 .. py:data:: SECURITY_FRESHNESS
 
     A timedelta used to protect endpoints that alter sensitive information.
-    This is used to protect the endpoint: :py:data:`SECURITY_US_SETUP_URL`, and
-    :py:data:`SECURITY_TWO_FACTOR_SETUP_URL`.
+    This is used to protect the following endpoints:
+
+        - :py:data:`SECURITY_US_SETUP_URL`
+        - :py:data:`SECURITY_TWO_FACTOR_SETUP_URL`
+        - :py:data:`SECURITY_WAN_REGISTER_URL`
+
     Setting this to a negative number will disable any freshness checking and
-    the endpoints :py:data:`SECURITY_VERIFY_URL`, :py:data:`SECURITY_US_VERIFY_URL`
-    and :py:data:`SECURITY_US_VERIFY_SEND_CODE_URL` won't be registered.
+    the endpoints:
+
+        - :py:data:`SECURITY_VERIFY_URL`
+        - :py:data:`SECURITY_US_VERIFY_URL`
+        - :py:data:`SECURITY_US_VERIFY_SEND_CODE_URL`
+        - :py:data:`SECURITY_WAN_VERIFY_URL`
+
+    won't be registered.
     Setting this to 0 results in undefined behavior.
     Please see :meth:`flask_security.check_and_update_authn_fresh` for details.
 
@@ -509,8 +519,12 @@ These are used by the Two-Factor and Unified Signin features.
 
     A timedelta that provides a grace period when altering sensitive
     information.
-    This is used to protect the endpoint: :py:data:`SECURITY_US_SETUP_URL`, and
-    :py:data:`SECURITY_TWO_FACTOR_SETUP_URL`.
+    This is used to protect the endpoints:
+
+        - :py:data:`SECURITY_US_SETUP_URL`
+        - :py:data:`SECURITY_TWO_FACTOR_SETUP_URL`
+        - :py:data:`SECURITY_WAN_REGISTER_URL`
+
     N.B. To avoid strange behavior, be sure to set the grace period less than
     the freshness period.
     Please see :meth:`flask_security.check_and_update_authn_fresh` for details.
@@ -1292,7 +1306,7 @@ WebAuthn
 
 .. py:data:: SECURITY_WEBAUTHN
 
-    To enable this feature - set this to ``True``. Please see :ref:`models` for
+    To enable this feature - set this to ``True``. Please see :ref:`models_topic` for
     required additions to your database models.
 
     Default: ``False``
@@ -1315,6 +1329,12 @@ WebAuthn
 
     Default: ``"/wan-delete"``
 
+.. py:data:: SECURITY_WAN_VERIFY_URL
+
+    Endpoint for re-authenticating using a WebAuthn credential.
+
+    Default: ``"/wan-verify"``
+
 .. py:data:: SECURITY_WAN_REGISTER_TEMPLATE
 
     Default: ``"security/wan_register.html"``
@@ -1322,6 +1342,11 @@ WebAuthn
 .. py:data:: SECURITY_WAN_SIGNIN_TEMPLATE
 
     Default: ``"security/wan_signin.html"``
+
+.. py:data:: SECURITY_WAN_VERIFY_TEMPLATE
+
+    Default: ``"security/wan_verify.html"``
+
 
 .. py:data:: SECURITY_WAN_RP_NAME
 
@@ -1388,6 +1413,19 @@ WebAuthn
 
     Default: ``True``
 
+.. py:data:: SECURITY_WAN_ALLOW_AS_VERIFY
+
+    Sets which type of WebAuthn security credential, if any, may be used for
+    reauthentication/verify events. This is a list with possible values:
+
+        - ``"first"`` - just keys registered as "first" usage are allowed
+        - ``"secondary"`` - just keys registered as "secondary" are allowed
+
+    If list is empty or ``None`` WebAuthn keys aren't allowed. This also means that the
+            :py:data::``SECURITY_WAN_VERIFY`` endpoint won't be registered.
+
+
+
 Feature Flags
 -------------
 All feature flags. By default all are 'False'/not enabled.
@@ -1437,6 +1475,7 @@ A list of all URLs and Views:
 * :py:data:`SECURITY_WAN_REGISTER_URL`
 * :py:data:`SECURITY_WAN_SIGNIN_URL`
 * :py:data:`SECURITY_WAN_DELETE_URL`
+* :py:data:`SECURITY_WAN_VERIFY_URL`
 
 Template Paths
 --------------
@@ -1457,6 +1496,7 @@ A list of all templates:
 * :py:data:`SECURITY_US_VERIFY_TEMPLATE`
 * :py:data:`SECURITY_WAN_REGISTER_TEMPLATE`
 * :py:data:`SECURITY_WAN_SIGNIN_TEMPLATE`
+* :py:data:`SECURITY_WAN_VERIFY_TEMPLATE`
 
 Messages
 -------------
@@ -1539,3 +1579,4 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_WEBAUTHN_ORPHAN_CREDENTIAL_ID``
 * ``SECURITY_MSG_WEBAUTHN_NO_VERIFY``
 * ``SECURITY_MSG_WEBAUTHN_CREDENTIAL_WRONG_USAGE``
+* ``SECURITY_MSG_WEBAUTHN_MISMATCH_USER_HANDLE``

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -76,6 +76,7 @@ The following is a list of all the available context processor decorators:
 * ``us_setup_context_processor``: Unified sign in setup view
 * ``wan_register_context_processor``: WebAuthn registration view
 * ``wan_signin_context_processor``: WebAuthn sign in view
+* ``wan_verify_context_processor``: WebAuthn verify view
 
 
 Forms

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -108,6 +108,13 @@ password add the following to your `User` model:
 
 * ``fs_token_uniquifier`` (string, 64 bytes, unique, non-nullable)
 
+Username
+~~~~~~~~~
+If you set :py:data:`SECURITY_USERNAME_ENABLE` to `True`, then your `User` model
+requires the following additional field:
+
+* ``username`` (string, 64 bytes, unique, nullable)
+
 Permissions
 ^^^^^^^^^^^
 If you want to protect endpoints with permissions, and assign permissions to roles

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -119,6 +119,7 @@ from .webauthn import (
     WebAuthnSigninForm,
     WebAuthnSigninResponseForm,
     WebAuthnDeleteForm,
+    WebAuthnVerifyForm,
 )
 from .webauthn_util import WebauthnUtil
 

--- a/flask_security/babel.py
+++ b/flask_security/babel.py
@@ -50,7 +50,7 @@ except ImportError:  # pragma: no cover
 
             @staticmethod
             def gettext(string, **variables):
-                return string % variables
+                return string if not variables else string % variables
 
             @staticmethod
             def ngettext(singular, plural, num, **variables):
@@ -80,7 +80,7 @@ if not t.TYPE_CHECKING:
 
             def gettext(self, string, **variables):
                 if not has_babel_ext():
-                    return string % variables
+                    return string if not variables else string % variables
                 return super().gettext(string, **variables)
 
             def ngettext(self, singular, plural, num, **variables):  # pragma: no cover

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -1038,7 +1038,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
         active: bool
         fs_uniquifier: str
         fs_token_uniquifier: str
-        fs_webauthn_uniquifier: str
+        fs_webauthn_user_handle: str
         confirmed_at: t.Optional[datetime.datetime]
         last_login_at: datetime.datetime
         current_login_at: datetime.datetime

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -98,10 +98,15 @@ def default_reauthn_handler(within, grace):
     m, c = get_message("REAUTHENTICATION_REQUIRED")
 
     if _security._want_json(request):
+        from .webauthn import has_webauthn
+
         is_us = config_value("UNIFIED_SIGNIN")
         payload = json_error_response(errors=m)
         payload["reauth_required"] = True
         payload["unified_signin_enabled"] = is_us
+        payload["has_webauthn_verify_credential"] = has_webauthn(
+            current_user, config_value("WAN_ALLOW_AS_VERIFY")
+        )
         return _security._render_json(payload, 401, None, None)
 
     view = "us_verify" if config_value("UNIFIED_SIGNIN") else "verify"

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -30,7 +30,7 @@
           name="us_setup_form">
       {{ us_setup_form.hidden_tag() }}
       {% if setup_methods %}
-        <div class="fs-div">Currently Active Sign In Options:
+        <div class="fs-div">Currently active sign in options:
         {% if active_methods %}
           {{ ", ".join(active_methods) }}
         {% else %}
@@ -38,7 +38,7 @@
         {% endif %}
         </div>
 
-        <h3>Setup Additional Sign In Option</h3>
+        <h3>{{ _fsdomain("Setup additional sign in option") }}</h3>
         <div class="fs-div">
           {% for subfield in us_setup_form.chosen_method %}
             {% if subfield.data in available_methods %}
@@ -77,7 +77,8 @@
       {% endif %}
     </form>
     {% if security.webauthn %}
-      <h3>WebAuthn</h3>
+      <hr class="fs-gap">
+      <h2>WebAuthn</h2>
       <div class="fs-div">
         {{ _fsdomain("This application supports WebAuthn security keys.") }}
         <a href="{{ url_for_security('wan_register') }}">{{ _fsdomain("You can set them up here.") }}</a>

--- a/flask_security/templates/security/us_signin.html
+++ b/flask_security/templates/security/us_signin.html
@@ -27,7 +27,7 @@
       </form>
   {% if security.webauthn %}
     <hr class="fs-gap">
-    <h3>Use WebAuthn to Sign In</h3>
+    <h2>Use WebAuthn to Sign In</h2>
     <div>
       <form method="GET" id="wan-signin-form" name="wan_signin_form">
         <input id="wan_signin" name="wan_signin" type="submit" value="Sign in with WebAuthn"

--- a/flask_security/templates/security/us_verify.html
+++ b/flask_security/templates/security/us_verify.html
@@ -3,7 +3,7 @@
 
 {% block content %}
     {% include "security/_messages.html" %}
-    <h1>{{ _fsdomain("Please re-authenticate") }}</h1>
+    <h1>{{ _fsdomain("Please Reauthenticate") }}</h1>
       <form action="{{ url_for_security("us_verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
           name="us_verify_form">
       {{ us_verify_form.hidden_tag() }}
@@ -23,5 +23,14 @@
         {{ render_field(us_verify_form.submit_send_code, formaction=send_code_to) }}
       {% endif %}
       </form>
+      {% if has_webauthn_verify_credential %}
+        <hr class="fs-gap">
+        <h2>Use a WebAuthn Security Key to Reauthenticate</h2>
+        <form action="{{ url_for_security("wan_verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
+          name="wan_verify_form">
+            {{ wan_verify_form.hidden_tag() }}
+            {{ render_field(wan_verify_form.submit) }}
+        </form>
+      {% endif %}
   {% include "security/_menu.html" %}
 {% endblock %}

--- a/flask_security/templates/security/verify.html
+++ b/flask_security/templates/security/verify.html
@@ -3,11 +3,20 @@
 
 {% block content %}
     {% include "security/_messages.html" %}
-    <h1>{{ _fsdomain("Please Enter Your Password") }}</h1>
+    <h1>{{ _fsdomain("Please Reauthenticate") }}</h1>
     <form action="{{ url_for_security("verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
           name="verify_form">
         {{ verify_form.hidden_tag() }}
         {{ render_field_with_errors(verify_form.password) }}
         {{ render_field(verify_form.submit) }}
     </form>
+   {% if has_webauthn_verify_credential %}
+      <hr class="fs-gap">
+      <h2>Use a WebAuthn Security Key to Reauthenticate</h2>
+      <form action="{{ url_for_security("wan_verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
+        name="wan_verify_form">
+          {{ wan_verify_form.hidden_tag() }}
+          {{ render_field(wan_verify_form.submit) }}
+      </form>
+    {% endif %}
 {% endblock %}

--- a/flask_security/templates/security/wan_register.html
+++ b/flask_security/templates/security/wan_register.html
@@ -53,16 +53,17 @@
 
   {% if registered_credentials %}
     <h3>{{ _fsdomain("Currently registered security keys:") }}</h3>
+    {% set listing = _fsdomain('Nickname: "%s" Usage: "%s" Transports: "%s" Discoverable: "%s" Last used on: %s') %}
     <ul>
       {% for cred in registered_credentials %}
-        <li>Nickname: "{{ cred.name }}" Usage: "{{ cred.usage }}" transports: "{{ cred.transports|join(", ") }}" discoverable: "{{ cred.discoverable }}" last used on {{ cred.lastuse }}</li>
+        <li>{{ listing|format(cred.name, cred.usage, cred.transports|join(", "), cred.discoverable, cred.lastuse)}}</li>
       {% endfor %}
     </ul>
   {% endif %}
 
   {% if wan_delete_form %}
     <hr>
-    <h2>{{ _fsdomain("Delete existing WebAuthn Security Key") }}</h2>
+    <h2>{{ _fsdomain("Delete Existing WebAuthn Security Key") }}</h2>
       <form action="{{ url_for_security("wan_delete") }}" method="POST"
             name="wan_delete_form">
         {{ wan_delete_form.hidden_tag() }}

--- a/flask_security/templates/security/wan_verify.html
+++ b/flask_security/templates/security/wan_verify.html
@@ -1,9 +1,5 @@
-{#
-  This template receives the following pieces of context in addition to the form:
-#}
-
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field %}
 
 {% block head_scripts %}
   {{ super() }}
@@ -14,18 +10,15 @@
 
 {% block content %}
   {% include "security/_messages.html" %}
-  <h1>{{ _fsdomain("Sign In Using WebAuthn Security Key") }}</h1>
+  <h1>{{ _fsdomain("Please Re-Authenticate Using Your WebAuthn Security Key") }}</h1>
   {% if not credential_options %}
-    <form action="{{ url_for_security("wan_signin") }}" method="POST"
-          name="wan_signin_form" id="wan-signin-form">
-      {{ wan_signin_form.hidden_tag() }}
-      {{ render_field_with_errors(wan_signin_form.identity) }}
-      {{ render_field_with_errors(wan_signin_form.remember) }}
-      {{ render_field_errors(wan_signin_form.credential) }}
-      {{ render_field(wan_signin_form.submit) }}
+    <form action="{{ url_for_security("wan_verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
+          name="wan_verify_form">
+        {{ wan_verify_form.hidden_tag() }}
+        {{ render_field(wan_verify_form.submit) }}
     </form>
   {% else %}
-    <form action="{{ url_for_security("wan_signin_response", token=wan_state) }}" method="POST"
+    <form action="{{ url_for_security("wan_verify_response", token=wan_state) }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
           name="wan_signin_response_form" id="wan-signin-response-form">
       {{ wan_signin_response_form.hidden_tag() }}
       <div id="wan-errors"></div>

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -5,7 +5,7 @@
     Flask-Security two_factor module
 
     :copyright: (c) 2016 by Gal Stainfeld, at Emedgene
-    :copyright: (c) 2019-2021 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
 """
 
 import typing as t
@@ -33,7 +33,7 @@ from .signals import (
     tf_profile_changed,
 )
 
-from .webauthn import has_webauthn_tf
+from .webauthn import has_webauthn
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from flask import Response
@@ -132,12 +132,11 @@ def tf_disable(user):
     tf_disabled.send(app._get_current_object(), user=user)
 
 
-def is_tf_setup(user, include_webauthn=True):
+def is_tf_setup(user):
     """Return True is user account is setup for 2FA."""
-    if include_webauthn:
-        return (user.tf_totp_secret and user.tf_primary_method) or has_webauthn_tf(user)
-    else:
-        return user.tf_totp_secret and user.tf_primary_method
+    return (user.tf_totp_secret and user.tf_primary_method) or has_webauthn(
+        user, "secondary"
+    )
 
 
 def tf_login(user, remember=None, primary_authn_via=None):
@@ -177,7 +176,7 @@ def tf_login(user, remember=None, primary_authn_via=None):
         methods = []
         if user.tf_primary_method:
             methods.append(user.tf_primary_method)
-        if has_webauthn_tf(user):
+        if has_webauthn(user, "secondary"):
             methods.append("webauthn")
         json_response["tf_methods"] = methods
 

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -600,10 +600,14 @@ def us_verify() -> "ResponseValue":
         return redirect(get_post_verify_redirect())
 
     # Here on GET or failed POST validate
+    from .webauthn import has_webauthn
+
+    webauthn_available = has_webauthn(current_user, cv("WAN_ALLOW_AS_VERIFY"))
     if _security._want_json(request):
         payload = {
             "available_methods": cv("US_ENABLED_METHODS"),
             "code_methods": code_methods,
+            "has_webauthn_verify_credential": webauthn_available,
         }
         return base_render_json(form, additional=payload)
 
@@ -618,6 +622,8 @@ def us_verify() -> "ResponseValue":
             cv("US_VERIFY_SEND_CODE_URL"),
             qparams={"next": propagate_next(request.url)},
         ),
+        has_webauthn_verify_credential=webauthn_available,
+        wan_verify_form=_security.wan_verify_form(),
         **_security._run_ctx_processor("us_verify")
     )
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -5,7 +5,7 @@
     Flask-Security utils module
 
     :copyright: (c) 2012-2019 by Matt Wright.
-    :copyright: (c) 2019-2021 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 import abc
@@ -73,7 +73,7 @@ def _(translate):
 def get_request_attr(name: str) -> t.Any:
     """Retrieve a request local attribute.
 
-    Currently public attributes are:
+    Current public attributes are:
 
     **fs_authn_via**
         will be set to the authentication mechanism (session, token, basic)
@@ -263,7 +263,7 @@ def check_and_update_authn_fresh(
     fs_gexp = session.get("fs_gexp", None)
     if fs_gexp:
         if now.timestamp() < fs_gexp:
-            # Within grace period - extend it and we're good.
+            # Within grace period - extend it, and we're good.
             session["fs_gexp"] = grace_ts
             return True
 
@@ -274,7 +274,7 @@ def check_and_update_authn_fresh(
 
     authn_time = datetime.datetime.utcfromtimestamp(session["fs_paa"])
     # allow for some time drift where it's possible authn_time is in the future
-    # but lets be cautious and not allow arbitrary future times
+    # but let's be cautious and not allow arbitrary future times
     delta = now - authn_time
     if within > delta > -within:
         session["fs_gexp"] = grace_ts

--- a/flask_security/webauthn_util.py
+++ b/flask_security/webauthn_util.py
@@ -73,11 +73,12 @@ class WebauthnUtil:
             - Attachment - platform or cross-platform
             - Does the key have to provide user-verification
 
-        Note1 - if the key isn't resident then it isn't discoverable which means that
-        the user won't be able to use that key unless they identify themselves
-        (use the key as a second factor OR type in their identity). If they are forced
-        to type in their identity PRIOR to being authenticated, then there is the
-        possibility that the app will leak username information.
+        :note::
+            If the key isn't resident then it isn't discoverable which means that
+            the user won't be able to use that key unless they identify themselves
+            (use the key as a second factor OR type in their identity). If they are forced
+            to type in their identity PRIOR to being authenticated, then there is the
+            possibility that the app will leak username information.
         """  # noqa: E501
 
         select_criteria = AuthenticatorSelectionCriteria()
@@ -94,18 +95,20 @@ class WebauthnUtil:
         return select_criteria
 
     def user_verification(
-        self, user: t.Optional["User"], usage: str
+        self, user: t.Optional["User"], usage: t.List[str]
     ) -> "UserVerificationRequirement":
         """
         As part of signin - do we want/need user verification.
-        This is called from /wan-signin
+        This is called from /wan-signin and /wan-verify
 
         :param user: User object - could be used to configure on a per-user basis.
             Note that this may not be set on initial wan-signin.
-        :param usage: Either "first" or "secondary" (webauthn is being used as a second
-            factor for authentication
+        :param usage: List of  "first", "secondary" (webauthn is being used as a second
+            factor for authentication). Note that in the ``verify``/``reauthentication``
+            case this list is derived from :py:data:`SECURITY_WAN_ALLOW_AS_VERIFY`
+
         """
-        if usage == "secondary":
+        if "secondary" in usage:
             return UserVerificationRequirement.DISCOURAGED
         if current_app.config.get("SECURITY_WAN_ALLOW_AS_MULTI_FACTOR"):
             return UserVerificationRequirement.PREFERRED

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@
     Test fixtures and what not
 
     :copyright: (c) 2017 by CERN.
-    :copyright: (c) 2019-2021 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -227,7 +227,7 @@ def app(request: pytest.FixtureRequest) -> "SecurityFixture":
         return render_template("index.html", content="Unauthorized")
 
     @app.route("/fresh", methods=["GET", "POST"])
-    @auth_required(within=0)
+    @auth_required(within=60)
     def fresh():
         if app.security._want_json(flask_request):
             return jsonify(title="Fresh Only")

--- a/tests/templates/custom_security/wan_verify.html
+++ b/tests/templates/custom_security/wan_verify.html
@@ -1,0 +1,3 @@
+CUSTOM WAN VERIFY
+{{ global }}
+{{ foo }}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@
 
     Test utils
 
-    :copyright: (c) 2019-2021 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 from contextlib import contextmanager
@@ -92,6 +92,17 @@ def get_session(response):
                 )
                 val = serializer.loads_unsafe(encoded_cookie)
                 return val[1]
+
+
+def reset_fresh(client, within):
+    # Assumes client authenticated.
+    # Upon return the NEXT request if protected with a freshness check
+    # will require a fresh authentication.
+    with client.session_transaction() as sess:
+        old_paa = sess["fs_paa"] - within.total_seconds() - 100
+        sess["fs_paa"] = old_paa
+        sess.pop("fs_gexp", None)
+    return old_paa
 
 
 def check_xlation(app, locale):

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -88,7 +88,7 @@ def create_app():
     app.config["SECURITY_TOTP_SECRETS"] = {
         "1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"
     }
-    app.config["SECURITY_FRESHNESS"] = datetime.timedelta(minutes=60)
+    app.config["SECURITY_FRESHNESS"] = datetime.timedelta(minutes=1)
     app.config["SECURITY_FRESHNESS_GRACE_PERIOD"] = datetime.timedelta(minutes=2)
     app.config["SECURITY_USERNAME_ENABLE"] = True
 


### PR DESCRIPTION
Add new /wan-verify entry point for reauthentication events.

Add WAN_ALLOW_AS_VERIFY config to control which (if any) usage type keys can be used for reauthentication.

Integrate wan-verify into us-verify and verify templates.

Unified some wording in various templates.

Allow i18n of WAN list of keys.

Add test utility - reset_fresh to enable easier testing of verify/reauthentication endpoints.

Add username to models - missed that when feature was introduced.