### PR TITLE
Change next release to 5.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
-Version 4.2.0
+Version 5.0.0
 -------------
 
 Released TBD
@@ -15,6 +15,7 @@ Features
 - (:pr:`540`) Improve Templates in support of JS required by WebAuthn
 - (:pr:`568`) Deprecate the old passwordless feature in favor of Unified Signin.
   Deprecate replacing login_manager so we can possibly vendor that in in the future.
+- (:pr:`608`) Add Icelandic translations. (ofurkusi)
 
 Fixes
 +++++

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -340,7 +340,7 @@ sends the following signals.
 
     .. versionadded:: 3.4.0
 
-    .. versionchanged:: 4.2.0
+    .. versionchanged:: 5.0.0
         Added delete argument.
 
 .. data:: wan_registered
@@ -348,13 +348,13 @@ sends the following signals.
     Sent when a WebAuthn credential was successfully created. In addition to the app
     (which is the sender), it is passed `user` and `name` arguments.
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 5.0.0
 
 .. data:: wan_deleted
 
     Sent when a WebAuthn credential was deleted. In addition to the app
     (which is the sender), it is passed `user` and `name` arguments.
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 5.0.0
 
 .. _Flask documentation on signals: https://flask.palletsprojects.com/en/2.0.x/signals/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Flask-Security"
-copyright = "2012-2021"
+copyright = "2012-2022"
 author = "Matt Wright & Chris Wagner"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -57,7 +57,7 @@ author = "Matt Wright & Chris Wagner"
 # built documents.
 #
 # The short X.Y version.
-version = "4.2.0"
+version = "5.0.0"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -134,7 +134,7 @@ These configuration keys are used globally across all features.
 
     Default: ``3`` (Good or Strong)
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 5.0.0
 .. py:data:: SECURITY_PASSWORD_CHECK_BREACHED
 
     If not ``None`` new/changed passwords will be checked against the
@@ -1100,7 +1100,7 @@ Configuration related to the two-factor authentication feature.
 
     Default: ``"/tf-select"``.
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 5.0.0
 
 
 .. py:data:: SECURITY_TWO_FACTOR_SELECT_TEMPLATE
@@ -1110,7 +1110,7 @@ Configuration related to the two-factor authentication feature.
 
     Default: ``security/two_factor_select.html``.
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 5.0.0
 
 .. py:data:: SECURITY_TWO_FACTOR_ALWAYS_VALIDATE
 
@@ -1141,7 +1141,7 @@ Configuration related to the two-factor authentication feature.
 
     Default: ``{"code": "flask_security.twofactor.CodeTfPlugin", "webauthn": "flask_security.webauthn.WebAuthnTfPlugin",}``
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 5.0.0
 
 
 Unified Signin
@@ -1288,7 +1288,7 @@ Additional relevant configuration variables:
 Passwordless
 -------------
 
-This feature is DEPRECATED as of 4.2.0. Please use unified signin feature instead.
+This feature is DEPRECATED as of 5.0.0. Please use unified signin feature instead.
 
 .. py:data:: SECURITY_PASSWORDLESS
 
@@ -1342,7 +1342,7 @@ Trackable
 WebAuthn
 --------------
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 5.0.0
 
 .. py:data:: SECURITY_WEBAUTHN
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,7 +32,7 @@ Many of these features are made possible by integrating various Flask extensions
 and libraries. They include:
 
 * `Flask-Login <https://flask-login.readthedocs.org/en/latest/>`_
-* `Flask-Mail <https://pypi.org/project/Flask-Mail/>`_
+* `Flask-Mailman <https://pypi.org/project/Flask-Mailman/>`_
 * `Flask-Principal <https://pypi.org/project/Flask-Principal/>`_
 * `Flask-WTF <https://pypi.org/project/Flask-WTF/>`_
 * `itsdangerous <https://pypi.org/project/itsdangerous/>`_

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -124,4 +124,4 @@ from .webauthn import (
 )
 from .webauthn_util import WebauthnUtil
 
-__version__ = "4.2.0"
+__version__ = "5.0.0"

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -971,7 +971,7 @@ class WebAuthnMixin:
         associated with this webauthn credential.
         Note that this probably has to be overridden using mongoengine.
 
