### PR TITLE
Add WAN_POST_REGISTER_VIEW config variable.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1375,6 +1375,13 @@ WebAuthn
 
     Default: ``"/wan-verify"``
 
+.. py:data:: SECURITY_WAN_POST_REGISTER_VIEW
+
+    Specifies the view to redirect to after a user successfully registers a new WebAuthn key (non-json).
+    This value can be set to a URL or an endpoint name.
+
+    Default: ``"/wan-register"``
+
 .. py:data:: SECURITY_WAN_REGISTER_TEMPLATE
 
     Default: ``"security/wan_register.html"``
@@ -1523,6 +1530,7 @@ A list of all URLs and Views:
 * :py:data:`SECURITY_WAN_SIGNIN_URL`
 * :py:data:`SECURITY_WAN_DELETE_URL`
 * :py:data:`SECURITY_WAN_VERIFY_URL`
+* :py:data:`SECURITY_WAN_POST_REGISTER_VIEW`
 
 Template Paths
 --------------

--- a/docs/webauthn.rst
+++ b/docs/webauthn.rst
@@ -28,6 +28,10 @@ there is at least one second-factor authentication method setup that is NOT plat
 Flask-Security requires that when registering a WebAuthn key, the user must specify whether the key
 will be used for first/primary authentication or for multi-factor/second authentication.
 
+It should be noted the the current spec REQUIRES javascript to communicate from your front-end to the browser.
+Flask-Security ships with the basic required JS (static/{webauthn.js,base64.js}).
+An application should be able to simply wire those into their templates or javascript.
+
 
 Configuration
 ++++++++++++++
@@ -47,7 +51,7 @@ flexibility in supporting a wide range of authenticators. The default configurat
 
 The bundled :class:`.WebauthnUtil` class implements the following defaults:
 
-    - The ``AuthenticatorSelectionCriteria`` is set to ``CROSS_PLATFORM`` for  webauthn keys being
+    - The ``AuthenticatorSelectionCriteria`` is set to ``CROSS_PLATFORM`` for webauthn keys being
       registered for first/primary authentication.
     - The ``UserVerificationRequirement`` is set to ``DISCOURAGED`` for keys used for secondary
       authentication, and ``PREFERRED`` for keys used for first/primary or multi-factor.

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -317,6 +317,7 @@ _default_config: t.Dict[str, t.Any] = {
     "USERNAME_NORMALIZE_FORM": "NFKD",
     "WEBAUTHN": False,
     "WAN_CHALLENGE_BYTES": None,  # uses system default
+    "WAN_POST_REGISTER_VIEW": "/wan-register",
     "WAN_RP_NAME": "My Flask App",
     "WAN_SALT": "wan-salt",
     "WAN_REGISTER_TIMEOUT": 60000,  # milliseconds

--- a/flask_security/static/js/webauthn.js
+++ b/flask_security/static/js/webauthn.js
@@ -29,20 +29,6 @@ function encode(attr) {
     c => c.charCodeAt(0));
 }
 
-async function fetch_json(url, options) {
-    const response = await fetch(url, options);
-    const body = await response.json();
-    if (body.fail) {
-      // Convert exception to our JSON API response.
-      return {
-        response: {
-          error: body.fail
-        }
-      }
-    }
-    return body;
-}
-
 /**
  * REGISTRATION FUNCTIONS
  */

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -514,7 +514,7 @@ def webauthn_register_response(token: str) -> "ResponseValue":
             return base_render_json(form)
         msg, c = get_message("WEBAUTHN_REGISTER_SUCCESSFUL", name=state["name"])
         do_flash(msg, c)
-        return redirect(url_for_security("wan_register"))
+        return redirect(get_url(cv("WAN_POST_REGISTER_VIEW")))
 
     if _security._want_json(request):
         return base_render_json(form)

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -1539,3 +1539,20 @@ def test_remember_token_tf(client):
     client.cookie_jar.clear_session_cookies()
     response = client.get("/profile")
     assert b"profile" in response.data
+
+
+@pytest.mark.settings(
+    webauthn_util_cls=HackWebauthnUtil,
+    wan_post_register_view="/post_register",
+)
+def test_post_register_redirect(app, client, get_message):
+    authenticate(client)
+
+    register_options, response_url = _register_start_json(client, name="testr3")
+    response = client.post(
+        response_url,
+        data=dict(credential=json.dumps(REG_DATA1)),
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert "/post_register" in response.location


### PR DESCRIPTION
Similar to the US_POST_SETUP_VIEW - upon successful register allow app to decide where to redirect to.

Add basic docs around javascript required for webauthn.

Remove fetch_json() method from webauthn.js - no longer used.