### PR TITLE
unified sign in setup/delete improvements.

### DIFF
--- a/flask_security/templates/security/_macros.html
+++ b/flask_security/templates/security/_macros.html
@@ -4,7 +4,7 @@
     {% if field.errors %}
       <ul>
       {% for error in field.errors %}
-        <li>{{ error }}</li>
+        <li class="fs-error-msg">{{ error }}</li>
       {% endfor %}
       </ul>
     {% endif %}
@@ -20,9 +20,20 @@
     {% if field and field.errors %}
       <ul>
       {% for error in field.errors %}
-        <li>{{ error }}</li>
+        <li class="fs-error-msg">{{ error }}</li>
       {% endfor %}
       </ul>
     {% endif %}
   </div>
+{% endmacro %}
+{% macro render_form_errors(form) %}
+  {% if form.form_errors %}
+    <div class="fs-div" id="fs-form-errors">
+    <ul>
+    {% for error in form.form_errors %}
+      <li class="fs-error-msg">{{ error }}</li>
+    {% endfor %}
+    </ul>
+    </div>
+  {% endif %}
 {% endmacro %}

--- a/flask_security/templates/security/_messages.html
+++ b/flask_security/templates/security/_messages.html
@@ -2,7 +2,7 @@
   {% if messages %}
     <ul class="flashes">
     {% for category, message in messages %}
-      <li class="{{ category }}">{{ message }}</li>
+      <li class="{{ category }} fs-error-msg">{{ message }}</li>
     {% endfor %}
     </ul>
   {% endif %}

--- a/flask_security/templates/security/base.html
+++ b/flask_security/templates/security/base.html
@@ -19,6 +19,7 @@
           .fs-important { font-size: larger; font-weight: bold }
           .fs-gap { margin-top: 20px; }
           .fs-div { margin: 4px; }
+          .fs-error-msg { color: darkred; }
         </style>
       {%- endblock styles %}
     {%- endblock head %}

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -21,7 +21,7 @@
 #}
 
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 
 {% block content %}
     {% include "security/_messages.html" %}
@@ -29,6 +29,7 @@
     <form action="{{ url_for_security("us_setup") }}" method="POST"
           name="us_setup_form">
       {{ us_setup_form.hidden_tag() }}
+      {{ render_form_errors(us_setup_form) }}
       {% if setup_methods %}
         <div class="fs-div">Currently active sign in options:<em>
         {% if active_methods %}

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -290,6 +290,9 @@ class UnifiedSigninSetupForm(Form):
         if not super().validate(**kwargs):
             return False
 
+        if not self.chosen_method.data and not self.delete_method.data:
+            self.form_errors.append(get_message("API_ERROR")[0])
+            return False
         if self.chosen_method.data:
             if self.chosen_method.data not in cv("US_ENABLED_METHODS"):
                 self.chosen_method.errors.append(
@@ -843,6 +846,8 @@ def us_setup() -> "ResponseValue":
 
     # Show user existing phone number
     form.phone.data = current_user.us_phone_number
+    form.chosen_method.data = None
+    form.delete_method.data = None
     return _security.render_template(
         cv("US_SETUP_TEMPLATE"),
         available_methods=cv("US_ENABLED_METHODS"),

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -693,7 +693,11 @@ def webauthn_signin_response(token: str) -> "ResponseValue":
     return redirect(url_for_security("wan_signin"))
 
 
-@auth_required(lambda: cv("API_ENABLED_METHODS"))
+@auth_required(
+    lambda: cv("API_ENABLED_METHODS"),
+    within=lambda: cv("FRESHNESS"),
+    grace=lambda: cv("FRESHNESS_GRACE_PERIOD"),
+)
 def webauthn_delete() -> "ResponseValue":
     """Deletes an existing registered credential."""
 
@@ -721,7 +725,8 @@ def webauthn_delete() -> "ResponseValue":
 
     if _security._want_json(request):
         return base_render_json(form)
-    # TODO flash something?
+    if form.name.errors:
+        do_flash(form.name.errors[0], "error")
     return redirect(url_for_security("wan_register"))
 
 

--- a/requirements_low/tests.txt
+++ b/requirements_low/tests.txt
@@ -10,7 +10,6 @@ babel==2.9.1
 bcrypt==3.2.0
 bleach==3.2.2
 python-dateutil==2.8.2
-# next 2 come from minimums from Flask 1.1.4 and need newer jinja2 for 3.10
 jinja2==3.0.0
 itsdangerous==2.0.0
 markupsafe==2.0.1

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -712,6 +712,10 @@ def test_setup(app, client, get_message):
         for i in [b"delete_method-0", b"chosen_method-1", b"chosen_method-2"]
     )
 
+    # test not supplying anything to do
+    response = client.post("us-setup", data=dict(phone="6505551212"))
+    assert get_message("API_ERROR") in response.data
+
     # test missing phone
     response = client.post("us-setup", data=dict(chosen_method="sms", phone=""))
     assert response.status_code == 200

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -629,11 +629,12 @@ def test_delete(app, clients, get_message):
     """
     response = clients.post("/wan-delete")
     assert get_message("WEBAUTHN_NAME_REQUIRED") in response.data
-
-    response = clients.post("/wan-delete", data=dict(name="testr1"))
-    assert response.status_code == 200
-    assert get_message("WEBAUTHN_NAME_NOT_FOUND", name="testr1") in response.data
     """
+
+    response = clients.post(
+        "/wan-delete", data=dict(name="testr1"), follow_redirects=True
+    )
+    assert get_message("WEBAUTHN_NAME_NOT_FOUND", name="testr1") in response.data
 
     with capture_flashes() as flashes:
         response = clients.post(


### PR DESCRIPTION
Use the wtforms 3.0 form-level errors feature to send back an error if neither chosen_method nor delete_method is selected.

This required adding support for form level errors in templates - in particular a new macro was defined that made this easy.

Added a new class - fs-error-msg for errors, flashes etc - and as an example set the color to crimson (go Quakers!)

Small fix for webauthn - webauthn_delete should require a fresh login.

Upon us-setup error - reset 'chosen_method' and 'delete_method' since WTForms doesn't really support a way for the user to 'reset' a radio button.