### PR TITLE
Improve field input types.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.0
+    rev: v2.32.1
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Features
 - (:pr:`568`) Deprecate the old passwordless feature in favor of Unified Signin.
   Deprecate replacing login_manager so we can possibly vendor that in in the future.
 - (:pr:`608`) Add Icelandic translations. (ofurkusi)
+- (:issue:`256`) Add custom HTML attributes to improve user experience.
 
 Fixes
 +++++
@@ -47,6 +48,9 @@ For unified signin:
   It now does what all over views due, and have the caller responsible for committing the transaction - usually by
   setting up a flask ``after_this_request`` action. This could affect an application that captured the registration signal
   and stored the ``user`` object for later use - this user object would likely be invalid after the request is finished.
+- Some fields have custom HTML attributes attached to them (e.g. autocomplete, type, etc). These are stored as part of the
+  form in the ``render_kw`` attribute. This could cause some confusion if an app had its own templates and set different
+  attributes.
 
 For templates:
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -146,12 +146,14 @@ By default the unit tests use an in-memory sqlite DB to test datastores (except 
 MongoDatastore which uses mongomock). While this is sufficient for most changes, changes
 to the datastore layer require testing against a real DB (the CI tests test against
 postgres). It is easy to run the unit tests against a real DB instance. First
-of course install the DB locally then::
+of course install and start the DB locally then::
 
   # For postgres
   pytest --realdburl postgresql://<user>@localhost/
   # For mysql
   pytest --realdburl "mysql+pymysql://root:<password>@localhost/"
+  # For mongodb
+  pytest --realmongodburl "localhost"
 
 Views
 +++++

--- a/docs/two_factor_configurations.rst
+++ b/docs/two_factor_configurations.rst
@@ -20,8 +20,9 @@ SQLAlchemy Install requirements
 
 ::
 
-     $ python3 -m venv /path/to/new/virtual/environment
-     $ pip install flask-security-too flask-sqlalchemy flask-mail bcrypt cryptography pyqrcode
+     $ python3 -m venv pymyenv
+     $ . pymyenv/bin/activate
+     $ pip install flask-security-too[common,mfa,fsqla]
 
 
 Two-factor Application

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -450,8 +450,8 @@ _default_messages = {
         "error",
     ),
     "FAILED_TO_SEND_CODE": (_("Failed to send code. Please try again later"), "error"),
