### PR TITLE
Implement ability to delete a previously setup unified sign in method.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -335,9 +335,13 @@ sends the following signals.
 .. data:: us_profile_changed
 
     Sent when user completes changing their unified sign in profile. In addition to the app
-    (which is the sender), it is passed `user` and `method` arguments.
+    (which is the sender), it is passed `user`, `method`, and `delete` arguments.
+    `delete` will be set to ``True`` if the user removed a sign in option.
 
     .. versionadded:: 3.4.0
+
+    .. versionchanged:: 4.2.0
+        Added delete argument.
 
 .. data:: wan_registered
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1204,10 +1204,9 @@ Unified Signin
 .. py:data:: SECURITY_US_POST_SETUP_VIEW
 
     Specifies the view to redirect to after a user successfully setups an authentication method (non-json).
-    This value can be set to a URL or an endpoint name. If this value is ``None``, the user is redirected to the
-    value of :py:data:`SECURITY_POST_LOGIN_VIEW`.
+    This value can be set to a URL or an endpoint name.
 
-    Default: ``None``
+    Default: ``"/us-setup"``
 
 .. py:data:: SECURITY_US_SIGNIN_TEMPLATE
 
@@ -1225,7 +1224,8 @@ Unified Signin
 
     Specifies the default enabled methods for unified sign in authentication.
     Be aware that ``password`` only affects this ``SECURITY_US_SIGNIN_URL`` endpoint.
