### PR TITLE
Minor updates.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -57,6 +57,9 @@ User Object Helpers
 .. autoclass:: flask_security.RoleMixin
    :members:
 
+.. autoclass:: flask_security.WebAuthnMixin
+   :members:
+
 .. autoclass:: flask_security.AnonymousUser
    :members:
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -749,7 +749,8 @@ Registerable
 
     Validation and normalization is encapsulated in :class:`.UsernameUtil`.
     Note that the default validation restricts username input to be unicode
-    letters and numbers.
+    letters and numbers. It also uses ``bleach`` to scrub any risky input. Be
+    sure your application requirements includes ``bleach``.
 
     Default: ``False``
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -978,6 +978,15 @@ class AnonymousUser(AnonymousUserMixin):
         return False
 
 
+class UnauthnCb(t.Protocol):
+    def __call__(
+        self,
+        mechanisms: t.Union[t.Set[str], t.List[str]],
+        headers: t.Optional[t.Dict[str, str]] = None,
+    ) -> "ResponseValue":
+        ...
+
+
 class Security:
     """The :class:`Security` class initializes the Flask-Security extension.
 
@@ -1159,9 +1168,7 @@ class Security:
         self.webauthn_util_cls = webauthn_util_cls
 
         # Attributes not settable from init.
-        self._unauthn_handler: t.Callable[
-            [t.List[str], t.Optional[t.Dict[str, str]]], "ResponseValue"
-        ] = default_unauthn_handler
+        self._unauthn_handler: UnauthnCb = default_unauthn_handler
         self._reauthn_handler: t.Callable[
             [timedelta, timedelta], "ResponseValue"
         ] = default_reauthn_handler
@@ -1694,7 +1701,7 @@ class Security:
 
     def unauthn_handler(
         self,
-        cb: t.Callable[[t.List[str], t.Optional[t.Dict[str, str]]], "ResponseValue"],
+        cb: UnauthnCb,
     ) -> None:
         """
         Callback for failed authentication.

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -978,15 +978,6 @@ class AnonymousUser(AnonymousUserMixin):
         return False
 
 
-class UnauthnCb(t.Protocol):
-    def __call__(
-        self,
-        mechanisms: t.Union[t.Set[str], t.List[str]],
-        headers: t.Optional[t.Dict[str, str]] = None,
-    ) -> "ResponseValue":
-        ...
-
-
 class Security:
     """The :class:`Security` class initializes the Flask-Security extension.
 
@@ -1168,7 +1159,9 @@ class Security:
         self.webauthn_util_cls = webauthn_util_cls
 
         # Attributes not settable from init.
-        self._unauthn_handler: UnauthnCb = default_unauthn_handler
+        self._unauthn_handler: t.Callable[
+            [t.List[str], t.Optional[t.Dict[str, str]]], "ResponseValue"
+        ] = default_unauthn_handler
         self._reauthn_handler: t.Callable[
             [timedelta, timedelta], "ResponseValue"
         ] = default_reauthn_handler
@@ -1701,7 +1694,7 @@ class Security:
 
     def unauthn_handler(
         self,
-        cb: UnauthnCb,
+        cb: t.Callable[[t.List[str], t.Optional[t.Dict[str, str]]], "ResponseValue"],
     ) -> None:
         """
         Callback for failed authentication.

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -239,7 +239,7 @@ def http_auth_required(realm: t.Any) -> DecoratedView:
             else:
                 r = _security.default_http_auth_realm if callable(realm) else realm
                 h = {"WWW-Authenticate": 'Basic realm="%s"' % r}
-                return _security._unauthn_handler(["basic"], headers=h)
+                return _security._unauthn_handler(["basic"], h)
 
         return wrapper
 

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -610,7 +610,7 @@ def reset_password(token):
 
     if form.validate_on_submit():
         after_this_request(view_commit)
-        update_password(user, _security._password_util.normalize(form.password.data))
+        update_password(user, form.password.data)
         if cv("TWO_FACTOR") and (
             cv("TWO_FACTOR_REQUIRED")
             or (form.user.tf_totp_secret and form.user.tf_primary_method)

--- a/requirements_low/tests.txt
+++ b/requirements_low/tests.txt
@@ -13,6 +13,7 @@ python-dateutil==2.8.2
 # next 2 come from minimums from Flask 1.1.4 and need newer jinja2 for 3.10
 jinja2==2.11.0
 itsdangerous==1.1.0
+markupsafe==2.0.1
 mongoengine==0.22.1
 mongomock==3.22.0
 pony==0.7.14;python_version<'3.10'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,18 +1,19 @@
 [options.extras_require]
 babel=
-    babel>=2.7.0
+    babel>=2.9.1
     flask_babel>=2.0.0
 fsqla=
-    flask_sqlalchemy>=2.4.4
-    sqlalchemy>=1.3.6
-    sqlalchemy-utils>=0.34.1
+    flask_sqlalchemy>=2.5.1
+    sqlalchemy>=1.3.24
+    sqlalchemy-utils>=0.37.9
 common=
     bcrypt>=3.1.5
     flask_mail>=0.9.1
+    bleach>=3.3.1
 mfa=
-    cryptography>=3.0.0
+    cryptography>=3.4.8
     pyqrcode>=1.2
-    phonenumberslite>=8.11.1
+    phonenumberslite>=8.12.18
 
 [aliases]
 test=pytest


### PR DESCRIPTION
Roll back the changes to #577 - that should be working already - wrote a test that confirms that.

Minor typing improvements to unauthn_handler.

Fix MarkupSafe version for 'low' version tests - recent release removed soft_unicode().

Update documentation around needing bleach when using username. Also included bleach in the 'common' setup.py configuration.

Closes: #580