### PR TITLE
Webauthn fixes for Safari and Firefox

### DIFF
--- a/flask_security/models/fsqla_v3.py
+++ b/flask_security/models/fsqla_v3.py
@@ -29,9 +29,11 @@ class AsaList(types.TypeDecorator):
     impl = types.String
 
     def process_bind_param(self, value, dialect):
-        if value:
+        # produce a string from an iterable
+        try:
             return ",".join(value)
-        return value
+        except TypeError:
+            return value
 
     def process_result_value(self, value, dialect):
         if value:

--- a/flask_security/static/js/webauthn.js
+++ b/flask_security/static/js/webauthn.js
@@ -100,13 +100,19 @@ const transformNewAssertionForServer = (newAssertion) => {
 
     const registrationClientExtensions = newAssertion.getClientExtensionResults();
 
+    // Not all browsers support getTransports() (e.g. Firefox)
+    let transports = null
+    if (newAssertion.response.hasOwnProperty('getTransports')) {
+      transports = newAssertion.response.getTransports()
+    }
+
     return {
         id: newAssertion.id,
         rawId: b64enc(rawId),
         type: newAssertion.type,
         response: {"attestationObject": b64enc(attObj), "clientDataJSON": b64enc(clientDataJSON)},
         extensions: JSON.stringify(registrationClientExtensions),
-        transports: newAssertion.response.getTransports(),
+        transports: transports,
     }
 }
 

--- a/flask_security/templates/security/wan_register.html
+++ b/flask_security/templates/security/wan_register.html
@@ -36,16 +36,16 @@
       <script type="text/javascript">
         handleRegister('{{ credential_options|safe }}')
           .then((result) => {
-            if (result.credential) {
+            if (result.error_msg) {
+              const error_element = document.getElementById("wan-errors")
+              error_element.innerHTML = `<em>${result.error_msg}</em`
+            } else {
               document.getElementById("credential").value = result.credential
               {# We auto-submit this form - there is a Submit button on the
                  form we could use - but there really isn't any reason to force the
                  user to click yet another button
                #}
               document.forms["wan-register-response-form"].submit()
-            } else {
-              const error_element = document.getElementById("wan-errors")
-              error_element.innerHTML = `<em>${result.error_msg}</em`
             }
           })
       </script>

--- a/flask_security/templates/security/wan_signin.html
+++ b/flask_security/templates/security/wan_signin.html
@@ -35,21 +35,25 @@
           name="wan_signin_response_form" id="wan-signin-response-form">
       {{ wan_signin_response_form.hidden_tag() }}
       {{ render_field_errors(wan_signin_form.remember) }}
+      {#  the following is important even though it is hidden - some browsers
+          require an input focus field (such as Safari)
+      #}
+      {{ render_field(wan_signin_response_form.credential) }}
       <div id="wan-errors"></div>
     </form>
       <script type="text/javascript">
         handleSignin('{{ credential_options|safe }}')
         .then((result) => {
-          if (result.credential) {
+          if (result.error_msg) {
+            const error_element = document.getElementById("wan-errors")
+            error_element.innerHTML = `<em>${result.error_msg}</em`
+          } else {
             document.getElementById("credential").value = result.credential
             {# We auto-submit this form - there is a Submit button on the
                form we could use - but there really isn't any reason to force the
                user to click yet another button
              #}
             document.forms["wan-signin-response-form"].submit()
-          } else {
-            const error_element = document.getElementById("wan-errors")
-            error_element.innerHTML = `<em>${result.error_msg}</em`
           }
         })
       </script>

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -1164,7 +1164,7 @@ def create_blueprint(app, state, import_name, json_encoder=None):
             methods=["POST"],
             endpoint="wan_signin_response",
         )(webauthn_signin_response)
-        bp.route(state.wan_delete_url, methods=["POST"], endpoint="wan_delete")(
+        bp.route(state.wan_delete_url, methods=["GET", "POST"], endpoint="wan_delete")(
             webauthn_delete
         )
         if cv("FRESHNESS", app=app).total_seconds() >= 0 and cv(

--- a/flask_security/webauthn_util.py
+++ b/flask_security/webauthn_util.py
@@ -104,6 +104,11 @@ class WebauthnUtil:
             select_criteria.authenticator_attachment = (
                 AuthenticatorAttachment.CROSS_PLATFORM
             )
+            select_criteria.user_verification = UserVerificationRequirement.PREFERRED
+        else:
+            # For second factor minimize user-interaction by not asking for UV
+            select_criteria.user_verification = UserVerificationRequirement.DISCOURAGED
+
         if not current_app.config.get("SECURITY_WAN_ALLOW_USER_HINTS"):
             select_criteria.resident_key = ResidentKeyRequirement.REQUIRED
         else:


### PR DESCRIPTION
Both Safari and FF require an input element for 'focus' - add a hidden one.
Fix error message showing in the template when credential_create fails.

We weren't handling UserVerification quite correctly - now, on registration or signin start - if the app wants UserVerification, we store that in the state and properly pass that when validating the credential.

wan-delete needs to handle GET - since that happens when an endpoint needs fresh/verify and redirects back to the originating endpoint.

Not all browsers handle getTransports() - make that optional, and fixed issue with our DB model List to comma separated string when the list was empty.