-    "TWO_FACTOR_INVALID_TOKEN": (_("Invalid Token"), "error"),
-    "TWO_FACTOR_LOGIN_SUCCESSFUL": (_("Your token has been confirmed"), "success"),
+    "TWO_FACTOR_INVALID_TOKEN": (_("Invalid code"), "error"),
+    "TWO_FACTOR_LOGIN_SUCCESSFUL": (_("Your code has been confirmed"), "success"),
     "TWO_FACTOR_CHANGE_METHOD_SUCCESSFUL": (
         _("You successfully changed your two-factor method."),
         "success",

--- a/flask_security/templates/security/_macros.html
+++ b/flask_security/templates/security/_macros.html
@@ -26,6 +26,8 @@
     {% endif %}
   </div>
 {% endmacro %}
+
+{# render WTForms (>3.0) form level errors #}
 {% macro render_form_errors(form) %}
   {% if form.form_errors %}
     <div class="fs-div" id="fs-form-errors">

--- a/flask_security/templates/security/two_factor_setup.html
+++ b/flask_security/templates/security/two_factor_setup.html
@@ -51,7 +51,7 @@
         {% if chosen_method=="sms" and chosen_method in choices %}
             <p>{{ _fsdomain("To Which Phone Number Should We Send Code To?") }}</p>
             {{ two_factor_setup_form.hidden_tag() }}
-            {{ render_field_with_errors(two_factor_setup_form.phone, placeholder="enter phone number") }}
+            {{ render_field_with_errors(two_factor_setup_form.phone) }}
             {{ render_field(two_factor_setup_form.submit) }}
         {% endif %}
     </form>

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -71,7 +71,7 @@
           <hr>
           <div class="fs-center">
             <div>
-              {{ _fsdomain("Open an authenticator app on your device and scan the following QRcode (or enter the code below manually) to start receiving passcodes:") }}
+              {{ _fsdomain("Open an authenticator app on your device and scan the following QRcode (or enter the code below manually) to start receiving codes:") }}
             </div>
             <div>
               <img alt="{{ _fsdomain("Passwordless QRCode") }}" id="qrcode" src="{{ authr_qrcode }}">

--- a/flask_security/translations/fr_FR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/fr_FR/LC_MESSAGES/flask_security.po
@@ -193,7 +193,7 @@ msgstr "Adresse email non valide"
 
 #: flask_security/core.py:413
 msgid "Invalid code"
-msgstr ""
+msgstr "Code invalide"
 
 #: flask_security/core.py:414
 msgid "Password not provided"
@@ -222,7 +222,7 @@ msgstr ""
 
 #: flask_security/core.py:426
 msgid "Phone number not valid e.g. missing country code"
-msgstr ""
+msgstr "Numéro de téléphone non valide, par ex. code pays manquant"
 
 #: flask_security/core.py:427
 msgid "Specified user does not exist"
@@ -234,7 +234,7 @@ msgstr "Mot de passe non valide"
 
 #: flask_security/core.py:429
 msgid "Password or code submitted is not valid"
-msgstr ""
+msgstr "Le mot de passe ou le code soumis n'est pas valide"
 
 #: flask_security/core.py:430
 msgid "You have successfully logged in."
@@ -426,7 +426,7 @@ msgstr "Connexion"
 #: flask_security/templates/security/email/us_instructions.html:16
 #: flask_security/templates/security/us_signin.html:6
 msgid "Sign In"
-msgstr ""
+msgstr "Sign In"
 
 #: flask_security/forms.py:64 flask_security/templates/security/_menu.html:28
 #: flask_security/templates/security/register_user.html:6
@@ -467,7 +467,7 @@ msgstr ""
 
 #: flask_security/forms.py:73
 msgid "Change Method"
-msgstr ""
+msgstr "Changer de méthode"
 
 #: flask_security/forms.py:74
 msgid "Phone Number"
@@ -475,7 +475,7 @@ msgstr ""
 
 #: flask_security/forms.py:75
 msgid "Authentication Code"
-msgstr ""
+msgstr "Code d'Identification"
 
 #: flask_security/forms.py:76
 msgid "Submit"
@@ -491,7 +491,7 @@ msgstr ""
 
 #: flask_security/forms.py:79
 msgid "Identity"
-msgstr ""
+msgstr "Identité"
 
 #: flask_security/forms.py:80
 msgid "Send Code"
@@ -499,7 +499,7 @@ msgstr ""
 
 #: flask_security/forms.py:81
 msgid "Passcode"
-msgstr ""
+msgstr "Code d'accès"
 
 #: flask_security/forms.py:82
 msgid "Username"
@@ -525,7 +525,7 @@ msgstr "Configurer par SMS"
 
 #: flask_security/forms.py:643
 msgid "Disable two factor authentication"
-msgstr ""
+msgstr "Désactiver l'authentification à deux facteurs"
 
 #: flask_security/tf_plugin.py:51
 msgid "Available Second Factor Methods:"
@@ -537,11 +537,11 @@ msgstr ""
 
 #: flask_security/unified_signin.py:129
 msgid "Code or Password"
-msgstr ""
+msgstr "Code ou mot de passe"
 
 #: flask_security/unified_signin.py:134 flask_security/unified_signin.py:262
 msgid "Available Methods"
-msgstr ""
+msgstr "Méthodes disponibles"
 
 #: flask_security/unified_signin.py:136
 msgid "Via email"
@@ -650,7 +650,7 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:35
 msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
+msgstr "Pour terminer la connexion, veuillez saisir le code envoyé à votre messagerie"
 
 #: flask_security/templates/security/two_factor_setup.html:41
 msgid ""
@@ -705,7 +705,7 @@ msgstr "Configurer une option de connexion supplémentaire"
 #: flask_security/templates/security/us_signin.html:23
 #: flask_security/templates/security/us_verify.html:21
 msgid "Code has been sent"
-msgstr ""
+msgstr "Le code a été envoyé"
 
 #: flask_security/templates/security/us_setup.html:65
 msgid ""

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -37,7 +37,15 @@ from flask import current_app as app
 from flask import after_this_request, request, session
 from flask_login import current_user
 from werkzeug.datastructures import MultiDict
-from wtforms import BooleanField, RadioField, StringField, SubmitField, validators
+from wtforms import (
+    BooleanField,
+    PasswordField,
+    RadioField,
+    StringField,
+    SubmitField,
+    TelField,
+    validators,
+)
 
 from .confirmable import requires_confirmation
 from .decorators import anonymous_user_required, auth_required, unauth_csrf
@@ -127,9 +135,14 @@ class _UnifiedPassCodeForm(Form):
     # Filled in here
     authn_via: str
 
-    passcode = StringField(
+    # PasswordField so it doesn't show, no autocomplete since it might be a password
+    # but it might be a passcode.
+    passcode = PasswordField(
         get_form_field_label("passcode"),
-        render_kw={"placeholder": _("Code or Password")},
+        render_kw={
+            "placeholder": get_form_field_xlate(_("Code or Password")),
+            "autocomplete": "off",
+        },
     )
     submit = SubmitField(get_form_field_label("submit"))
 
@@ -280,7 +293,7 @@ class UnifiedSigninSetupForm(Form):
         ],
         validate_choice=False,
     )
-    phone = StringField(get_form_field_label("phone"))
+    phone = TelField(get_form_field_label("phone"))
     submit = SubmitField(get_form_field_label("submit"))
 
     def __init__(self, *args, **kwargs):
@@ -322,7 +335,15 @@ class UnifiedSigninSetupValidateForm(Form):
     user: "User"
     totp_secret: str
 
-    passcode = StringField(get_form_field_label("passcode"), validators=[Required()])
+    passcode = StringField(
+        get_form_field_label("passcode"),
+        render_kw={
+            "autocomplete": "one-time-code",
+            "inputtype": "numeric",
+            "pattern": "[0-9]*",
+        },
+        validators=[Required()],
+    )
     submit = SubmitField(get_form_field_label("submitcode"))
 
     def __init__(self, *args, **kwargs):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -266,9 +266,9 @@ def mongoengine_setup(request, app, tmpdir, realmongodburl):
         ReferenceField,
         StringField,
     )
