### PR TITLE
Add support for two-factor recovery codes.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
     python: python3.9
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.32.1
+    rev: v2.34.0
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ Released TBD
 Features
 ++++++++
 - (:issue:`475`) Support for WebAuthn
+- (:issue:`479`) Support Two-factor recovery codes
 - (:pr:`532`) Support for Python 3.10
 - (:pr:`540`) Improve Templates in support of JS required by WebAuthn
 - (:pr:`568`) Deprecate the old passwordless feature in favor of Unified Signin.
@@ -29,12 +30,14 @@ Fixes
 - (:pr:`625`) Improve username support - the LoginForm now has a separate field for username if
   ``SECURITY_USERNAME_ENABLE`` is True, and properly displays input fields only if the associated
   field is an identity attribute (as specified by :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES`)
-- (:pr:`xxx`) Improve empty password handling. Prior, an unguessable password was set into the user
+- (:pr:`627`) Improve empty password handling. Prior, an unguessable password was set into the user
   record when a user registered without a password - now, the DB user model has been changed to
   allow nullable passwords. This provides a better user experience since Flask-Security now
   knows if a user has an empty password or not. Since registering without a password is not
   a mainstream feature, a new configuration variable :py:data:`SECURITY_PASSWORD_REQUIRED`
   has been added (defaults to ``True``).
+- (:issue:`479`) A new configuration option :py:data:`SECURITY_TWO_FACTOR_RESCUE_EMAIL` has been added
+  that allows disabling that feature - defaults to backwards compatible ``True``
 
 Backward Compatibility Concerns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -42,8 +45,8 @@ Backward Compatibility Concerns
 For unified signin:
 
 - The redirect after a successful us-setup used to redirect to ``SECURITY_US_POST_SETUP_VIEW`` or
-  ``SECURITY_POST_LOGIN_VIEW`` (which would default to '/'). Now it just redirects based on
-  ``SECURITY_US_POST_SETUP_VIEW`` configuration which defaults back to the ``/us-setup`` view.
+  ``SECURITY_POST_LOGIN_VIEW`` (which would default to '/'). Now it just redirects to
+  ``SECURITY_US_POST_SETUP_VIEW`` which defaults back to the ``/us-setup`` view.
 - The ability to authenticate using a one-time email link was automatically setup by the system
   for all users.
   "email" now behaves like the other unified sign in methods and must be explicitly set up - with the
@@ -65,7 +68,7 @@ Login:
   This has always been problematic and confusing - and with the addition of HTML attributes for various
   form fields - having a field with multiple possible inputs is no longer a viable user experience.
   This is no longer supported, and the LoginForm now declares the ``email`` field to be of type ``EmailField``
-  which requires a valid (after normalization). The most common usage of this legacy feature was to allow
+  which requires a valid (after normalization) email address. The most common usage of this legacy feature was to allow
   an email or username - Flask-Security now has core support for a ``username`` option - see :py:data:`SECURITY_USERNAME_ENABLE`.
   Please see :ref:`custom_login_form` for an example of how to replicate the legacy behavior.
 - Some error messages have changed - ``USER_DOES_NOT_EXIST`` is now returned for any identity error including an empty value.
@@ -80,6 +83,10 @@ Other:
   form in the ``render_kw`` attribute. This could cause some confusion if an app had its own templates and set different
   attributes.
 - encrypt_password method has been removed. It has been deprecated since 2.0.2
+- The keys for "/tf-rescue" select options have changed to be more 'action' oriented:
+
+    - `lost_device` -> `email`
+    - `no_mail_access` -> `help`
 
 For templates:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -213,6 +213,8 @@ Forms
 .. autoclass:: flask_security.ConfirmRegisterForm
 .. autoclass:: flask_security.ForgotPasswordForm
 .. autoclass:: flask_security.LoginForm
+.. autoclass:: flask_security.MfRecoveryCodesForm
+.. autoclass:: flask_security.MfRecoveryForm
 .. autoclass:: flask_security.PasswordlessLoginForm
 .. autoclass:: flask_security.RegisterForm
 .. autoclass:: flask_security.ResetPasswordForm

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -521,6 +521,7 @@ These are used by the Two-Factor and Unified Signin features.
         - :py:data:`SECURITY_US_SETUP_URL`
         - :py:data:`SECURITY_TWO_FACTOR_SETUP_URL`
         - :py:data:`SECURITY_WAN_REGISTER_URL`
+        - :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES`
 
     Setting this to a negative number will disable any freshness checking and
     the endpoints:
@@ -1159,6 +1160,16 @@ Configuration related to the two-factor authentication feature.
 
     .. versionadded:: 5.0.0
 
+.. py:data:: SECURITY_TWO_FACTOR_RESCUE_EMAIL
+
+    If True, then the 'email' option for two-factor rescue is enabled - allowing a user to
+    recover a missing/inoperable second factor device by requesting a one time code sent to their email.
+    While this is very convenient is has the downside that if a user's email is hacked, their second factor
+    is useless to protect their account.
+
+    Default: ``True``
+
+    .. versionadded:: 5.0.0
 
 Unified Signin
 --------------
@@ -1494,6 +1505,52 @@ Additional relevant configuration variables:
     * :py:data:`SECURITY_FRESHNESS` - Used to protect /us-setup.
     * :py:data:`SECURITY_FRESHNESS_GRACE_PERIOD` - Used to protect /us-setup.
 
+Recovery Codes
+--------------
+
+    .. versionadded:: 5.0.0
+
+.. py:data:: SECURITY_MULTI_FACTOR_RECOVERY_CODES
+
+    To enable this feature - set this to ``True``. Please see :ref:`models_topic` for
+    required additions to your database models. This enables a user to generate and
+    use a recovery code for two-factor authentication. This works for all two-factor
+    mechanisms - including webauthn. Note that these code are single use and
+    the user should be advised to write them down and store in a safe place.
+
+.. py:data:: SECURITY_MULTI_FACTOR_RECOVERY_CODES_N
+
+    How many recovery codes to generate.
+
+    Default:: 5
+
+.. py:data:: SECURITY_MULTI_FACTOR_RECOVERY_CODES_URL
+
+    Endpoint for displaying and generating recovery codes.
+
+    Default: ``"/mf-recovery-codes"``
+
+.. py:data:: SECURITY_MULTI_FACTOR_RECOVERY_CODES_TEMPLATE
+
+    Default: ``"security/mf_recovery_codes.html"``
+
+.. py:data:: SECURITY_MULTI_FACTOR_RECOVERY_URL
+
+    Endpoint for entering a recovery code.
+
+    Default: ``"/mf-recovery"``
+
+.. py:data:: SECURITY_MULTI_FACTOR_RECOVERY_TEMPLATE
+
+    Default: ``"security/mf_recovery.html"``
+
+Additional relevant configuration variables:
+
+    * :py:data:`SECURITY_FRESHNESS` - Used to protect /mf-recovery-codes.
+    * :py:data:`SECURITY_FRESHNESS_GRACE_PERIOD` - Used to protect /mf-recovery-codes.
+    * :py:data:`SECURITY_TOTP_SECRETS` - TOTP/passlib is used to generate the codes.
+    * :py:data:`SECURITY_TOTP_ISSUER`
+
 Feature Flags
 -------------
 All feature flags. By default all are 'False'/not enabled.
@@ -1507,6 +1564,7 @@ All feature flags. By default all are 'False'/not enabled.
 * ``SECURITY_TWO_FACTOR``
 * :py:data:`SECURITY_UNIFIED_SIGNIN`
 * :py:data:`SECURITY_WEBAUTHN`
+* :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES`
 
 URLs and Views
 --------------
@@ -1519,6 +1577,8 @@ A list of all URLs and Views:
 * ``SECURITY_RESET_URL``
 * ``SECURITY_CHANGE_URL``
 * ``SECURITY_CONFIRM_URL``
+* :py:data:``SECURITY_MULTI_FACTOR_RECOVERY_CODES_URL``
+* :py:data:``SECURITY_MULTI_FACTOR_RECOVERY_URL``
 * :py:data:`SECURITY_TWO_FACTOR_SELECT_URL`
 * :py:data:`SECURITY_TWO_FACTOR_SETUP_URL`
 * :py:data:`SECURITY_TWO_FACTOR_TOKEN_VALIDATION_URL`
@@ -1557,6 +1617,8 @@ A list of all templates:
 * :py:data:`SECURITY_REGISTER_USER_TEMPLATE`
 * :py:data:`SECURITY_RESET_PASSWORD_TEMPLATE`
 * :py:data:`SECURITY_CHANGE_PASSWORD_TEMPLATE`
+* :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_TEMPLATE`
+* :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES_TEMPLATE`
 * :py:data:`SECURITY_SEND_CONFIRMATION_TEMPLATE`
 * :py:data:`SECURITY_SEND_LOGIN_TEMPLATE`
 * :py:data:`SECURITY_TWO_FACTOR_VERIFY_CODE_TEMPLATE`
@@ -1597,6 +1659,7 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_INVALID_LOGIN_TOKEN``
 * ``SECURITY_MSG_INVALID_PASSWORD``
 * ``SECURITY_MSG_INVALID_PASSWORD_CODE``
+* ``SECURITY_MSG_INVALID_RECOVERY_CODE``
 * ``SECURITY_MSG_INVALID_REDIRECT``
 * ``SECURITY_MSG_INVALID_RESET_PASSWORD_TOKEN``
 * ``SECURITY_MSG_LOGIN``

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -16,6 +16,8 @@ following is a list of view templates:
 
 * `security/forgot_password.html`
 * `security/login_user.html`
+* `security/mf_recovery.html`
+* `security/mf_recovery_codes.html`
 * `security/register_user.html`
 * `security/reset_password.html`
 * `security/change_password.html`
@@ -66,6 +68,8 @@ The following is a list of all the available context processor decorators:
 * ``context_processor``: All views
 * ``forgot_password_context_processor``: Forgot password view
 * ``login_context_processor``: Login view
+* ``mf_recovery_codes_context_processor``: Setup recovery codes view
+* ``mf_recovery_context_processor``: Use recovery code view
 * ``register_context_processor``: Register view
 * ``reset_password_context_processor``: Reset password view
 * ``change_password_context_processor``: Change password view
@@ -127,6 +131,8 @@ The following is a list of all the available form overrides:
 * ``reset_password_form``: Reset password form
 * ``change_password_form``: Change password form
 * ``send_confirmation_form``: Send confirmation form
+* ``mf_recovery_codes_form``: Setup recovery codes form
+* ``mf_recovery_form``: Use recovery code form
 * ``passwordless_login_form``: Passwordless login form
 * ``two_factor_verify_code_form``: Two-factor verify code form
 * ``two_factor_select_form``: Two-factor select form

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -105,8 +105,13 @@ an authenticator app such as Google Authenticator, LastPass Authenticator, or Au
 By default, tokens provided by the authenticator app are
 valid for 2 minutes, tokens sent by mail for up to 5 minute and tokens sent by
 sms for up to 2 minutes. The QR code used to supply the authenticator app with
-the secret is generated using the PyQRCode library.
+the secret is generated using the `qrcode <https://pypi.org/project/qrcode/>`_ library.
 Please read :ref:`2fa_theory_of_operation` for more details.
+
+The Two-factor feature offers the ability for a user to 'rescue' themselves if
+they lose track of their secondary factor device. Rescue options include sending
+a one time code via email, send an email to the application admin, and using a previously
+generated and downloaded one-time code.
 
 .. _unified-sign-in:
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ and libraries. They include:
 * `Flask-WTF <https://pypi.org/project/Flask-WTF/>`_
 * `itsdangerous <https://pypi.org/project/itsdangerous/>`_
 * `passlib <https://pypi.org/project/passlib/>`_
-* `PyQRCode <https://pypi.org/project/PyQRCode/>`_
+* `QRCode <https://pypi.org/project/qrcode/>`_
 * `webauthn <https://pypi.org/project/webauthn/>`_
 
 Additionally, it assumes you'll be using a common library for your database

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -198,6 +198,19 @@ The `User` model needs the following additional fields:
 * ``fs_webauthn_user_handle`` (string, 64 bytes, unique).
   This is used as the `PublicKeyCredentialUserEntity` `id` value.
 
+Recovery Codes
+^^^^^^^^^^^^^^^
+If :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES` is set to ``True`` then
+the `User` model needs the following field:
+
+* ``mfa_recovery_codes`` (string, 1024 bytes, nullable)
+
+The length depends on how many codes are created :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES_N`
+and how long each code is (default 14 bytes).
+
+A recovery code can be used in place of any configured second-factor authenticator
+(e.g. SMS, WebAuthn, ...).
+
 Custom User Payload
 ^^^^^^^^^^^^^^^^^^^
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1165,24 +1165,30 @@ paths:
             schema:
               type: object
               properties:
-                help-setup:
-                  description: Either 'lost_device' or 'no_mail_access'.
+                help_setup:
+                  description: What rescue option is desired.
                   type: string
-                  example: "lost_device"
+                  enum: [help, email, recovery_code]
+                  example: "recovery_code"
           application/x-www-form-urlencoded:
             schema:
               type: object
               properties:
                 help_setup:
-                  description: Either 'lost_device' or 'no_mail_access'.
+                  description: What rescue option is desired.
                   type: string
-                  example: "lost_device"
+                  enum: [help, email, recovery_code]
+                  example: "email"
       responses:
         200:
           description: >
-            If 'lost_device' was specified, then an authentication code was sent to the email
-            on record for the user. If 'no_mail_access' then an email was sent to administrator address
-            specified by SECURITY_TWO_FACTOR_RESCUE_MAIL.
+            If 'email' was specified and SECURITY_TWO_FACTOR_RESCUE_EMAIL is True,
+            then an authentication code was sent to the email
+            on record for the user. If 'help' then an email was sent to administrator address
+            specified by SECURITY_TWO_FACTOR_RESCUE_MAIL. If 'recovery_code' was specified
+            and SECURITY_MULTI_FACTOR_RECOVERY_CODES is True, and the user had previously
+            setup and downloaded a set of recovery codes the user will be redirected to
+            SECURITY_MULTI_FACTOR_RECOVERY_URL.
           content:
             application/json:
               schema:
@@ -1213,14 +1219,21 @@ paths:
                 example: render_template(SECURITY_TWO_FACTOR_SELECT_TEMPLATE)
             application/json:
               schema:
-                type: object
-                properties:
-                  tf_setup_methods:
-                    type: string
-                    description: A list of methods to choose from
-                  tf_select:
-                    type: boolean
-                    example: True
+                allOf:
+                  - $ref: "#/components/schemas/DefaultJsonResponseNoUser"
+                  - type: object
+                    properties:
+                      response:
+                        type: object
+                        properties:
+                          tf_setup_methods:
+                            type: array
+                            items:
+                              type: string
+                              description: A list of methods to choose from
+                          tf_select:
+                            type: boolean
+                            example: True
     post:
       summary: Select a two-factor method
       requestBody:
@@ -1267,6 +1280,130 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DefaultJsonErrorResponse"
+  /mf-recovery-codes:
+    get:
+      summary: Generate and retrieve one-time use recovery codes.
+      description: >
+        If a user has two-factor authentication enabled, they can generate and
+        use a recovery code if they lose or otherwise can't use their second factor
+        device.
+      responses:
+        200:
+          description: Multi-factor recovery code form
+          content:
+            text/html:
+              schema:
+                example: render_template(SECURITY_MULTI_FACTOR_RECOVERY_CODES_TEMPLATE)
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/DefaultJsonResponseNoUser"
+                  - type: object
+                    properties:
+                      response:
+                        type: object
+                        properties:
+                          recovery_codes:
+                            type: array
+                            description: A list of codes
+                            items:
+                              type: string
+
+    post:
+      summary: Generate a new set of one-time recovery codes
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+                description: Generate Codes Form
+                type: string
+                example: render_template(SECURITY_MULTI_FACTOR_RECOVERY_CODES_TEMPLATE)
+      responses:
+        200:
+          description: New one-time codes generated.
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/DefaultJsonResponseNoUser"
+                  - type: object
+                    properties:
+                      response:
+                        type: object
+                        properties:
+                          recovery_codes:
+                            type: array
+                            description: List of new recovery codes
+                            items:
+                              type: string
+            text/html:
+              schema:
+                description: New codes generated.
+                type: string
+                example: render_template(SECURITY_MULTI_FACTOR_RECOVERY_CODES_TEMPLATE)
+        400:
+          description: Errors while generating new codes.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultJsonErrorResponse"
+
+  /mf-recovery:
+    get:
+      summary: Get recovery code form.
+      description: >
+        If a user has two-factor authentication enabled, they can generate and
+        use a recovery code if they lose or otherwise can't use their second factor
+        device.
+      responses:
+        200:
+          description: Multi-factor recovery form
+          content:
+            text/html:
+              schema:
+                example: render_template(SECURITY_MULTI_FACTOR_RECOVERY_TEMPLATE)
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultJsonResponseNoUser"
+
+    post:
+      summary: Use a one-time recovery code to satisfy a two-factor authentication requirement.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                code:
+                  type: string
+                  description: One-time recovery code
+          application/x-www-form-urlencoded:
+            schema:
+                description: Use one-time code form
+                type: string
+                example: render_template(SECURITY_MULTI_FACTOR_RECOVERY_TEMPLATE)
+      responses:
+        200:
+          description: Successful authentication.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultJsonResponse"
+        302:
+          description: Successful login
+          headers:
+            Location:
+              description: Redirect to ``SECURITY_POST_LOGIN_VIEW``
+              schema:
+                type: string
+        400:
+          description: Error when validating code.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultJsonErrorResponse"
+
   /wan-register:
     get:
       summary: Register a new WebAuthn key - Step 1
@@ -1632,9 +1769,7 @@ components:
       properties:
         email:
           type: string
-          description: |
-            user identifier. This is by default an email address, but can be any (unique)
-            field that is part of the User model and is defined in the __SECURITY_USER_IDENTITY_ATTRIBUTES__ configuration variable. It will also match against numeric User model fields.
+          description: user email
         password:
           type: string
           description: Password
@@ -1644,7 +1779,7 @@ components:
             If true, will remember userid as part of cookie. There is a configuration variable DEFAULT_REMEMBER_ME that can be set. This field will override that.
         tf_validity_token:
           type: string
-          description: Code verifying the user has successfully verfied 2FA in the past. If verified, the user is able to skip validation of the second factor. Only used when SECURITY_TWO_FACTOR_ALWAYS_VALIDATE is False.
+          description: Code verifying the user has successfully verified 2FA in the past. If verified, the user is able to skip validation of the second factor. Only used when SECURITY_TWO_FACTOR_ALWAYS_VALIDATE is False.
     LoginJsonResponse:
       type: object
       description: >
@@ -1673,9 +1808,21 @@ components:
             tf_state:
               type: string
               description: if "setup_from_login" then the caller must go through two-factor setup endpoint. If "ready" then a code has been sent and should be supplied to SECURITY_TWO_FACTOR_TOKEN_VALIDATION_URL.
-            tf_primary_method:
+            tf_method:
               type: string
               description: Which method was used to send code.
+              example: "webauthn"
+            tf_select:
+              type: boolean
+              description: <
+                If user has setup multiple forms of two-factor authentication, this will be True
+                and the application should prompt the user for which method they want to use.
+            tf_setup_methods:
+              type: array
+              items:
+                type: string
+                description: If user has setup multiple forms of two-factor authentication they are listed
+
     BaseJsonResponse:
       type: object
       required: [ meta, response ]

--- a/docs/two_factor_configurations.rst
+++ b/docs/two_factor_configurations.rst
@@ -181,8 +181,12 @@ the desired 2FA method, and finally have the user enter the code and POST to ``/
 
 Rescue
 ~~~~~~
-Life happens - if the user doesn't have their mobile devices (SMS) or authenticator app, then they can request using ``/tf-rescue`` endpoint to have the code sent to their email.
-If they have lost access to their email, they can request an email be sent to the application administrators.
+Life happens - if the user doesn't have their mobile devices (SMS) or authenticator app, then they can use the ``/tf-rescue`` endpoint to
+see possible recovery options. Flask-Security supports the following:
+
+    - Have a one-time code sent to their email.
+    - Send an email to the application administrators.
+    - Use a previously setup one-time recovery code (see :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES`)
 
 Validity
 ++++++++

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -49,6 +49,8 @@ from .forms import (
     ResetPasswordForm,
     PasswordlessLoginForm,
     ConfirmRegisterForm,
+    MfRecoveryForm,
+    MfRecoveryCodesForm,
     SendConfirmationForm,
     TwoFactorRescueForm,
     TwoFactorSetupForm,

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -776,19 +776,50 @@ class TwoFactorVerifyCodeForm(Form, CodeFormMixin):
 class TwoFactorRescueForm(Form):
     """The Two-factor Rescue validation form"""
 
+    # rescue options - additional options are generated in set_rescue_options()
     help_setup = RadioField(
-        "Trouble Accessing Your Account?",
+        "Trouble Accessing Your Account?/Lost Mobile Device?",
         choices=[
-            ("lost_device", "Can not access mobile device?"),
-            ("no_mail_access", "Can not access mail account?"),
+            ("help", "Contact Administrator"),
         ],
     )
     submit = SubmitField(get_form_field_label("submit"))
+
+
+class MfRecoveryCodesForm(Form):
+    """Generate and fetch recovery codes"""
+
+    show_codes = SubmitField(get_form_field_xlate(_("Show Recovery Codes")))
+    generate_new_codes = SubmitField(
+        get_form_field_xlate(_("Generate New Recovery Codes"))
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):  # pragma: no cover
+            return False
+        return True
+
+
+class MfRecoveryForm(Form):
+    code = StringField(
+        get_form_field_xlate(_("Recovery Code")),
+        validators=[Required()],
+    )
+    submit = SubmitField(get_form_field_label("submitcode"))
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # filled by view
+        self.user: "User" = None
+
+    def validate(self, **kwargs: t.Any) -> bool:
+        if not super().validate(**kwargs):  # pragma: no cover
+            return False
+        codes = _datastore.mf_get_recovery_codes(self.user)
+        if self.code.data not in codes:
+            self.code.errors.append(get_message("INVALID_RECOVERY_CODE")[0])
             return False
         return True

--- a/flask_security/models/fsqla_v3.py
+++ b/flask_security/models/fsqla_v3.py
@@ -15,6 +15,7 @@ This is Version 3:
 
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, LargeBinary, String
 from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.sql import func
 import sqlalchemy.types as types
 
@@ -63,8 +64,8 @@ class FsUserMixin(FsUserMixinV2):
     # Note max length 64 as specified in spec.
     fs_webauthn_user_handle = Column(String(64), unique=True)
 
-    # 2FA - one time recovery codes - comma separated.
-    tf_recovery_codes = Column(AsaList(1024), nullable=True)
+    # MFA - one time recovery codes - comma separated.
+    mf_recovery_codes = Column(MutableList.as_mutable(AsaList(1024)), nullable=True)
 
     # Change password to nullable so we can tell after registration whether
     # a user has a password or not.
@@ -88,7 +89,7 @@ class FsWebAuthnMixin(WebAuthnMixin):
     credential_id = Column(LargeBinary(1024), index=True, unique=True, nullable=False)
     public_key = Column(LargeBinary, nullable=False)
     sign_count = Column(Integer, default=0)
-    transports = Column(AsaList(255), nullable=True)
+    transports = Column(MutableList.as_mutable(AsaList(1024)), nullable=True)
 
     # a JSON string as returned from registration
     extensions = Column(String(255), nullable=True)

--- a/flask_security/templates/security/mf_recovery.html
+++ b/flask_security/templates/security/mf_recovery.html
@@ -1,0 +1,13 @@
+{% extends "security/base.html" %}
+{% from "security/_macros.html" import render_field_with_errors, render_field %}
+
+{% block content %}
+    {% include "security/_messages.html" %}
+    <h1>{{ _fsdomain("Enter Recovery Code") }}</h1>
+    <form action="{{ url_for_security("mf_recovery") }}" method="POST"
+          name="mf_recovery_form">
+        {{ mf_recovery_form.hidden_tag() }}
+        {{ render_field_with_errors(mf_recovery_form.code) }}
+        {{ render_field(mf_recovery_form.submit) }}
+    </form>
+{% endblock %}

--- a/flask_security/templates/security/mf_recovery_codes.html
+++ b/flask_security/templates/security/mf_recovery_codes.html
@@ -1,0 +1,31 @@
+{% extends "security/base.html" %}
+{% from "security/_macros.html" import render_field_with_errors, render_field %}
+
+{% block content %}
+    {% include "security/_messages.html" %}
+    <h1>{{ _fsdomain("Recovery Codes") }}</h1>
+    {% if recovery_codes %}
+      <ul>
+        {% for rc in recovery_codes %}
+          <li class="fs-div">{{ rc }}</li>
+        {% endfor %}
+      </ul>
+      <div class="fs-important">
+      {{ _fsdomain("Be sure to copy these and store in a safe place. Each code can be used only once.") }}
+      </div>
+    {% else %}
+      <form action="{{ url_for_security("mf_recovery_codes") }}" method="GET"
+            name="mf_recovery_codes_form">
+
+          {{ render_field(mf_recovery_codes_form.show_codes) }}
+      </form>
+    {% endif %}
+    <hr class="fs-gap">
+    <h2>Generate new Recovery Codes</h2>
+    <form action="{{ url_for_security("mf_recovery_codes") }}" method="POST"
+      name="mf_recovery_codes_form">
+        {{ mf_recovery_codes_form.hidden_tag() }}
+        {{ render_field(mf_recovery_codes_form.generate_new_codes) }}
+    </form>
+    {% include "security/_menu.html" %}
+{% endblock %}

--- a/flask_security/templates/security/two_factor_setup.html
+++ b/flask_security/templates/security/two_factor_setup.html
@@ -56,7 +56,7 @@
         {% endif %}
     </form>
     {% if security.webauthn and not chosen_method %}
-      <h3>WebAuthn</h3>
+      <h3>{{ _fsdomain("WebAuthn") }}</h3>
       <div class="fs-div">
         {{ _fsdomain("This application supports WebAuthn security keys.") }}
         <a href="{{ url_for_security('wan_register') }}">{{ _fsdomain("You can set them up here.") }}</a>
@@ -71,6 +71,13 @@
           {{ render_field_with_errors(two_factor_verify_code_form.code) }}
           {{ render_field(two_factor_verify_code_form.submit) }}
       </form>
+    {% endif %}
+    {% if security.support_mfa and security.multi_factor_recovery_codes %}
+      <h3>{{ _fsdomain("Recovery Codes") }}</h3>
+      <div class="fs-div">
+        {{ _fsdomain("This application supports setting up recovery codes.") }}
+        <a href="{{ url_for_security('mf_recovery_codes') }}">{{ _fsdomain("You can set them up here.") }}</a>
+      </div>
     {% endif %}
     {% include "security/_menu.html" %}
 {% endblock %}

--- a/flask_security/templates/security/two_factor_verify_code.html
+++ b/flask_security/templates/security/two_factor_verify_code.html
@@ -11,13 +11,14 @@
         {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder="enter code") }}
         {{ render_field(two_factor_verify_code_form.submit) }}
     </form>
+    <hr class="fs-gap">
     <form action="{{ url_for_security("two_factor_rescue") }}" method="POST" name="two_factor_rescue_form">
         {{ two_factor_rescue_form.hidden_tag() }}
         {{ render_field_with_errors(two_factor_rescue_form.help_setup) }}
-        {% if problem=="lost_device" %}
+        {% if problem=="email" %}
             <div>{{ _fsdomain("The code for authentication was sent to your email address") }}</div>
         {% endif %}
-        {% if problem=="no_mail_access" %}
+        {% if problem=="help" %}
             <div>{{ _fsdomain("A mail was sent to us in order to reset your application account") }}</div>
         {% endif %}
         {{ render_field(two_factor_rescue_form.submit) }}

--- a/flask_security/templates/security/wan_register.html
+++ b/flask_security/templates/security/wan_register.html
@@ -71,5 +71,13 @@
         {{ render_field(wan_delete_form.submit) }}
       </form>
   {% endif %}
+  {% if security.support_mfa and security.multi_factor_recovery_codes %}
+    <hr>
+    <h2>{{ _fsdomain("Recovery Codes") }}</h2>
+    <div class="fs-div">
+      {{ _fsdomain("This application supports setting up recovery codes.") }}
+      <a href="{{ url_for_security('mf_recovery_codes') }}">{{ _fsdomain("You can set them up here.") }}</a>
+    </div>
+    {% endif %}
   {% include "security/_menu.html" %}
 {% endblock %}

--- a/flask_security/totp.py
+++ b/flask_security/totp.py
@@ -12,6 +12,7 @@ import io
 import typing as t
 
 from passlib.totp import TOTP, TokenError, TotpMatch
+from passlib.pwd import genword
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from .datastore import User
@@ -154,6 +155,23 @@ class Totp:
         except ImportError:  # pragma: no cover
             # This should have been checked at app init.
             raise
+
+    def generate_recovery_codes(self, number: int) -> t.List[str]:
+        """Generate a set of secure passwords - used a 2FA recovery codes.
+            # this is nice for english - but not for others
+            return genphrase(entropy="fair", wordset="eff_short", sep="-",
+             returns=number)
+
+        .. versionadded:: 5.0.0
+        """
+        pwds = genword(length=12, charset="hex", returns=number)
+        # make this a bit easier to type - 3 sets of 4 characters
+        spwds = []
+        for pwd in pwds:
+            spwds.append(
+                "-".join([pwd[i : i + 4] for i in range(0, len(pwd), 4)])  # noqa: E203
+            )
+        return spwds
 
     def get_last_counter(self, user: "User") -> t.Optional[TotpMatch]:
         """Implement this to fetch stored last_counter from cache.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -326,6 +326,7 @@ def mongoengine_setup(request, app, tmpdir, realmongodburl):
         tf_primary_method = StringField(max_length=255)
         tf_totp_secret = StringField(max_length=255)
         tf_phone_number = StringField(max_length=255)
+        mf_recovery_codes = ListField(required=False)
         us_totp_secrets = StringField()
         us_phone_number = StringField(max_length=255)
         last_login_ip = StringField(max_length=100)
@@ -416,6 +417,7 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl):
     from sqlalchemy import create_engine
     from sqlalchemy.orm import scoped_session, sessionmaker, relationship, backref
     from sqlalchemy.ext.declarative import declarative_base, declared_attr
+    from sqlalchemy.ext.mutable import MutableList
     from sqlalchemy.sql import func
     from sqlalchemy import (
         Boolean,
@@ -452,7 +454,7 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl):
         )
         public_key = Column(LargeBinary, nullable=False)
         sign_count = Column(Integer, default=0)
-        transports = Column(AsaList(255), nullable=True)  # comma separated
+        transports = Column(MutableList.as_mutable(AsaList(255)), nullable=True)
 
         # a JSON string as returned from registration
         extensions = Column(String(255), nullable=True)
@@ -512,6 +514,7 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl):
         tf_primary_method = Column(String(255), nullable=True)
         tf_totp_secret = Column(String(255), nullable=True)
         tf_phone_number = Column(String(255), nullable=True)
+        mf_recovery_codes = Column(MutableList.as_mutable(AsaList(1024)), nullable=True)
         us_totp_secrets = Column(Text, nullable=True)
         us_phone_number = Column(String(64), nullable=True)
         last_login_ip = Column(String(100))
@@ -624,6 +627,7 @@ def peewee_setup(request, app, tmpdir, realdburl):
         tf_primary_method = TextField(null=True)
         tf_totp_secret = TextField(null=True)
         tf_phone_number = TextField(null=True)
+        mf_recovery_codes = AsaList(null=True)
         us_totp_secrets = TextField(null=True)
         us_phone_number = TextField(null=True)
         last_login_ip = TextField(null=True)

--- a/tests/templates/custom_security/mf_recovery.html
+++ b/tests/templates/custom_security/mf_recovery.html
@@ -1,0 +1,3 @@
+CUSTOM MF RECOVERY
+{{ global }}
+{{ foo }}

--- a/tests/templates/custom_security/mf_recovery_codes.html
+++ b/tests/templates/custom_security/mf_recovery_codes.html
@@ -1,0 +1,3 @@
+CUSTOM MF RECOVERY CODES
+{{ global }}
+{{ foo }}

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -105,6 +105,7 @@ def create_app():
     app.config["SECURITY_FRESHNESS_GRACE_PERIOD"] = datetime.timedelta(minutes=2)
     app.config["SECURITY_USERNAME_ENABLE"] = True
     app.config["SECURITY_PASSWORD_REQUIRED"] = False
+    app.config["SECURITY_MULTI_FACTOR_RECOVERY_CODES"] = True
 
     class TestWebauthnUtil(WebauthnUtil):
         def generate_challenge(self, nbytes: t.Optional[int] = None) -> str:


### PR DESCRIPTION
These are single-use codes that a user can generate, download and store safely.

A new feature flag SECURITY_MULTI_FACTOR_RECOVERY_CODES enables this feature and causes the various views/forms to be registered.

The old two-factor rescue endpoint has been updated to present this option if available.
A new configuration option SECURITY_TWO_FACTOR_RESCUE_EMAIL (default True) allows the application to NOT allow a recovery code to be sent to the users email (this could be considered a security issue).

closes #479