### PR TITLE
Make the required zxcvbn complexity score configurable

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -126,6 +126,15 @@ These configuration keys are used globally across all features.
     Default: ``None``
 
     .. versionadded:: 3.4.0
+.. py:data:: SECURITY_ZXCVBN_MINIMUM_SCORE
+
+    Required ``zxcvbn`` password complexity score (0-4).
+    Refer to https://github.com/dropbox/zxcvbn#usage for exact meanings of
+    different score values.
+
+    Default: ``3`` (Good or Strong)
+
+    .. versionadded:: 4.2.0
 .. py:data:: SECURITY_PASSWORD_CHECK_BREACHED
 
     If not ``None`` new/changed passwords will be checked against the

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -334,6 +334,7 @@ _default_config: t.Dict[str, t.Any] = {
     "WAN_ALLOW_AS_MULTI_FACTOR": True,
     "WAN_ALLOW_USER_HINTS": True,
     "WAN_ALLOW_AS_VERIFY": ["first", "secondary"],
+    "ZXCVBN_MINIMUM_SCORE": 3,
 }
 
 #: Default Flask-Security messages

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -1180,8 +1180,7 @@ def password_complexity_validator(
             if kwargs:
                 user_info = list(kwargs.values())
         results = zxcvbn.zxcvbn(password, user_inputs=user_info)
-        if results["score"] > 2:
-            # Good or Strong
+        if results["score"] >= config_value("ZXCVBN_MINIMUM_SCORE"):
             return None
         # Should we return suggestions? Default forms don't really know what to do.
         if results["feedback"]["warning"]:

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -440,8 +440,7 @@ def test_basic_change(app, client_nc, get_message):
     assert b"Home Page" in response.data
 
 
-@pytest.mark.settings(password_complexity_checker="zxcvbn")
-def test_easy_password(app, client):
+def __test_easy_password(client):
     authenticate(client)
 
     data = (
@@ -453,9 +452,21 @@ def test_easy_password(app, client):
         "/change", data=data, headers={"Content-Type": "application/json"}
     )
     assert response.headers["Content-Type"] == "application/json"
+    return response
+
+
+@pytest.mark.settings(password_complexity_checker="zxcvbn")
+def test_easy_password(app, client):
+    response = __test_easy_password(client)
     assert response.status_code == 400
     # Response from zxcvbn
     assert "Repeats like" in response.json["response"]["errors"]["new_password"][0]
+
+
+@pytest.mark.settings(password_complexity_checker="zxcvbn", zxcvbn_minimum_score=0)
+def test_easy_password_ok(app, client):
+    response = __test_easy_password(client)
+    assert response.status_code == 200
 
 
 def test_my_validator(app, sqlalchemy_datastore):


### PR DESCRIPTION
At the moment flask-security allows only 3 and 4. In some cases it
might be desirable to decrease or increase the minimum allowed score.
Provide SECURITY_ZXCVBN_MINIMUM_SCORE knob for this.