-    from mongoengine import PULL, CASCADE
+    from mongoengine import PULL, CASCADE, disconnect_all
 
-    db_name = "flask_security_test_%s" % str(time.time()).replace(".", "_")
+    db_name = "flask_security_test"
     app.config["MONGODB_SETTINGS"] = {
         "db": db_name,
         "host": realmongodburl if realmongodburl else "mongomock://localhost",
@@ -343,6 +343,7 @@ def mongoengine_setup(request, app, tmpdir, realmongodburl):
             Role.drop_collection()
             WebAuthn.drop_collection()
             db.connection.drop_database(db_name)
+            disconnect_all()
 
     request.addfinalizer(tear_down)
 

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -287,10 +287,7 @@ def test_confirmation_different_user_when_logged_in_no_auto(client, get_message)
     response = client.get("/confirm/" + token2, follow_redirects=True)
     assert get_message("EMAIL_CONFIRMED") in response.data
     # should get a login view
-    assert (
-        b'<input id="password" name="password" required type="password" value="">'
-        in response.data
-    )
+    assert b'<a href="/login">Login</a>' in response.data
 
 
 @pytest.mark.registerable()

--- a/tests/test_tf_plugin.py
+++ b/tests/test_tf_plugin.py
@@ -70,7 +70,7 @@ def test_tf_select(app, client, get_message):
     assert b"Please enter your authentication code generated via: sms" in response.data
     code = sms_sender.messages[0].split()[-1]
     response = client.post("/tf-validate", data=dict(code=code), follow_redirects=True)
-    assert b"Your token has been confirmed" in response.data
+    assert b"Your code has been confirmed" in response.data
 
     assert not tf_in_session(get_session(response))
 

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -1375,7 +1375,7 @@ def test_tf(app, client, get_message):
     code = sms_sender.messages[0].split()[-1]
 
     response = client.post("/tf-validate", data=dict(code=code), follow_redirects=True)
-    assert b"Your token has been confirmed" in response.data
+    assert get_message("TWO_FACTOR_LOGIN_SUCCESSFUL") in response.data
 
 
 @pytest.mark.two_factor()

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -112,6 +112,13 @@ def create_app():
             # NEVER NEVER NEVER do this in production
             return "smCCiy_k2CqQydSQ_kPEjV5a2d0ApfatcpQ1aXDmQPo"
 
+        def origin(self) -> str:
+            # Return the RP origin - normally this is just the URL of the application.
+            # To test with ngrok - we need the https address that the browser originally
+            # sent - it is sent as the ORIGIN header - not sure if this should be
+            # default or just for testing.
+            return request.origin if request.origin else request.host_url.rstrip("/")
+
     # Turn on all features (except passwordless since that removes normal login)
     for opt in [
         "changeable",

--- a/tox.ini
+++ b/tox.ini
@@ -29,12 +29,12 @@ commands =
 [testenv:py38-main]
 deps =
     -r requirements/tests.txt
-    git+git://github.com/pallets/werkzeug@main#egg=werkzeug
-    git+git://github.com/pallets/flask@main#egg=flask
-    git+git://github.com/pallets/flask-sqlalchemy@main#egg=flask-sqlalchemy
-    git+git://github.com/pallets/jinja@main#egg=jinja2
-    git+git://github.com/wtforms/wtforms@master#egg=wtforms
-    git+git://github.com/maxcountryman/flask-login@main#egg=flask-login
+    git+https://github.com/pallets/werkzeug@main#egg=werkzeug
+    git+https://github.com/pallets/flask@main#egg=flask
+    git+https://github.com/pallets/flask-sqlalchemy@main#egg=flask-sqlalchemy
+    git+https://github.com/pallets/jinja@main#egg=jinja2
+    git+https://github.com/wtforms/wtforms@master#egg=wtforms
+    git+https://github.com/maxcountryman/flask-login@main#egg=flask-login
 commands =
     python setup.py compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}


### PR DESCRIPTION
Note that these changed were to Forms - not templates. This could cause some backwards compatability concerns.

Provide templates with (modern) information about various fields by passing in input attributes such as autocomplete, pattern, etc.

- Phone number fields have <input type="tel">
- Password fields have autocomplete="current-password" or "new-password" as appropriate.
- Two-Factor-Setup and Unified Setup verify codes have autocomplete="one-time-code", inputtype="numeric", pattern="[0-9]*"
- Register username field has autocomplete="username"
- The unified signin form 'passcode' field is now a PasswordField so that it doesn't show what the user typed.

Other:
- Changed Two-factor messages from 'token' to 'code'.
- Fixed an issue with running out of file descriptors when testing against a real mongodb
- github turned off unauthorized access - change tox.ini for grabbing lates versions of flask etc.
-

Now that we are on WTForms 3.0 - remove workarounds and backward compat hacks.

closes #256