### PR TITLE
Improve empty password support.

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -166,6 +166,18 @@ These configuration keys are used globally across all features.
 
 .. _5.1.1.2 Memorized Secret Verifiers: https://pages.nist.gov/800-63-3/sp800-63b.html#sec5
 
+.. py:data:: SECURITY_PASSWORD_REQUIRED
+
+    If set to ``False`` then a user can register with an empty password.
+    This requires :py:data:`SECURITY_UNIFIED_SIGNIN` to be enabled. By
+    default, the user will be able to authenticate using an email link.
+    Please note: this does not mean a user can sign in with an empty
+    password - it means that they must have some OTHER means of authenticating.
+
+    Default: ``True``
+
+    .. versionadded:: 5.0.0
+
 .. py:data:: SECURITY_TOKEN_AUTHENTICATION_KEY
 
     Specifies the query string parameter to read when using token authentication.
@@ -1275,6 +1287,7 @@ Unified Signin
 Additional relevant configuration variables:
 
     * :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES` - Defines the order and methods for parsing and validating identity.
+    * :py:data:`SECURITY_PASSWORD_REQUIRED` - Can a user register w/o a password?
     * :py:data:`SECURITY_DEFAULT_REMEMBER_ME`
     * :py:data:`SECURITY_SMS_SERVICE` - When SMS is enabled in :py:data:`SECURITY_US_ENABLED_METHODS`.
     * :py:data:`SECURITY_SMS_SERVICE_CONFIG`
@@ -1597,7 +1610,7 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_PASSWORD_IS_THE_SAME``
 * ``SECURITY_MSG_PASSWORD_MISMATCH``
 * ``SECURITY_MSG_PASSWORD_NOT_PROVIDED``
-* ``SECURITY_MSG_PASSWORD_NOT_SET``
+* ``SECURITY_MSG_PASSWORD_REQUIRED``
 * ``SECURITY_MSG_PASSWORD_RESET``
 * ``SECURITY_MSG_PASSWORD_RESET_EXPIRED``
 * ``SECURITY_MSG_PASSWORD_RESET_REQUEST``

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -33,7 +33,7 @@ At the bare minimum your `User` and `Role` model should include the following fi
 
 * primary key
 * ``email`` (for most features - unique, non-nullable)
-* ``password`` (non-nullable)
+* ``password`` (string)
 * ``active`` (boolean, non-nullable)
 * ``fs_uniquifier`` (string, 64 bytes, unique, non-nullable)
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -350,6 +350,18 @@ paths:
             text/html:
               schema:
                 example: render_template(SECURITY_CHANGE_PASSWORD_TEMPLATE)
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/DefaultJsonResponse'
+                  - type: object
+                    properties:
+                      response:
+                        type: object
+                        properties:
+                          active_password:
+                            type: boolean
+                            description: Does user already have a password?
     post:
       summary: Change password
       parameters:

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -153,6 +153,7 @@ _default_config: t.Dict[str, t.Any] = {
     "PASSWORD_CHECK_BREACHED": False,
     "PASSWORD_BREACHED_COUNT": 1,
     "PASSWORD_NORMALIZE_FORM": "NFKD",
+    "PASSWORD_REQUIRED": True,
     "DEPRECATED_PASSWORD_SCHEMES": ["auto"],
     "LOGIN_URL": "/login",
     "LOGOUT_URL": "/logout",
@@ -412,7 +413,6 @@ _default_messages = {
     "INVALID_EMAIL_ADDRESS": (_("Invalid email address"), "error"),
     "INVALID_CODE": (_("Invalid code"), "error"),
     "PASSWORD_NOT_PROVIDED": (_("Password not provided"), "error"),
-    "PASSWORD_NOT_SET": (_("No password is set for this user"), "error"),
     "PASSWORD_INVALID_LENGTH": (
         _("Password must be at least %(length)s characters"),
         "error",

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -1059,7 +1059,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
         id: int
         email: str
         username: t.Optional[str]
-        password: str
+        password: t.Optional[str]
         active: bool
         fs_uniquifier: str
         fs_token_uniquifier: str

--- a/flask_security/models/fsqla_v3.py
+++ b/flask_security/models/fsqla_v3.py
@@ -66,6 +66,10 @@ class FsUserMixin(FsUserMixinV2):
     # 2FA - one time recovery codes - comma separated.
     tf_recovery_codes = Column(AsaList(1024), nullable=True)
 
+    # Change password to nullable so we can tell after registration whether
+    # a user has a password or not.
+    password = Column(String(255), nullable=True)
+
     # This is repeated since I couldn't figure out how to have it reference the
     # new version of FsModels.
     @declared_attr

--- a/flask_security/templates/security/change_password.html
+++ b/flask_security/templates/security/change_password.html
@@ -6,7 +6,11 @@
 <h1>{{ _fsdomain('Change password') }}</h1>
 <form action="{{ url_for_security('change_password') }}" method="POST" name="change_password_form">
   {{ change_password_form.hidden_tag() }}
-  {{ render_field_with_errors(change_password_form.password) }}
+  {% if active_password %}
+    {{ render_field_with_errors(change_password_form.password) }}
+  {% else %}
+    <h3>{{  _fsdomain('You do not currently have a password - this will add one.') }}</h3>
+  {% endif %}
   {{ render_field_with_errors(change_password_form.new_password) }}
   {{ render_field_with_errors(change_password_form.new_password_confirm) }}
   {{ render_field(change_password_form.submit) }}

--- a/flask_security/templates/security/email/change_notice.txt
+++ b/flask_security/templates/security/email/change_notice.txt
@@ -1,4 +1,4 @@
-{{ _fsdomain('Your password has been changed') }}
+{{ _fsdomain('Your password has been changed.') }}
 {% if security.recoverable %}
 {{ _fsdomain('If you did not change your password, click the link below to reset it.') }}
 {{ url_for_security('forgot_password', _external=True) }}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,8 +385,6 @@ def sqlalchemy_setup(request, app, tmpdir, realdburl):
 
     class User(db.Model, fsqla.FsUserMixin):
         security_number = db.Column(db.Integer, unique=True)
-        # For testing allow null passwords.
-        password = db.Column(db.String(255), nullable=True)
 
         def get_security_payload(self):
             # Make sure we still properly hook up to flask JSONEncoder

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -4,7 +4,7 @@
 
     Changeable tests
 
-    :copyright: (c) 2019-2021 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -75,6 +75,16 @@ def test_changeable_flag(app, client, get_message):
     response = client.post(
         "/change",
         data={"password": "   ", "new_password": "", "new_password_confirm": ""},
+        follow_redirects=True,
+    )
+    assert get_message("PASSWORD_NOT_PROVIDED") in response.data
+    response = client.post(
+        "/change",
+        data={
+            "password": "   ",
+            "new_password": "awesome password",
+            "new_password_confirm": "awesome password",
+        },
         follow_redirects=True,
     )
     assert get_message("PASSWORD_NOT_PROVIDED") in response.data

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -267,7 +267,9 @@ def test_inactive_forbids_basic(app, client, get_message):
 
 def test_unset_password(client, get_message):
     response = authenticate(client, "jess@lp.com", "password")
-    assert get_message("PASSWORD_NOT_SET") in response.data
+    assert get_message("INVALID_PASSWORD") in response.data
+    response = authenticate(client, "jess@lp.com", "")
+    assert get_message("PASSWORD_NOT_PROVIDED") in response.data
 
 
 def test_logout(client):

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -197,6 +197,7 @@ def test_required_password_confirm(client, get_message):
 
 @pytest.mark.confirmable()
 @pytest.mark.unified_signin()
+@pytest.mark.settings(password_required=False)
 def test_allow_null_password(client, get_message):
     # If unified sign in is enabled - should be able to register w/o password
     data = dict(email="trp@lp.com", password="")
@@ -205,6 +206,7 @@ def test_allow_null_password(client, get_message):
 
 
 @pytest.mark.unified_signin()
+@pytest.mark.settings(password_required=False)
 def test_allow_null_password_nologin(client, get_message):
     # If unified sign in is enabled - should be able to register w/o password
     # With confirmable false - should be logged in automatically upon register.

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -71,7 +71,7 @@ class FlashMailUtil(MailUtil):
         user: "User",
         **kwargs: t.Any,
     ) -> None:
-        flash(body)
+        flash(f"Email body: {body}")
 
 
 def create_app():
@@ -104,6 +104,7 @@ def create_app():
     app.config["SECURITY_FRESHNESS"] = datetime.timedelta(minutes=1)
     app.config["SECURITY_FRESHNESS_GRACE_PERIOD"] = datetime.timedelta(minutes=2)
     app.config["SECURITY_USERNAME_ENABLE"] = True
+    app.config["SECURITY_PASSWORD_REQUIRED"] = False
 
     class TestWebauthnUtil(WebauthnUtil):
         def generate_challenge(self, nbytes: t.Optional[int] = None) -> str:


### PR DESCRIPTION
Previously, if a user registered w/o a passwd (which was allowed if UNIFIED_SIGNIN was enabled) we put in a non-guessable password in the password User record. This meant that after registration, there was no way to tell if a user had a legitimate password or not. Not great.

Now - change User DB model to allow the password field to be nullable.
Change registration and change endpoints to properly handle an empty password.

Add a config variable - PASSWORD_REQUIRED (default True) that selects whether an empty password is allowed.

Enhance change template to properly show or hide the 'current' password. Note that for users that don't have passwords, the /change endpoint is protected via a freshness check.

Fix small bug that GET /change with json didn't work.