-    Removing it from here won't stop users from using the ``SECURITY_LOGIN_URL`` endpoint.
+    Removing it from here won't stop users from using the ``SECURITY_LOGIN_URL`` endpoint
+    (unless you replace the login endpoint using ``SECURITY_US_SIGNIN_REPLACES_LOGIN``).
 
     If you select ``sms`` then make sure you add this to :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES`::
 
@@ -1467,6 +1467,10 @@ WebAuthn
     Default:: ``["first", "secondary"]``
 
 
+Additional relevant configuration variables:
+
+    * :py:data:`SECURITY_FRESHNESS` - Used to protect /us-setup.
+    * :py:data:`SECURITY_FRESHNESS_GRACE_PERIOD` - Used to protect /us-setup.
 
 Feature Flags
 -------------

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -660,28 +660,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/DefaultJsonErrorResponse"
   /us-signin/send-code:
-    get:
-      summary: Unified Sign In send authentication code
-      responses:
-        200:
-          description: Send Code form
-          content:
-            text/html:
-              schema:
-                example: render_template(SECURITY_US_SIGNIN_TEMPLATE)
-            application/json:
-              schema:
-                type: object
-                properties:
-                  methods:
-                    type: string
-                    description: Config setting SECURITY_US_ENABLED_METHODS
-                  code_methods:
-                    type: string
-                    description: All SECURITY_US_ENABLED_METHODS that require a code to be generated and sent.
-                  identity_attributes:
-                    type: string
-                    description: Configuration setting SECURITY_USER_IDENTITY_ATTRIBUTES
     post:
       summary: Send Code for unified sign in.
       requestBody:
@@ -736,11 +714,17 @@ paths:
                 type: object
                 properties:
                   available_methods:
-                    type: string
+                    type: array
                     description: Config setting SECURITY_US_ENABLED_METHODS
+                    items:
+                      type: string
+                      example: ["email", "sms"]
                   code_methods:
-                    type: string
-                    description: All SECURITY_US_ENABLED_METHODS that require a code to be generated and sent.
+                    type: array
+                    description: All SECURITY_US_ENABLED_METHODS that the user has setup that require a code to be generated and sent.
+                    items:
+                      type: string
+                      example: ["sms"]
                   has_webauthn_verify_credential:
                     type: boolean
                     description: <
@@ -788,25 +772,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/DefaultJsonErrorResponse"
   /us-verify/send-code:
-    get:
-      summary: Unified sign in verify/re-authenticate send authentication code
-      responses:
-        200:
-          description: Send Code form
-          content:
-            text/html:
-              schema:
-                example: render_template(SECURITY_US_VERIFY_TEMPLATE)
-            application/json:
-              schema:
-                type: object
-                properties:
-                  methods:
-                    type: string
-                    description: Config setting SECURITY_US_ENABLED_METHODS
-                  code_methods:
-                    type: string
-                    description: All SECURITY_US_ENABLED_METHODS that require a code to be generated and sent.
     post:
       summary: Send Code for unified sign in verify.
       requestBody:
@@ -857,17 +822,29 @@ paths:
                 type: object
                 properties:
                   available_methods:
-                    type: string
+                    type: array
                     description: Config setting SECURITY_US_ENABLED_METHODS
+                    items:
+                      type: string
+                      example: ["email", "sms"]
                   active_methods:
-                    type: string
+                    type: array
                     description: Methods that have already been setup.
+                    items:
+                      type: string
+                      example: ["sms"]
                   setup_methods:
-                    type: string
+                    type: array
                     description: All SECURITY_US_ENABLED_METHODS that require setup.
+                    items:
+                      type: string
+                      example: ["email", "sms", "authenticator"]
                   identity_attributes:
-                    type: string
+                    type: array
                     description: Configuration setting SECURITY_USER_IDENTITY_ATTRIBUTES
+                    items:
+                      type: string
+                      example: ["email"]
                   phone:
                     type: string
                     description: existing configured phone number
@@ -950,8 +927,7 @@ paths:
           headers:
             Location:
               description: |
-                On form-success: SECURITY_POST_SETUP_VIEW or
-                                 SECURITY_POST_LOGIN_VIEW
+                On form-success: SECURITY_POST_SETUP_VIEW
               schema:
                 type: string
         400:
@@ -1907,11 +1883,13 @@ components:
           description: which method should be used to send the code, as configured with SECURITY_US_ENABLED_METHODS
     UsSetup:
       type: object
-      required: [chosen_method]
       properties:
         chosen_method:
           type: string
           description: which method should be used to send the code, as configured with SECURITY_US_ENABLED_METHODS
+        delete_method:
+          type: string
+          description: which previously set up method should be deleted.
         phone:
           type: string
           description: phone number (this will be normalized). Required if chosen_method == "sms".
@@ -1929,6 +1907,7 @@ components:
               description: Http status code
         response:
           type: object
+          description: Response when setting up a new method. When deleting, nothing is returned.
           properties:
             chosen_method:
               type: string

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -331,7 +331,7 @@ def users_change_password(user, password):
     Administratively change a user's password.
     All the user's sessions will be immediately invalidated.
     You will have to inform the user via an out of band mechanism
-    what the their new password is.
+    what their new password is.
 
     USER is identity as defined by SECURITY_USER_IDENTITY_ATTRIBUTES.
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -287,7 +287,7 @@ _default_config: t.Dict[str, t.Any] = {
     "US_VERIFY_URL": "/us-verify",
     "US_VERIFY_SEND_CODE_URL": "/us-verify/send-code",
     "US_VERIFY_LINK_URL": "/us-verify-link",
-    "US_POST_SETUP_VIEW": None,
+    "US_POST_SETUP_VIEW": "/us-setup",
     "US_SIGNIN_TEMPLATE": "security/us_signin.html",
     "US_SETUP_TEMPLATE": "security/us_setup.html",
     "US_VERIFY_TEMPLATE": "security/us_verify.html",

--- a/flask_security/mail_util.py
+++ b/flask_security/mail_util.py
@@ -53,7 +53,7 @@ class MailUtil:
         user: "User",
         **kwargs: t.Any,
     ) -> None:
-        """Send an email via the Flask-Mail extension.
+        """Send an email via the Flask-Mailman or Flask-Mail extension.
 
         :param template: the Template name. The message has already been rendered
             however this might be useful to differentiate why the email is being sent.

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -38,10 +38,10 @@
         {% endif %}
         </em></div>
 
-        <h3>{{ _fsdomain("Setup additional sign in option") }}</h3>
+        <h3>{{ us_setup_form.chosen_method.label }}</h3>
         <div class="fs-div">
           {% for subfield in us_setup_form.chosen_method %}
-            {% if subfield.data in available_methods %}
+            {% if subfield.data in available_methods and subfield.data not in active_methods %}
                 {{ render_field_with_errors(subfield) }}
             {% endif %}
           {% endfor %}
@@ -49,14 +49,22 @@
         </div>
 
         <div class="fs-div">
-          {% if "sms" in available_methods %}
+          {% if "sms" in available_methods and "sms" not in active_methods %}
             {{ render_field_with_errors(us_setup_form.phone) }}
           {% endif %}
-          {% if code_sent %}
-            <div class="fs-important">{{ _fsdomain("Code has been sent") }}</div>
-          {% endif %}
-          {{ render_field(us_setup_form.submit) }}
         </div>
+        {% if active_methods %}
+          <h3>{{ us_setup_form.delete_method.label }}</h3>
+          <div class="fs-div">
+            {% for subfield in us_setup_form.delete_method %}
+              {% if subfield.data in active_methods %}
+                  {{ render_field_with_errors(subfield) }}
+              {% endif %}
+            {% endfor %}
+            {{ render_field_errors(us_setup_form.delete_method) }}
+          </div>
+        {% endif %}
+        <div class="fs-gap">{{ render_field(us_setup_form.submit) }}</div>
 
         {% if chosen_method == "authenticator" %}
           <hr>
@@ -78,11 +86,12 @@
     </form>
     {% if state %}
       <hr class="fs-gap">
+      <div class="fs-important">{{ _fsdomain("Enter code here to complete setup") }}</div>
       <form action="{{ url_for_security("us_setup_validate", token=state) }}" method="POST"
           name="us_setup_validate_form">
         {{ us_setup_validate_form.hidden_tag() }}
         {{ render_field_with_errors(us_setup_validate_form.passcode) }}
-        {{ render_field(us_setup_validate_form.submit) }}
+        <div class="fs-gap">{{ render_field(us_setup_validate_form.submit) }}</div>
       </form>
     {% endif %}
     {% if security.webauthn %}

--- a/flask_security/templates/security/us_verify.html
+++ b/flask_security/templates/security/us_verify.html
@@ -20,7 +20,7 @@
         {% if code_sent %}
           <p>{{ _fsdomain("Code has been sent") }}
         {% endif %}
-        {{ render_field(us_verify_form.submit_send_code, formaction=send_code_to) }}
+        <div class="fs-gap">{{ render_field(us_verify_form.submit_send_code, formaction=send_code_to) }}</div>
       {% endif %}
       </form>
       {% if has_webauthn_verify_credential %}

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -277,6 +277,7 @@ def register() -> "ResponseValue":
 
     form = form_class(form_data, meta=suppress_form_csrf())
     if form.validate_on_submit():
+        after_this_request(view_commit)
         did_login = False
         user = register_user(form)
         form.user = user
@@ -292,7 +293,6 @@ def register() -> "ResponseValue":
             if response:
                 return response
             # two factor not required - login user.
-            after_this_request(view_commit)
             login_user(user, authn_via=["register"])
             did_login = True
 
@@ -1069,7 +1069,7 @@ def create_blueprint(app, state, import_name, json_encoder=None):
         )
         bp.route(
             state.us_signin_send_code_url,
-            methods=["GET", "POST"],
+            methods=["POST"],
             endpoint="us_signin_send_code",
         )(us_signin_send_code)
         bp.route(state.us_setup_url, methods=["GET", "POST"], endpoint="us_setup")(
@@ -1088,7 +1088,7 @@ def create_blueprint(app, state, import_name, json_encoder=None):
             )(us_verify)
             bp.route(
                 state.us_verify_send_code_url,
-                methods=["GET", "POST"],
+                methods=["POST"],
                 endpoint="us_verify_send_code",
             )(us_verify_send_code)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,7 +40,7 @@ def test_cli_createuser(script_info):
     # Create user
     result = runner.invoke(
         users_create,
-        ["email@example.org", "--password", "battery staple"],
+        ["email@example.tld", "--password", "battery staple"],
         obj=script_info,
     )
     assert result.exit_code == 0
@@ -49,7 +49,7 @@ def test_cli_createuser(script_info):
     result = runner.invoke(
         users_create,
         [
-            "email1@example.org",
+            "email1@example.tld",
             "us_phone_number:5551212",
             "--password",
             "battery staple",
@@ -70,7 +70,7 @@ def test_cli_createuser_extraargs(script_info):
     result = runner.invoke(
         users_create,
         [
-            "email1@example.org",
+            "email1@example.tld",
             "security_number:666",
             "--password",
             "battery staple",
@@ -79,7 +79,7 @@ def test_cli_createuser_extraargs(script_info):
         obj=script_info,
     )
     assert result.exit_code == 0
-    result = runner.invoke(users_activate, ["email1@example.org"], obj=script_info)
+    result = runner.invoke(users_activate, ["email1@example.tld"], obj=script_info)
     assert result.exit_code == 0
     assert "was already activated" in result.output
 
@@ -90,15 +90,15 @@ def test_cli_createuser_normalize(script_info):
 
     result = runner.invoke(
         users_create,
-        ["email@EXAMPLE.org", "--password", "battery staple\N{ROMAN NUMERAL ONE}"],
+        ["email@example.tld", "--password", "battery staple\N{ROMAN NUMERAL ONE}"],
         obj=script_info,
     )
     assert result.exit_code == 0
-    assert "email@example.org" in result.stdout
+    assert "email@example.tld" in result.stdout
 
     app = script_info.load_app()
     with app.app_context():
-        user = app.security.datastore.find_user(email="email@example.org")
+        user = app.security.datastore.find_user(email="email@example.tld")
         assert verify_password(
             "battery staple\N{LATIN CAPITAL LETTER I}", user.password
         )
@@ -169,7 +169,7 @@ def test_cli_addremove_role(script_info):
 
     # Create a user and a role
     result = runner.invoke(
-        users_create, ["a@example.org", "--password", "battery staple"], obj=script_info
+        users_create, ["a@example.tld", "--password", "battery staple"], obj=script_info
     )
     assert result.exit_code == 0
     result = runner.invoke(roles_create, ["superuser"], obj=script_info)
@@ -177,42 +177,42 @@ def test_cli_addremove_role(script_info):
 
     # User not found
     result = runner.invoke(
-        roles_add, ["inval@example.org", "superuser"], obj=script_info
+        roles_add, ["inval@example.tld", "superuser"], obj=script_info
     )
     assert result.exit_code != 0
 
     # Add:
-    result = runner.invoke(roles_add, ["a@example.org", "invalid"], obj=script_info)
+    result = runner.invoke(roles_add, ["a@example.tld", "invalid"], obj=script_info)
     assert result.exit_code != 0
 
     result = runner.invoke(
-        roles_remove, ["inval@example.org", "superuser"], obj=script_info
+        roles_remove, ["inval@example.tld", "superuser"], obj=script_info
     )
     assert result.exit_code != 0
 
     # Remove:
-    result = runner.invoke(roles_remove, ["a@example.org", "invalid"], obj=script_info)
+    result = runner.invoke(roles_remove, ["a@example.tld", "invalid"], obj=script_info)
     assert result.exit_code != 0
 
     result = runner.invoke(
-        roles_remove, ["b@example.org", "superuser"], obj=script_info
+        roles_remove, ["b@example.tld", "superuser"], obj=script_info
     )
     assert result.exit_code != 0
 
     result = runner.invoke(
-        roles_remove, ["a@example.org", "superuser"], obj=script_info
+        roles_remove, ["a@example.tld", "superuser"], obj=script_info
     )
     assert result.exit_code != 0
 
     # Add:
-    result = runner.invoke(roles_add, ["a@example.org", "superuser"], obj=script_info)
+    result = runner.invoke(roles_add, ["a@example.tld", "superuser"], obj=script_info)
     assert result.exit_code == 0
-    result = runner.invoke(roles_add, ["a@example.org", "superuser"], obj=script_info)
+    result = runner.invoke(roles_add, ["a@example.tld", "superuser"], obj=script_info)
     assert result.exit_code != 0
 
     # Remove:
     result = runner.invoke(
-        roles_remove, ["a@example.org", "superuser"], obj=script_info
+        roles_remove, ["a@example.tld", "superuser"], obj=script_info
     )
     assert result.exit_code == 0
 
@@ -261,7 +261,7 @@ def test_cli_activate_deactivate(script_info):
 
     # Create a user
     result = runner.invoke(
-        users_create, ["a@example.org", "--password", "battery staple"], obj=script_info
+        users_create, ["a@example.tld", "--password", "battery staple"], obj=script_info
     )
     assert result.exit_code == 0
 
@@ -271,15 +271,15 @@ def test_cli_activate_deactivate(script_info):
     result = runner.invoke(users_deactivate, ["in@valid.org"], obj=script_info)
     assert result.exit_code != 0
 
-    result = runner.invoke(users_activate, ["a@example.org"], obj=script_info)
+    result = runner.invoke(users_activate, ["a@example.tld"], obj=script_info)
     assert result.exit_code == 0
-    result = runner.invoke(users_activate, ["a@example.org"], obj=script_info)
+    result = runner.invoke(users_activate, ["a@example.tld"], obj=script_info)
     assert result.exit_code == 0
 
     # Deactivate
-    result = runner.invoke(users_deactivate, ["a@example.org"], obj=script_info)
+    result = runner.invoke(users_deactivate, ["a@example.tld"], obj=script_info)
     assert result.exit_code == 0
-    result = runner.invoke(users_deactivate, ["a@example.org"], obj=script_info)
+    result = runner.invoke(users_deactivate, ["a@example.tld"], obj=script_info)
     assert result.exit_code == 0
 
 
@@ -288,7 +288,7 @@ def test_cli_reset_user(script_info):
     result = runner.invoke(
         users_create,
         [
-            "email1@example.org",
+            "email1@example.tld",
             "us_phone_number:5551212",
             "--password",
             "battery staple",
@@ -299,7 +299,7 @@ def test_cli_reset_user(script_info):
     result = runner.invoke(users_reset_access, ["5551212"], obj=script_info)
     assert result.exit_code == 0
     result = runner.invoke(users_reset_access, ["5551212"], obj=script_info)
-    assert result.exit_code == 0
+    assert result.exit_code == 2
 
     result = runner.invoke(users_reset_access, ["4441212"], obj=script_info)
     assert "User not found" in result.output
@@ -310,12 +310,12 @@ def test_cli_change_password(script_info):
 
     runner.invoke(
         users_create,
-        ["email1@example.org", "--password", "battery staple"],
+        ["email1@example.tld", "--password", "battery staple"],
         obj=script_info,
     )
     result = runner.invoke(
         users_change_password,
-        ["email1@example.org", "--password", "battery_staple"],
+        ["email1@example.tld", "--password", "battery_staple"],
         obj=script_info,
     )
     assert result.exit_code == 0
@@ -323,7 +323,7 @@ def test_cli_change_password(script_info):
     # check too short a password
     result = runner.invoke(
         users_change_password,
-        ["email1@example.org", "--password", "hi"],
+        ["email1@example.tld", "--password", "hi"],
         obj=script_info,
     )
     assert result.exit_code == 2
@@ -332,14 +332,14 @@ def test_cli_change_password(script_info):
     # check that password is properly normalized
     result = runner.invoke(
         users_change_password,
-        ["email1@EXAMPLE.org", "--password", "battery staple\N{ROMAN NUMERAL ONE}"],
+        ["email1@example.tld", "--password", "battery staple\N{ROMAN NUMERAL ONE}"],
         obj=script_info,
     )
     assert result.exit_code == 0
 
     app = script_info.load_app()
     with app.app_context():
-        user = app.security.datastore.find_user(email="email1@example.org")
+        user = app.security.datastore.find_user(email="email1@example.tld")
         assert verify_password(
             "battery staple\N{LATIN CAPITAL LETTER I}", user.password
         )
@@ -350,7 +350,7 @@ def test_cli_change_password(script_info):
     # check unknown user
     result = runner.invoke(
         users_change_password,
-        ["wrong_email@example.org", "--password", "battery_staple"],
+        ["wrong_email@example.tld", "--password", "battery_staple"],
         obj=script_info,
     )
     assert result.exit_code == 2

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -94,8 +94,9 @@ def test_confirmable_flag(app, clients, get_message):
 
     # Test already confirmed and expired token
     app.config["SECURITY_CONFIRM_EMAIL_WITHIN"] = "-1 days"
-    with app.app_context():
-        user = registrations[0]["user"]
+    with app.test_request_context("/"):
+        email = registrations[0]["email"]
+        user = app.security.datastore.find_user(email=email)
         expired_token = generate_confirmation_token(user)
     response = clients.get("/confirm/" + expired_token, follow_redirects=True)
     assert get_message("ALREADY_CONFIRMED") in response.data
@@ -190,13 +191,13 @@ def test_expired_confirmation_token(client, get_message):
         data = dict(email="mary@lp.com", password="awesome sunset", next="")
         client.post("/register", data=data, follow_redirects=True)
 
-    user = registrations[0]["user"]
+    email = registrations[0]["email"]
     token = registrations[0]["confirm_token"]
 
     time.sleep(1)
 
     response = client.get("/confirm/" + token, follow_redirects=True)
-    msg = get_message("CONFIRMATION_EXPIRED", within="1 milliseconds", email=user.email)
+    msg = get_message("CONFIRMATION_EXPIRED", within="1 milliseconds", email=email)
     assert msg in response.data
 
 

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -176,7 +176,7 @@ def test_unified_signin_context_processors(client, app):
     assert b"global" in response.data
     assert b"signin" in response.data
 
-    response = client.get("/us-signin/send-code")
+    response = client.post("/us-signin/send-code")
     assert b"CUSTOM UNIFIED SIGN IN" in response.data
     assert b"global" in response.data
     assert b"signin" in response.data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -259,6 +259,7 @@ def capture_registrations():
     registrations = []
 
     def _on(app, **data):
+        data["email"] = data["user"].email
         registrations.append(data)
 
     user_registered.connect(_on)


### PR DESCRIPTION
Changed the model that "email" is always automatically setup magically, and make that much like all the
other possible sign in methods.
The exception is that if a user registers WITHOUT a password, we do setup "email" as part of registration - since otherwise they wouldn't ever be able to authenticate.

Also made other smaller non-compatible changes to unified signin - send_code endpoints are not POST only, the JSON response for various endpoints now returns only setup methods, not all methods.
us-setup, on success not just redirects to US_POST_SETUP_VIEW which now defaults to point back to /us-setup.

'Fix' long time anomaly where a new user (during registration) had their DB record committed immediately - now, like all other views, the caller is required to set up a 'after_this_request'.

Fixed a bunch of openapi.yaml errors.