### PR TITLE
Improve username support.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -117,6 +117,8 @@ Datastores
 
 Utils
 -----
+.. autofunction:: flask_security.lookup_identity
+
 .. autofunction:: flask_security.login_user
 
 .. autofunction:: flask_security.logout_user

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -383,13 +383,15 @@ These configuration keys are used globally across all features.
         ]
 
     If you enable :py:data:`SECURITY_UNIFIED_SIGNIN` and set ``sms`` as a :py:data:`SECURITY_US_ENABLED_METHODS`
-    the following would be necessary::
+    and your `SECURITY_USER_IDENTITY_ATTRIBUTES` contained::
 
         [
             {"email": {"mapper": uia_email_mapper, "case_insensitive": True}},
             {"us_phone_number": {"mapper": uia_phone_mapper}},
         ]
 
+    Then after the user sets up their SMS - they could login using their phone number and
+    get a text with the authentication code.
 
     .. versionchanged:: 4.0.0
         Changed from list to list of dict.
@@ -749,12 +751,14 @@ Registerable
 
 .. py:data:: SECURITY_USERNAME_ENABLE
 
-    If set to True, the default registration form and template will have
+    If set to True, the default registration form and template, and
+    login form and template will have
     a username field added. This requires that your user model contain the
     field ``username``. It MUST be set as 'unique' and if you don't want
     to require a username, it should be set as 'nullable'.
-    Also, if set, the LoginForm will have the 'email' input changed from
-    an EmailField (which renders as an html input=email) to a StringField.
+
+    If you already have added a username field to your forms, don't set this
+    option - the system will throw an exception at init_app time.
 
     Validation and normalization is encapsulated in :class:`.UsernameUtil`.
     Note that the default validation restricts username input to be unicode
@@ -1222,15 +1226,13 @@ Unified Signin
 
 .. py:data:: SECURITY_US_ENABLED_METHODS
 
-    Specifies the default enabled methods for unified sign in authentication.
+    Specifies the default enabled methods for unified signin authentication.
     Be aware that ``password`` only affects this ``SECURITY_US_SIGNIN_URL`` endpoint.
     Removing it from here won't stop users from using the ``SECURITY_LOGIN_URL`` endpoint
-    (unless you replace the login endpoint using ``SECURITY_US_SIGNIN_REPLACES_LOGIN``).
+    (unless you replace the login endpoint using :py:data:`SECURITY_US_SIGNIN_REPLACES_LOGIN`).
 
-    If you select ``sms`` then make sure you add this to :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES`::
-
-        {"us_phone_number": {"mapper": uia_phone_mapper}},
-
+    This config variable defines which methods can be used to provide authentication data.
+    :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES` controls what sorts of identities can be used.
 
     Default: ``["password", "email", "authenticator", "sms"]`` - which are the only supported options.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -38,7 +38,18 @@ paths:
                 example: render_template(SECURITY_LOGIN_USER_TEMPLATE)
             application/json:
               schema:
