### PR TITLE
Fixes for new versions of flask and werkzeug and flask_login

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,12 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.31.1
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -136,7 +136,7 @@ class CodeTfPlugin(TfPluginBase):
 
     def tf_login(
         self, user: "User", json_payload: t.Dict[str, t.Any]
-    ) -> t.Optional["ResponseValue"]:
+    ) -> "ResponseValue":
         """Helper for two-factor authentication login
 
         This is called only when login/password have already been validated.

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -611,7 +611,7 @@ def us_verify() -> "ResponseValue":
             qparams={"next": propagate_next(request.url)},
         ),
         has_webauthn_verify_credential=webauthn_available,
-        wan_verify_form=_security.wan_verify_form(),
+        wan_verify_form=_security.wan_verify_form(formdata=None),
         **_security._run_ctx_processor("us_verify")
     )
 
@@ -796,7 +796,7 @@ def us_setup() -> "ResponseValue":
             code_sent=form.chosen_method.data in _compute_code_methods(),
             chosen_method=form.chosen_method.data,
             us_setup_form=form,
-            us_setup_validate_form=_security.us_setup_validate_form(),
+            us_setup_validate_form=_security.us_setup_validate_form(formdata=None),
             **qrcode_values,
             state=state_token,
             **_security._run_ctx_processor("us_setup")

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -238,7 +238,7 @@ def verify():
         cv("VERIFY_TEMPLATE"),
         verify_form=form,
         has_webauthn_verify_credential=webauthn_available,
-        wan_verify_form=_security.wan_verify_form(),
+        wan_verify_form=_security.wan_verify_form(formdata=None),
         **_ctx("verify"),
     )
 
@@ -614,7 +614,7 @@ def reset_password(token):
         # two factor not required - just login
         login_user(user, authn_via=["reset"])
         if _security._want_json(request):
-            login_form = _security.login_form()
+            login_form = _security.login_form(formdata=None)
             login_form.user = user
             return base_render_json(login_form, include_auth_token=True)
         else:
@@ -798,7 +798,7 @@ def two_factor_setup():
                 authr_username=authr_setup_values["username"],
                 authr_issuer=authr_setup_values["issuer"],
             )
-        code_form = _security.two_factor_verify_code_form()
+        code_form = _security.two_factor_verify_code_form(formdata=None)
         if not _security._want_json(request):
             return _security.render_template(
                 cv("TWO_FACTOR_SETUP_TEMPLATE"),
@@ -828,7 +828,7 @@ def two_factor_setup():
         }
         return base_render_json(form, include_user=False, additional=json_response)
 
-    code_form = _security.two_factor_verify_code_form()
+    code_form = _security.two_factor_verify_code_form(formdata=None)
     return _security.render_template(
         cv("TWO_FACTOR_SETUP_TEMPLATE"),
         two_factor_setup_form=form,
@@ -930,7 +930,7 @@ def two_factor_token_validation():
 
     # if we were trying to validate a new method
     if changing:
-        setup_form = _security.two_factor_setup_form()
+        setup_form = _security.two_factor_setup_form(formdata=None)
 
         return _security.render_template(
             cv("TWO_FACTOR_SETUP_TEMPLATE"),
@@ -943,7 +943,7 @@ def two_factor_token_validation():
 
     # if we were trying to validate an existing method
     else:
-        rescue_form = _security.two_factor_rescue_form()
+        rescue_form = _security.two_factor_rescue_form(formdata=None)
         return _security.render_template(
             cv("TWO_FACTOR_VERIFY_CODE_TEMPLATE"),
             two_factor_rescue_form=rescue_form,
@@ -1018,7 +1018,7 @@ def two_factor_rescue():
     if _security._want_json(request):
         return base_render_json(form, include_user=False)
 
-    code_form = _security.two_factor_verify_code_form()
+    code_form = _security.two_factor_verify_code_form(formdata=None)
     return _security.render_template(
         cv("TWO_FACTOR_VERIFY_CODE_TEMPLATE"),
         two_factor_verify_code_form=code_form,

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -379,13 +379,10 @@ def webauthn_register() -> "ResponseValue":
     payload: t.Dict[str, t.Any]
 
     form_class = _security.wan_register_form
-    if request.is_json:
-        if request.content_length:
-            form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
-        else:
-            form = form_class(formdata=None, meta=suppress_form_csrf())
-    else:
-        form = form_class(meta=suppress_form_csrf())
+    form_data = None
+    if request.content_length:
+        form_data = MultiDict(request.get_json()) if request.is_json else request.form
+    form = form_class(formdata=form_data, meta=suppress_form_csrf())
 
     if form.validate_on_submit():
         challenge = _security._webauthn_util.generate_challenge(
@@ -433,7 +430,7 @@ def webauthn_register() -> "ResponseValue":
         return _security.render_template(
             cv("WAN_REGISTER_TEMPLATE"),
             wan_register_form=form,
-            wan_register_response_form=WebAuthnRegisterResponseForm(),
+            wan_register_response_form=WebAuthnRegisterResponseForm(formdata=None),
             wan_state=state_token,
             credential_options=json.dumps(co_json),
             **_security._run_ctx_processor("wan_register")
@@ -463,7 +460,7 @@ def webauthn_register() -> "ResponseValue":
     return _security.render_template(
         cv("WAN_REGISTER_TEMPLATE"),
         wan_register_form=form,
-        wan_delete_form=_security.wan_delete_form(),
+        wan_delete_form=_security.wan_delete_form(formdata=None),
         registered_credentials=current_creds,
         **_security._run_ctx_processor("wan_register")
     )
@@ -474,10 +471,10 @@ def webauthn_register_response(token: str) -> "ResponseValue":
     """Response from browser."""
 
     form_class = _security.wan_register_response_form
-    if request.is_json:
-        form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
-    else:
-        form = form_class(meta=suppress_form_csrf())
+    form_data = None
+    if request.content_length:
+        form_data = MultiDict(request.get_json()) if request.is_json else request.form
+    form = form_class(formdata=form_data, meta=suppress_form_csrf())
 
     expired, invalid, state = check_and_get_token_status(
         token, "wan", get_within_delta("WAN_REGISTER_WITHIN")
@@ -570,13 +567,10 @@ def webauthn_signin() -> "ResponseValue":
     else:
         abort(404)
     form_class = _security.wan_signin_form
-    if request.is_json:
-        if request.content_length:
-            form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
-        else:
-            form = form_class(formdata=None, meta=suppress_form_csrf())
-    else:
-        form = form_class(meta=suppress_form_csrf())
+    form_data = None
+    if request.content_length:
+        form_data = MultiDict(request.get_json()) if request.is_json else request.form
+    form = form_class(formdata=form_data, meta=suppress_form_csrf())
 
     form.is_secondary = is_secondary
     if form.validate_on_submit():
@@ -604,7 +598,7 @@ def webauthn_signin() -> "ResponseValue":
     return _security.render_template(
         cv("WAN_SIGNIN_TEMPLATE"),
         wan_signin_form=form,
-        wan_signin_response_form=WebAuthnSigninResponseForm(),
+        wan_signin_response_form=WebAuthnSigninResponseForm(formdata=None),
         is_secondary=is_secondary,
         **_security._run_ctx_processor("wan_signin")
     )
@@ -617,10 +611,10 @@ def webauthn_signin_response(token: str) -> "ResponseValue":
     ] in ["ready"]
 
     form_class = _security.wan_signin_response_form
-    if request.is_json:
-        form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
-    else:
-        form = form_class(meta=suppress_form_csrf())
+    form_data = None
+    if request.content_length:
+        form_data = MultiDict(request.get_json()) if request.is_json else request.form
+    form = form_class(formdata=form_data, meta=suppress_form_csrf())
 
     expired, invalid, state = check_and_get_token_status(
         token, "wan", get_within_delta("WAN_SIGNIN_WITHIN")
@@ -718,10 +712,10 @@ def webauthn_delete() -> "ResponseValue":
     """Deletes an existing registered credential."""
 
     form_class = _security.wan_delete_form
-    if request.is_json:
-        form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
-    else:
-        form = form_class(meta=suppress_form_csrf())
+    form_data = None
+    if request.content_length:
+        form_data = MultiDict(request.get_json()) if request.is_json else request.form
+    form = form_class(formdata=form_data, meta=suppress_form_csrf())
 
     if form.validate_on_submit():
         # validate made sure form.name.data exists.
@@ -755,13 +749,10 @@ def webauthn_verify() -> "ResponseValue":
     """
     form_class = _security.wan_verify_form
 