-        .. versionadded:: 4.2.0
+        .. versionadded:: 5.0.0
         """
         return dict(id=self.user_id)  # type: ignore
 
@@ -1060,11 +1060,11 @@ class Security:
     .. versionadded:: 4.1.0
         ``username_util_cls`` added to encapsulate username handling.
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 5.0.0
         ``wan_register_form``, ``wan_register_response_form``,
          ``webauthn_signin_form``, ``wan_signin_response_form``,
          ``webauthn_delete_form``, ``webauthn_verify_form``, ``tf_select_form``.
-    .. versionadded:: 4.2.0
+    .. versionadded:: 5.0.0
         ``WebauthnUtil`` class.
 
     .. deprecated:: 4.0.0
@@ -1072,8 +1072,8 @@ class Security:
         ``two_factor_verify_password_form`` removed.
         ``password_validator`` removed in favor of the new ``password_util_cls``.
 
-    .. deprecated:: 4.2.0
-        Passing in a LoginManager instance will be removed in 5.0
+    .. deprecated:: 5.0.0
+        Passing in a LoginManager instance was removed in 5.0.0
     """
 
     def __init__(
@@ -1444,7 +1444,7 @@ class Security:
 
         if self.login_manager:
             warnings.warn(
-                "Replacing login_manager is deprecated in 4.2.0 and will be"
+                "Replacing login_manager is deprecated in 5.0.0 and will be"
                 " removed in 5.0",
                 DeprecationWarning,
             )
@@ -1475,8 +1475,8 @@ class Security:
 
         if cv("PASSWORDLESS", app=app):
             warnings.warn(
-                "The passwordless feature was deprecated in Version 4.2.0"
-                " and will be removed in 5.0. Please use the Unified Signin"
+                "The passwordless feature was deprecated in Version 5.0.0"
+                " and will be removed in the future. Please use the Unified Signin"
                 " feature instead.",
                 DeprecationWarning,
             )

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -563,7 +563,7 @@ class UserDatastore:
 
         .. versionadded:: 3.4.1
 
-        .. versionchanged:: 4.2.0
+        .. versionchanged:: 5.0.0
             Added optional method argument to delete just a single method
 
         """
@@ -620,27 +620,27 @@ class UserDatastore:
         Note that we need to find webauthn records per user as well as
         find a user from a given webauthn (credential_id) record.
 
-        .. versionadded: 4.2.0
+        .. versionadded: 5.0.0
         """
         raise NotImplementedError
 
     def delete_webauthn(self, webauthn: "WebAuthn") -> None:
         """
-        .. versionadded: 4.2.0
+        .. versionadded: 5.0.0
         """
         self.delete(webauthn)
 
     def find_webauthn(self, credential_id: bytes) -> t.Union["WebAuthn", None]:
         """Returns a credential matching the id.
 
-        .. versionadded: 4.2.0
+        .. versionadded: 5.0.0
         """
         raise NotImplementedError
 
     def find_user_from_webauthn(self, webauthn: "WebAuthn") -> t.Union["User", None]:
         """Returns user associated with this webauthn credential
 
-        .. versionadded: 4.2.0
+        .. versionadded: 5.0.0
         """
         if not self.webauthn_model:
             raise NotImplementedError
@@ -653,7 +653,7 @@ class UserDatastore:
         There doesn't appear to be any reason to change the user's
         fs_webauthn_user_handle.
 
-        .. versionadded: 4.2.0
+        .. versionadded: 5.0.0
         """
         for cred in user.webauthn:
             self.delete(cred)

--- a/flask_security/webauthn_util.py
+++ b/flask_security/webauthn_util.py
@@ -38,7 +38,7 @@ class WebauthnUtil:
     To provide your own implementation, pass in the class as ``webauthn_util_cls``
     at init time.  Your class will be instantiated once as part of app initialization.
 
-    .. versionadded:: 4.2.0
+    .. versionadded:: 5.0.0
     """
 
     def __init__(self, app: "flask.Flask"):

--- a/requirements_low/tests.txt
+++ b/requirements_low/tests.txt
@@ -1,29 +1,28 @@
 # Lowest supported versions
-Flask==1.1.4
+Flask==2.0.0
 Flask-SQLAlchemy==2.4.4
 Flask-Babel==2.0.0
 Flask-Mailman==0.3.0
 Flask-Mongoengine==1.0.0
 peewee==3.11.2
 argon2_cffi==20.1.0
-babel==2.7.0
+babel==2.9.1
 bcrypt==3.2.0
 bleach==3.2.2
 python-dateutil==2.8.2
 # next 2 come from minimums from Flask 1.1.4 and need newer jinja2 for 3.10
-jinja2==2.11.0
-itsdangerous==1.1.0
+jinja2==3.0.0
+itsdangerous==2.0.0
 markupsafe==2.0.1
 mongoengine==0.22.1
 mongomock==3.22.0
 pony==0.7.14;python_version<'3.10'
 phonenumberslite==8.11.1
 pyqrcode==1.2
-sqlalchemy==1.3.24
-sqlalchemy-utils==0.37.1
+sqlalchemy==1.4.15
+sqlalchemy-utils==0.37.4
 # These 2 come from webauthn requirements
-cryptography==3.3.2;python_version<'3.8'
-cryptography==36.0.1;python_version>='3.8'
-webauthn==1.3.0;python_version>='3.8'
-werkzeug==0.16.1
+cryptography==36.0.1
+webauthn==1.5.0;python_version>='3.8'
+werkzeug==2.0.0
 zxcvbn==4.4.28

--- a/setup.py
+++ b/setup.py
@@ -10,14 +10,15 @@ with open("flask_security/__init__.py", encoding="utf8") as f:
     version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
 
 install_requires = [
-    "Flask>=1.1.1",
-    "Flask-Login>=0.4.1",
+    "Flask>=2.0.0",
+    "Flask-Login>=0.6.0",
     "Flask-Principal>=0.4.0",
-    "Flask-WTF>=0.14.3",
+    "Flask-WTF>=1.0.0",
     "email-validator>=1.1.1",
-    "itsdangerous>=1.1.0",
-    "passlib>=1.7.2",
+    "itsdangerous>=2.0.0",
+    "passlib>=1.7.4",
     "blinker>=1.4",
+    "wtforms>=3.0.0",  # for form-level errors
 ]
 
 packages = find_packages(exclude=["tests"])


### PR DESCRIPTION
We are making too many backwards potentially incompatible changes.

Also - significantly bump up minimum versions - especially wtforms to >3.0 so we can use form level errors.