-                $ref: "#/components/schemas/DefaultJsonResponse"
+                allOf:
+                  - $ref: '#/components/schemas/BaseJsonResponse'
+                  - type: object
+                    properties:
+                      response:
+                        type: object
+                        properties:
+                          identity_attributes:
+                            type: array
+                            description: List of allowable identities
+                            items:
+                              type: string
         302:
           description: Response when already logged in (non-JSON request)
           headers:

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -101,6 +101,7 @@ from .utils import (
     check_and_update_authn_fresh,
     login_user,
     logout_user,
+    lookup_identity,
     password_breached_validator,
     password_complexity_validator,
     password_length_validator,

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -20,7 +20,7 @@ from .quart_compat import get_quart_status
 
 from .changeable import admin_change_password
 from .utils import (
-    find_user,
+    lookup_identity,
     get_identity_attributes,
     get_identity_attribute,
     hash_password,
@@ -175,7 +175,7 @@ def roles_add(user, role):
 
     USER is identity as defined by SECURITY_USER_IDENTITY_ATTRIBUTES.
     """
-    user_obj = find_user(user)
+    user_obj = lookup_identity(user)
     if user_obj is None:
         raise click.UsageError("User not found.")
 
@@ -201,7 +201,7 @@ def roles_remove(user, role):
 
     USER is identity as defined by SECURITY_USER_IDENTITY_ATTRIBUTES.
     """
-    user_obj = find_user(user)
+    user_obj = lookup_identity(user)
     if user_obj is None:
         raise click.UsageError("User not found.")
 
@@ -273,7 +273,7 @@ def users_activate(user):
 
     USER is identity as defined by SECURITY_USER_IDENTITY_ATTRIBUTES.
     """
-    user_obj = find_user(user)
+    user_obj = lookup_identity(user)
     if user_obj is None:
         raise click.UsageError("User not found.")
     if _datastore.activate_user(user_obj):
@@ -291,7 +291,7 @@ def users_deactivate(user):
 
     USER is identity as defined by SECURITY_USER_IDENTITY_ATTRIBUTES.
     """
-    user_obj = find_user(user)
+    user_obj = lookup_identity(user)
     if user_obj is None:
         raise click.UsageError("User not found.")
     if _datastore.deactivate_user(user_obj):
@@ -312,7 +312,7 @@ def users_reset_access(user):
     USER is identity as defined by SECURITY_USER_IDENTITY_ATTRIBUTES.
 
     """
-    user_obj = find_user(user)
+    user_obj = lookup_identity(user)
     if user_obj is None:
         raise click.UsageError("User not found.")
     _datastore.reset_user_access(user_obj)
@@ -336,7 +336,7 @@ def users_change_password(user, password):
     USER is identity as defined by SECURITY_USER_IDENTITY_ATTRIBUTES.
 
     """
-    user_obj = find_user(user)
+    user_obj = lookup_identity(user)
     if user_obj is None:
         raise click.UsageError("User not found.")
 

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -26,9 +26,9 @@ from .utils import (
     FsPermNeed,
     config_value,
     do_flash,
-    find_user,
     get_message,
     get_url,
+    lookup_identity,
     check_and_update_authn_fresh,
     json_error_response,
     set_request_attr,
@@ -165,7 +165,7 @@ def _check_http_auth():
     auth = request.authorization or BasicAuth(username=None, password=None)
     if not auth.username:
         return False
-    user = find_user(auth.username)
+    user = lookup_identity(auth.username)
     if user and not user.active:
         return False
 

--- a/flask_security/templates/security/login_user.html
+++ b/flask_security/templates/security/login_user.html
@@ -1,13 +1,23 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 
 {% block content %}
 {% include "security/_messages.html" %}
 <h1>{{ _fsdomain('Login') }}</h1>
   <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
     {{ login_user_form.hidden_tag() }}
-    {{ render_field_with_errors(login_user_form.email) }}
-    {{ render_field_with_errors(login_user_form.password) }}
+    {{ render_form_errors(login_user_form) }}
+    {% if "email" in identity_attributes %}
+      {{ render_field_with_errors(login_user_form.email) }}
+    {% endif %}
+    {% if login_user_form.username and "username" in identity_attributes %}
+      {% if "email" in identity_attributes %}
+        <h3>{{ _fsdomain("or") }}</h3>
+      {% endif %}
+      {{ render_field_with_errors(login_user_form.username) }}
+    {% endif %}
+    <div class="fs-gap">
+      {{ render_field_with_errors(login_user_form.password) }}</div>
     {{ render_field_with_errors(login_user_form.remember) }}
     {{ render_field_errors(login_user_form.csrf_token) }}
     {{ render_field(login_user_form.submit) }}

--- a/flask_security/tf_plugin.py
+++ b/flask_security/tf_plugin.py
@@ -8,7 +8,7 @@
     :license: MIT, see LICENSE for more details.
 
     TODO:
-        - add localzed callback for select choices.
+        - add localized callback for select choices.
 """
 import typing as t
 

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -60,7 +60,6 @@ from .utils import (
     check_and_get_token_status,
     config_value as cv,
     do_flash,
-    find_user,
     get_identity_attributes,
     get_post_login_redirect,
     get_post_verify_redirect,
@@ -69,6 +68,7 @@ from .utils import (
     get_within_delta,
     json_error_response,
     login_user,
+    lookup_identity,
     propagate_next,
     send_mail,
     suppress_form_csrf,
@@ -116,7 +116,7 @@ def _us_common_validate(form):
     # Validate identity - we go in order to figure out which user attribute the
     # request gave us. Note that we give up on the first 'match' even if that
     # doesn't yield a user. Why?
-    form.user = find_user(form.identity.data)
+    form.user = lookup_identity(form.identity.data)
     if not form.user:
         form.identity.errors.append(get_message("US_SPECIFY_IDENTITY")[0])
         return False

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -17,7 +17,6 @@ import hmac
 from pkg_resources import parse_version
 import time
 import typing as t
-import warnings
 from urllib.parse import parse_qsl, parse_qs, urlsplit, urlunsplit, urlencode
 import urllib.request
 import urllib.error
@@ -346,22 +345,6 @@ def verify_and_update_password(password: SB, user: "User") -> bool:
         user.password = hash_password(password)
         _datastore.put(user)
     return verified
-
-
-def encrypt_password(password):  # pragma: no cover
-    """Encrypt the specified plaintext password.
-
-    It uses the configured encryption options.
-
-    .. deprecated:: 2.0.2
-       Use :func:`hash_password` instead.
-
-    :param password: The plaintext password to encrypt
-    """
-    warnings.warn(
-        "Please use hash_password instead of encrypt_password.", DeprecationWarning
-    )
-    return hash_password(password)
 
 
 def hash_password(password: SB) -> t.Any:
@@ -810,7 +793,7 @@ def get_identity_attribute(
     return {}
 
 
-def find_user(identity):
+def lookup_identity(identity):
     """
     Validate identity - we go in order to figure out which user attribute the
     request gave us. Note that we give up on the first 'match' even if that

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -82,7 +82,6 @@ from .utils import (
     check_and_get_token_status,
     config_value as cv,
     do_flash,
-    find_user,
     json_error_response,
     get_message,
     get_post_login_redirect,
@@ -90,6 +89,7 @@ from .utils import (
     get_url,
     get_within_delta,
     login_user,
+    lookup_identity,
     propagate_next,
     simple_render_json,
     suppress_form_csrf,
@@ -226,7 +226,7 @@ class WebAuthnSigninForm(Form):
             # out if an unknown or disabled account - that would provide too
             # much 'discovery' capability of un-authenticated users.
             if self.identity.data:
-                user = find_user(self.identity.data)
+                user = lookup_identity(self.identity.data)
         if user and user.is_active:
             self.user = user
         return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -244,8 +244,8 @@ def app(request: pytest.FixtureRequest) -> "SecurityFixture":
     def revert_forms():
         # Some forms/tests have dynamic fields - be sure to revert them.
         if hasattr(app, "security"):
-            if hasattr(app.security.login_form, "email"):
-                del app.security.login_form.email
+            if hasattr(app.security.login_form, "username"):
+                del app.security.login_form.username
             if hasattr(app.security.register_form, "username"):
                 del app.security.register_form.username
             if hasattr(app.security.confirm_register_form, "username"):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -62,6 +62,7 @@ from flask_security.utils import (
     get_request_attr,
     hash_data,
     send_mail,
+    uia_email_mapper,
     uia_phone_mapper,
     validate_redirect_url,
     verify_hash,
@@ -106,9 +107,15 @@ def test_register_blueprint_flag(app, sqlalchemy_datastore):
 @pytest.mark.registerable()
 @pytest.mark.recoverable()
 @pytest.mark.changeable()
+@pytest.mark.settings(
+    USER_IDENTITY_ATTRIBUTES=[
+        {"email": {"mapper": uia_email_mapper}},
+        {"username": {"mapper": lambda x: x}},
+    ]
+)
 def test_basic_custom_forms(app, sqlalchemy_datastore):
     class MyLoginForm(LoginForm):
-        email = EmailField("My Login Email Address Field")
+        username = StringField("My Login Username Field")
 
     class MyRegisterForm(RegisterForm):
         email = EmailField("My Register Email Address Field")
@@ -139,7 +146,7 @@ def test_basic_custom_forms(app, sqlalchemy_datastore):
     client = app.test_client()
 
     response = client.get("/login")
-    assert b"My Login Email Address Field" in response.data
+    assert b"My Login Username Field" in response.data
 
     response = client.get("/register")
     assert b"My Register Email Address Field" in response.data


### PR DESCRIPTION
The LoginForm now has a username field added if USERNAME_ENABLE is set - rather than changing the type of the 'email' field
to string. This effectively once and for all removed the old flask-security hack of allowing username or email (or anything else) to be set in the email field and used as a possible identity.
The Login template now properly display input fields based on whether they correspond to a USER_IDENTITY_ATTRIBUTES.

Changed API for login to return the current list of USER_IDENTITY_ATTRIBUTES so templates/json can make good decisions.

Add an example in the docs for how to create your own LoginForm that has the old legacy behavior.

Changed the name of the higher level find_user method - it was very confusing since there is a DataStore find_user method as well and they were both used in similar places.

Finally remove encrypt_password() method - it has been deprecated for years.