-    if request.is_json:
-        if request.content_length:
-            form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
-        else:
-            form = form_class(formdata=None, meta=suppress_form_csrf())
-    else:
-        form = form_class(meta=suppress_form_csrf())
+    form_data = None
+    if request.content_length:
+        form_data = MultiDict(request.get_json()) if request.is_json else request.form
+    form = form_class(formdata=form_data, meta=suppress_form_csrf())
 
     if form.validate_on_submit():
         o_json, state_token = _signin_common(form.user, cv("WAN_ALLOW_AS_VERIFY"))
@@ -772,7 +763,7 @@ def webauthn_verify() -> "ResponseValue":
         return _security.render_template(
             cv("WAN_VERIFY_TEMPLATE"),
             wan_verify_form=form,
-            wan_signin_response_form=WebAuthnSigninResponseForm(),
+            wan_signin_response_form=WebAuthnSigninResponseForm(formdata=None),
             wan_state=state_token,
             credential_options=json.dumps(o_json),
             **_security._run_ctx_processor("wan_verify")
@@ -783,7 +774,7 @@ def webauthn_verify() -> "ResponseValue":
     return _security.render_template(
         cv("WAN_VERIFY_TEMPLATE"),
         wan_verify_form=form,
-        wan_signin_response_form=WebAuthnSigninResponseForm(),
+        wan_signin_response_form=WebAuthnSigninResponseForm(formdata=None),
         skip_login_menu=True,
         response_to=get_url(
             cv("WAN_VERIFY_URL"),
@@ -796,10 +787,10 @@ def webauthn_verify() -> "ResponseValue":
 @unauth_csrf(fall_through=True)
 def webauthn_verify_response(token: str) -> "ResponseValue":
     form_class = _security.wan_signin_response_form
-    if request.is_json:
-        form = form_class(MultiDict(request.get_json()), meta=suppress_form_csrf())
-    else:
-        form = form_class(meta=suppress_form_csrf())
+    form_data = None
+    if request.content_length:
+        form_data = MultiDict(request.get_json()) if request.is_json else request.form
+    form = form_class(formdata=form_data, meta=suppress_form_csrf())
 
     expired, invalid, state = check_and_get_token_status(
         token, "wan", get_within_delta("WAN_SIGNIN_WITHIN")
@@ -908,7 +899,7 @@ class WebAuthnTfPlugin(TfPluginBase):
 
     def tf_login(
         self, user: "User", json_payload: t.Dict[str, t.Any]
-    ) -> t.Optional["ResponseValue"]:
+    ) -> "ResponseValue":
         session["tf_state"] = "ready"
         if not _security._want_json(request):
             return redirect(url_for_security("wan_signin"))

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -193,7 +193,7 @@ def test_change_invalidates_session(app, client):
     # try to access protected endpoint - shouldn't work
     response = client.get("/profile")
     assert response.status_code == 302
-    assert response.headers["Location"] == "http://localhost/login?next=%2Fprofile"
+    assert "/login?next=%2Fprofile" in response.location
 
 
 def test_change_updates_remember(app, client):
@@ -243,7 +243,7 @@ def test_change_invalidates_auth_token(app, client):
     # authtoken should now be invalid
     response = client.get("/token", headers=headers)
     assert response.status_code == 302
-    assert response.headers["Location"] == "http://localhost/login?next=%2Ftoken"
+    assert "/login?next=%2Ftoken" in response.location
 
 
 def test_auth_uniquifier(app):

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -318,13 +318,13 @@ def test_unauthorized_access(client, get_message):
 def test_unauthorized_access_with_referrer(client, get_message):
     authenticate(client, "joe@lp.com")
     response = client.get("/admin", headers={"referer": "/admin"})
-    assert response.headers["Location"] != "/admin"
-    client.get(response.headers["Location"])
+    assert response.location != "/admin"
+    client.get(response.location)
 
     response = client.get(
         "/admin?a=b", headers={"referer": "http://localhost/admin?x=y"}
     )
-    assert response.headers["Location"] == "http://localhost/"
+    assert "/" in response.location
     client.get(response.headers["Location"])
 
     response = client.get(
@@ -336,7 +336,7 @@ def test_unauthorized_access_with_referrer(client, get_message):
     # we expect a temp redirect (302) to the referer
     response = client.get("/admin?w=s", headers={"referer": "/profile"})
     assert response.status_code == 302
-    assert response.headers["Location"] == "http://localhost/profile"
+    assert "/profile" in response.location
 
 
 @pytest.mark.settings(unauthorized_view="/unauthz")

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -24,11 +24,11 @@ def test_view_configuration(client):
 
     response = authenticate(client, endpoint="/custom_login")
     assert "location" in response.headers
-    assert response.headers["Location"] == "http://localhost/post_login"
+    assert "/post_login" in response.location
 
     response = logout(client, endpoint="/custom_logout")
     assert "location" in response.headers
-    assert response.headers["Location"] == "http://localhost/post_logout"
+    assert "/post_logout" in response.location
 
     response = client.get(
         "/http",

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -522,7 +522,7 @@ def test_email_not_identity(app, sqlalchemy_datastore, get_message):
     token = registrations[0]["confirm_token"]
     response = client.get("/confirm/" + token, headers={"Accept": "application/json"})
     assert response.status_code == 302
-    assert response.location == "http://localhost/"
+    assert "/" in response.location
 
     logout(client)
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -818,8 +818,7 @@ def test_authn_freshness(
         response = client.get("/myspecialview", follow_redirects=False)
         assert response.status_code == 302
         assert (
-            response.location
-            == "http://localhost/verify?next=http%3A%2F%2Flocalhost%2Fmyspecialview"
+            "/verify?next=http%3A%2F%2Flocalhost%2Fmyspecialview" in response.location
         )
     assert flashes[0]["category"] == "error"
     assert flashes[0]["message"].encode("utf-8") == get_message(
@@ -900,10 +899,7 @@ def test_default_authn_bp(app, client):
     reset_fresh(client, within=timedelta(minutes=1))
     response = client.get("/myview", follow_redirects=False)
     assert response.status_code == 302
-    assert (
-        response.location
-        == "http://localhost/myprefix/verify?next=http%3A%2F%2Flocalhost%2Fmyview"
-    )
+    assert "/myprefix/verify?next=http%3A%2F%2Flocalhost%2Fmyview" in response.location
 
 
 def test_authn_freshness_grace(app, client, get_message):
@@ -945,10 +941,7 @@ def test_authn_freshness_nc(app, client_nc, get_message):
     # This should fail - should be a redirect
     response = client_nc.get("/myview", headers=h, follow_redirects=False)
     assert response.status_code == 302
-    assert (
-        response.location
-        == "http://localhost/verify?next=http%3A%2F%2Flocalhost%2Fmyview"
-    )
+    assert "/verify?next=http%3A%2F%2Flocalhost%2Fmyview" in response.location
 
 
 def test_verify_fresh(app, client, get_message):
@@ -1143,11 +1136,11 @@ def test_post_security_with_application_root(app, sqlalchemy_datastore):
         "/login", data=dict(email="matt@lp.com", password="password")
     )
     assert response.status_code == 302
-    assert response.headers["Location"] == "http://localhost/root"
+    assert "/root" in response.location
 
     response = client.get("/logout")
     assert response.status_code == 302
-    assert response.headers["Location"] == "http://localhost/root"
+    assert "/root" in response.location
 
 
 def test_post_security_with_application_root_and_views(app, sqlalchemy_datastore):
@@ -1166,11 +1159,11 @@ def test_post_security_with_application_root_and_views(app, sqlalchemy_datastore
         "/login", data=dict(email="matt@lp.com", password="password")
     )
     assert response.status_code == 302
-    assert response.headers["Location"] == "http://localhost/post_login"
+    assert "/post_login" in response.location
 
     response = client.get("/logout")
     assert response.status_code == 302
-    assert response.headers["Location"] == "http://localhost/post_logout"
+    assert "/post_logout" in response.location
 
 
 @pytest.mark.settings(redirect_validate_mode="regex")

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -289,7 +289,7 @@ def test_recover_invalidates_session(app, client):
     # try to access protected endpoint with old session - shouldn't work
     response = other_client.get("/profile")
     assert response.status_code == 302
-    assert response.headers["Location"] == "http://localhost/login?next=%2Fprofile"
+    assert "/login?next=%2Fprofile" in response.location
 
 
 def test_login_form_description(sqlalchemy_app):

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -52,7 +52,7 @@ def test_default_unauthn(app, client):
 
     response = client.get("/profile")
     assert response.status_code == 302
-    assert response.headers["Location"] == "http://localhost/login?next=%2Fprofile"
+    assert "/login?next=%2Fprofile" in response.location
 
     response = client.get("/profile", headers={"Accept": "application/json"})
     assert response.status_code == 401
@@ -68,10 +68,7 @@ def test_default_unauthn_bp(app, client):
 
     response = client.get("/profile")
     assert response.status_code == 302
-    assert (
-        response.headers["Location"]
-        == "http://localhost/myprefix/mylogin?next=%2Fprofile"
-    )
+    assert "/myprefix/mylogin?next=%2Fprofile" in response.location
 
 
 def test_default_unauthn_myjson(app, client):

--- a/tests/test_tf_plugin.py
+++ b/tests/test_tf_plugin.py
@@ -119,4 +119,4 @@ def test_tf_select_auth(app, client, get_message):
     # /tf-select is an unauthenticated endpoint - make sure only allowable in correct
     # state.
     response = client.get("/tf-select", follow_redirects=False)
-    assert response.location == "http://localhost/login"
+    assert "/login" in response.location

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -515,7 +515,7 @@ def test_verify_link(app, client, get_message):
 
     # Try with no code
     response = client.get("us-verify-link?email=matt@lp.com", follow_redirects=False)
-    assert response.location == "http://localhost/us-signin"
+    assert "/us-signin" in response.location
     response = client.get("us-verify-link?email=matt@lp.com", follow_redirects=True)
     assert get_message("API_ERROR") in response.data
 
@@ -839,10 +839,7 @@ def test_verify(app, client, get_message):
     us_authenticate(client)
     response = client.get("us-setup", follow_redirects=False)
     verify_url = response.location
-    assert (
-        verify_url
-        == "http://localhost/us-verify?next=http%3A%2F%2Flocalhost%2Fus-setup"
-    )
+    assert "/us-verify?next=http%3A%2F%2Flocalhost%2Fus-setup" in verify_url
     logout(client)
     us_authenticate(client)
 
@@ -1101,7 +1098,7 @@ def test_next(app, client, get_message):
         data=dict(identity="matt@lp.com", passcode=requests[0]["token"]),
         follow_redirects=False,
     )
-    assert response.location == "http://localhost/post_login"
+    assert "/post_login" in response.location
 
     logout(client)
     response = client.post(
@@ -1111,7 +1108,8 @@ def test_next(app, client, get_message):
         ),
         follow_redirects=False,
     )
-    assert response.location == "http://localhost/post_login"
+
+    assert "/post_login" in response.location
 
 
 @pytest.mark.registerable()


### PR DESCRIPTION
- flask now returns relative URLs on redirect.
- flask_wtf was fixed - but add code to many views to not rely on flask_wtf to return None on empty formdata.
- possible subtle bug - when instantiating a form that isn't part of the view - set formdata=None so it doesn't try to pick up data from the request.
- Fix mypy issue.