### PR TITLE
Note on JSON/Ajax using confirm_register_form only

### DIFF
--- a/docs/features.rst
+++ b/docs/features.rst
@@ -258,6 +258,8 @@ JSON is supported for the following operations:
 In addition, Single-Page-Applications (like those built with Vue, Angular, and
 React) are supported via customizable redirect links.
 
+Note: All registeration requests done through JSON/Ajax utilize the ``confirm_register_form``.
+
 Command Line Interface
 ----------------------
 


### PR DESCRIPTION
JSON/Ajax quietly does not use `register_form` and instead uses `confirm_register_form` always, even when `SECURITY_CONFIRMABLE` is not enabled.
Currently the only place I found this mentioned was in answer to #271. So this change simply documents that fact more clearly.

I tried to keep this as concise as possible, but let me know if I need to be clearer or move this documentation elsewhere.