### PR TITLE
Replace unmaintained pyqrcode dependency with qrcode

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -30,7 +30,7 @@ Supported extras are:
 * ``fsqla`` - Use flask-sqlalchemy and sqlalchemy as your storage interface.
 * ``common`` - Install Flask-Mailman, bcrypt (the default password hash), and bleach.
 * ``mfa`` - Install packages used for multi-factor (two-factor, unified signin, WebAuthn):
-  cryptography, pyqrcode, phonenumberslite (note that for SMS you still need
+  cryptography, qrcode, phonenumberslite (note that for SMS you still need
   to pick an SMS provider and install appropriate packages), and webauthn.
 
 Your application will also need a database backend:

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -7,7 +7,7 @@ There are some complete (but simple) examples available in the *examples* direct
 .. note::
     The below quickstarts are just that - they don't enable most of the features (such as registration, reset, etc.).
     They basically create a single user, and you can login as that user... that's it.
-    As you add more features, additional packages (e.g. Flask-Mailman, Flask-Babel, pyqrcode) might be required
+    As you add more features, additional packages (e.g. Flask-Mailman, Flask-Babel, qrcode) might be required
     and will need to be added to your requirements.txt (or equivalent) file.
     Flask-Security does some configuration validation and will output error messages to the console
     for some missing packages.

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1595,7 +1595,7 @@ class Security:
                 and "authenticator" in cv("TWO_FACTOR_ENABLED_METHODS", app=app)
             )
             if need_qrcode:
-                self._check_modules("pyqrcode", "TWO_FACTOR or UNIFIED_SIGNIN")
+                self._check_modules("qrcode", "TWO_FACTOR or UNIFIED_SIGNIN")
 
             need_sms = (
                 cv("UNIFIED_SIGNIN", app=app)

--- a/flask_security/totp.py
+++ b/flask_security/totp.py
@@ -139,11 +139,15 @@ class Totp:
         .. versionadded:: 4.0.0
         """
         try:
-            import pyqrcode
+            import qrcode
+            import qrcode.image.svg
 
-            code = pyqrcode.create(self.get_totp_uri(username, totp))
+            image = qrcode.make(
+                self.get_totp_uri(username, totp),
+                image_factory=qrcode.image.svg.SvgImage,
+            )
             with io.BytesIO() as virtual_file:
-                code.svg(file=virtual_file, scale=3)
+                image.save(virtual_file)
                 image_as_str = base64.b64encode(virtual_file.getvalue()).decode("ascii")
 
             return f"data:image/svg+xml;base64,{image_as_str}"

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -20,10 +20,10 @@ passlib
 pony
 phonenumberslite
 pydocstyle
-pyqrcode
 pytest-cache
 pytest-cov
 pytest
+qrcode
 sqlalchemy
 sqlalchemy-utils
 webauthn>=1.5.0;python_version>='3.8'

--- a/requirements_low/tests.txt
+++ b/requirements_low/tests.txt
@@ -17,7 +17,7 @@ mongoengine==0.22.1
 mongomock==3.22.0
 pony==0.7.14;python_version<'3.10'
 phonenumberslite==8.11.1
-pyqrcode==1.2
+qrcode==7.3.1
 sqlalchemy==1.4.15
 sqlalchemy-utils==0.37.4
 # These 2 come from webauthn requirements

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ common=
     bleach>=3.3.1
 mfa=
     cryptography>=3.4.8
-    pyqrcode>=1.2
+    qrcode>=7.3.1
     phonenumberslite>=8.12.18
     webauthn>=1.5.0
 


### PR DESCRIPTION
Use the maintained `qrcode` backend instead of `pyqrcode` that has not
seen a single commit since 2015.  This paves the way forward towards
proper Python 3.11 support in Gentoo.  The result is *almost* the same:
there seems to be a barely noticeable difference in image size.

Fixes #622