### PR TITLE
Add support for generic response messages.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,12 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.34.0
+    rev: v2.37.1
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.6.0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Features
 Fixes
 +++++
 - (:pr:`591`) Make the required zxcvbn complexity score configurable (mephi42)
+- (:issue:`585`) Provide option to prevent user enumeration.
 - (:issue:`531`) Get rid of Flask-Mail. Flask-Mailman is now the default preferred email package.
   Flask-Mail is still supported so there should be no backwards compatability issues.
 - (:issue:`597`) A delete option has been added to us-setup (form and view).
@@ -60,6 +61,8 @@ For unified signin:
 - ``SECURITY_US_VERIFY_SEND_CODE_URL`` and ``SECURITY_US_SIGNIN_SEND_CODE_URL`` endpoints are now POST only.
 - Empty passwords were always permitted when ``SECURITY_UNIFIED_SIGNIN`` was enabled - now an additional configuration
   variable ``SECURITY_PASSWORD_REQUIRED`` must be set to False.
+- ``SECURITY_US_VERIFY_SEND_CODE_URL`` and ``SECURITY_US_SIGNIN_SEND_CODE_URL`` used to send ``code_sent`` to the template.
+  Now they flash the ``SECURITY_MSG_CODE_HAS_BEEN_SENT`` message.
 
 Login:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -268,6 +268,19 @@ sends the following signals.
    `form_data` is a dictionary representation of registration form's content
    received with the registration request.
 
+.. data:: user_not_registered
+
+    Sent when a user attempts to register, but is already registered. This is ONLY sent
+    when :py:data:`SECURITY_RETURN_GENERIC_RESPONSES` is enabled. It is passed the
+    following arguments:
+
+        * `user` - The existing user model
+        * `existing_email` - True if attempting to register an existing email
+        * `existing_username`- True if attempting to register an existing username
+        * `form_data` - the entire contents of the posted request form
+
+    .. versionadded:: 5.0.0
+
 .. data:: user_confirmed
 
    Sent when a user is confirmed. In addition to the app (which is the

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -435,6 +435,13 @@ These configuration keys are used globally across all features.
 
     Default: ``False``.
 
+.. py:data:: SECURITY_RETURN_GENERIC_RESPONSES
+
+    If set to ``True`` Flask-Security will return generic responses to endpoints
+    that could be used to enumerate users. Please see :ref:`generic_responses`.
+
+    .. versionadded:: 5.0.0
+
 .. py:data:: SECURITY_BACKWARDS_COMPAT_UNAUTHN
 
     If set to ``True`` then the default behavior for authentication
@@ -1515,7 +1522,7 @@ Recovery Codes
     To enable this feature - set this to ``True``. Please see :ref:`models_topic` for
     required additions to your database models. This enables a user to generate and
     use a recovery code for two-factor authentication. This works for all two-factor
-    mechanisms - including webauthn. Note that these code are single use and
+    mechanisms - including WebAuthn. Note that these code are single use and
     the user should be advised to write them down and store in a safe place.
 
 .. py:data:: SECURITY_MULTI_FACTOR_RECOVERY_CODES_N
@@ -1642,6 +1649,7 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_ALREADY_CONFIRMED``
 * ``SECURITY_MSG_API_ERROR``
 * ``SECURITY_MSG_ANONYMOUS_USER_REQUIRED``
+* ``SECURITY_MSG_CODE_HAS_BEEN_SENT``
 * ``SECURITY_MSG_CONFIRMATION_EXPIRED``
 * ``SECURITY_MSG_CONFIRMATION_REQUEST``
 * ``SECURITY_MSG_CONFIRMATION_REQUIRED``
@@ -1652,6 +1660,9 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_EMAIL_NOT_PROVIDED``
 * ``SECURITY_MSG_FAILED_TO_SEND_CODE``
 * ``SECURITY_MSG_FORGOT_PASSWORD``
+* ``SECURITY_MSG_GENERIC_AUTHN_FAILED``
+* ``SECURITY_MSG_GENERIC_RECOVERY``
+* ``SECURITY_MSG_GENERIC_US_SIGNIN``
 * ``SECURITY_MSG_IDENTITY_ALREADY_ASSOCIATED``
 * ``SECURITY_MSG_INVALID_CODE``
 * ``SECURITY_MSG_INVALID_CONFIRMATION_TOKEN``

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -303,6 +303,10 @@ The following is a list of email templates:
 * `security/email/change_notice.html`
 * `security/email/welcome.html`
 * `security/email/welcome.txt`
+* `security/email/welcome_existing.html`
+* `security/email/welcome_existing.txt`
+* `security/email/welcome_existing_username.html`
+* `security/email/welcome_existing_username.txt`
 * `security/email/two_factor_instructions.html`
 * `security/email/two_factor_instructions.txt`
 * `security/email/two_factor_rescue.html`
@@ -338,33 +342,37 @@ to ``False`` will bypass sending of the email (they all default to ``True``).
 In most cases, in addition to an email being sent, a :ref:`Signal <signals_topic>` is sent.
 The table below summarizes all this:
 
-=============================   ================================   =============================================     ====================== ===============================
-**Template Name**               **Gate Config**                    **Subject Config**                                **Context Vars**       **Signal Sent**
------------------------------   --------------------------------   ---------------------------------------------     ---------------------- -------------------------------
-welcome                         SECURITY_SEND_REGISTER_EMAIL       SECURITY_EMAIL_SUBJECT_REGISTER                   - user                 user_registered
-                                                                                                                     - confirmation_link
-                                                                                                                     - confirmation_token
-confirmation_instructions       N/A                                SECURITY_EMAIL_SUBJECT_CONFIRM                    - user                 confirm_instructions_sent
-                                                                                                                     - confirmation_link
-                                                                                                                     - confirmation_token
-login_instructions              N/A                                SECURITY_EMAIL_SUBJECT_PASSWORDLESS               - user                 login_instructions_sent
-                                                                                                                     - login_link
-                                                                                                                     - login_token
-reset_instructions              SEND_PASSWORD_RESET_EMAIL          SECURITY_EMAIL_SUBJECT_PASSWORD_RESET             - user                 reset_password_instructions_sent
-                                                                                                                     - reset_link
-                                                                                                                     - reset_token
-reset_notice                    SEND_PASSWORD_RESET_NOTICE_EMAIL   SECURITY_EMAIL_SUBJECT_PASSWORD_NOTICE            - user                 password_reset
+=============================   ==================================   =============================================     ====================== ===============================
+**Template Name**               **Gate Config**                      **Subject Config**                                **Context Vars**       **Signal Sent**
+-----------------------------   ----------------------------------   ---------------------------------------------     ---------------------- -------------------------------
+welcome                         SECURITY_SEND_REGISTER_EMAIL         SECURITY_EMAIL_SUBJECT_REGISTER                   - user                 user_registered
+                                                                                                                       - confirmation_link
+                                                                                                                       - confirmation_token
+confirmation_instructions       N/A                                  SECURITY_EMAIL_SUBJECT_CONFIRM                    - user                 confirm_instructions_sent
+                                                                                                                       - confirmation_link
+                                                                                                                       - confirmation_token
+login_instructions              N/A                                  SECURITY_EMAIL_SUBJECT_PASSWORDLESS               - user                 login_instructions_sent
+                                                                                                                       - login_link
+                                                                                                                       - login_token
+reset_instructions              SEND_PASSWORD_RESET_EMAIL            SECURITY_EMAIL_SUBJECT_PASSWORD_RESET             - user                 reset_password_instructions_sent
+                                                                                                                       - reset_link
+                                                                                                                       - reset_token
+reset_notice                    SEND_PASSWORD_RESET_NOTICE_EMAIL     SECURITY_EMAIL_SUBJECT_PASSWORD_NOTICE            - user                 password_reset
 
-change_notice                   SEND_PASSWORD_CHANGE_EMAIL         SECURITY_EMAIL_SUBJECT_PASSWORD_CHANGE_NOTICE     - user                 password_changed
-two_factor_instructions         N/A                                SECURITY_EMAIL_SUBJECT_TWO_FACTOR                 - user                 tf_security_token_sent
-                                                                                                                     - token
-                                                                                                                     - username
-two_factor_rescue               N/A                                SECURITY_EMAIL_SUBJECT_TWO_FACTOR_RESCUE          - user                 N/A
-us_instructions                 N/A                                SECURITY_US_EMAIL_SUBJECT                         - user                 us_security_token_sent
-                                                                                                                     - login_token
-                                                                                                                     - login_link
-                                                                                                                     - username
-=============================   ================================   =============================================     ====================== ===============================
+change_notice                   SEND_PASSWORD_CHANGE_EMAIL           SECURITY_EMAIL_SUBJECT_PASSWORD_CHANGE_NOTICE     - user                 password_changed
+two_factor_instructions         N/A                                  SECURITY_EMAIL_SUBJECT_TWO_FACTOR                 - user                 tf_security_token_sent
+                                                                                                                       - token
+                                                                                                                       - username
+two_factor_rescue               N/A                                  SECURITY_EMAIL_SUBJECT_TWO_FACTOR_RESCUE          - user                 N/A
+us_instructions                 N/A                                  SECURITY_US_EMAIL_SUBJECT                         - user                 us_security_token_sent
+                                                                                                                       - login_token
+                                                                                                                       - login_link
+                                                                                                                       - username
+welcome_existing                SECURITY_SEND_REGISTER_EMAIL         SECURITY_EMAIL_SUBJECT_REGISTER                   - user                 user_not_registered
+                                SECURITY_RETURN_GENERIC_RESPONSES                                                      - recovery_link
+welcome_existing_username       SECURITY_SEND_REGISTER_EMAIL         SECURITY_EMAIL_SUBJECT_REGISTER                   - email                user_not_registered
+                                SECURITY_RETURN_GENERIC_RESPONSES                                                      - username
+=============================   ==================================   =============================================     ====================== ===============================
 
 When sending an email, Flask-Security goes through the following steps:
 
@@ -375,7 +383,7 @@ When sending an email, Flask-Security goes through the following steps:
 
   #. Calls :meth:`.MailUtil.send_mail` with all the required parameters.
 
-The default implementation of ``MailUtil.send_mail`` uses Flask-Mail to create and send the message.
+The default implementation of ``MailUtil.send_mail`` uses flask-mailman to create and send the message.
 By providing your own implementation, you can use any available python email handling package.
 
 Email subjects are by default localized - see above section on Localization to learn how

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -119,6 +119,7 @@ _default_config: t.Dict[str, t.Any] = {
     "URL_PREFIX": None,
     "SUBDOMAIN": None,
     "FLASH_MESSAGES": True,
+    "RETURN_GENERIC_RESPONSES": False,
     "I18N_DOMAIN": "flask_security",
     "I18N_DIRNAME": pkg_resources.resource_filename("flask_security", "translations"),
     "EMAIL_VALIDATOR_ARGS": None,
@@ -350,6 +351,21 @@ _default_config: t.Dict[str, t.Any] = {
 #: Default Flask-Security messages
 _default_messages = {
     "API_ERROR": (_("Input not appropriate for requested API"), "error"),
+    "GENERIC_AUTHN_FAILED": (
+        _("Authentication failed - identity or password/passcode invalid"),
+        "error",
+    ),
+    "GENERIC_RECOVERY": (
+        _(
+            "If that email address is in our system, "
+            "you will receive an email describing how to reset your password."
+        ),
+        "info",
+    ),
+    "GENERIC_US_SIGNIN": (
+        _("If that identity is in our system, you were sent a code."),
+        "info",
+    ),
     "UNAUTHORIZED": (_("You do not have permission to view this resource."), "error"),
     "UNAUTHENTICATED": (
         _("You are not authenticated. Please supply the correct credentials."),
@@ -458,6 +474,7 @@ _default_messages = {
         _("You can only access this endpoint when not logged in."),
         "error",
     ),
+    "CODE_HAS_BEEN_SENT": (_("Code has been sent."), "info"),
     "FAILED_TO_SEND_CODE": (_("Failed to send code. Please try again later"), "error"),
     "TWO_FACTOR_INVALID_TOKEN": (_("Invalid code"), "error"),
     "TWO_FACTOR_LOGIN_SUCCESSFUL": (_("Your code has been confirmed"), "success"),

--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -8,13 +8,22 @@
     :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
+import typing as t
 
 from flask import current_app as app
 
 from .confirmable import generate_confirmation_link
+from .forms import form_errors_munge
 from .proxies import _security, _datastore
-from .signals import user_registered
-from .utils import config_value as cv, do_flash, get_message, hash_password, send_mail
+from .signals import user_registered, user_not_registered
+from .utils import (
+    config_value as cv,
+    do_flash,
+    get_message,
+    hash_password,
+    send_mail,
+    url_for_security,
+)
 
 
 def register_user(registration_form):
@@ -27,7 +36,8 @@ def register_user(registration_form):
 
     user_model_kwargs = registration_form.to_dict(only_user=True)
 
-    # passwords are always required - with UNIFIED_SIGNIN
+    # passwords are not always required -
+    # with UNIFIED_SIGNIN and PASSWORD_REQUIRED=False
     if user_model_kwargs["password"]:
         user_model_kwargs["password"] = hash_password(user_model_kwargs["password"])
     user = _datastore.create_user(**user_model_kwargs)
@@ -60,3 +70,92 @@ def register_user(registration_form):
         )
 
     return user
+
+
+def register_existing(form):
+    """
+    In the case of generic responses we want to mitigate any possible
+    email/username enumeration.
+    For an existing email we send an email to that address and tell them they
+    are already registered (and provide their username if any).
+
+    N.B. This (and forgot and confirm) could be used to DDOS an email by constantly
+    issuing requests. One way to mitigate that is to use signals and add specific
+    application code.
+
+    """
+
+    if not (
+        cv("RETURN_GENERIC_RESPONSES")
+        or form.existing_username_user
+        or form.existing_email_user
+    ):  # pragma: no cover
+        return False
+
+    # There are 2 classes of error - an existing email/username and non-compliant
+    # username/password. We want to give the user feedback on a non-compliant
+    # username/password - but not give away whether the email/username is already taken.
+    # Since in this case we have an 'existing' entry - we simply Null out those
+    # errors.
+    # This also means for JSON there is no way to tell if things worked or not.
+    fields_to_squash: t.Dict[str, t.Dict[str, str]] = dict(email=dict())
+    if hasattr(form, "username") and form.existing_username_user:
+        fields_to_squash["username"] = dict()
+    form_errors_munge(form, fields_to_squash)
+    if form.errors:
+        # some other illegal password/username - return an error
+        return False
+
+    # only errors were existing email/username
+    hash_password("not-a-password")  # reduce timing between successful and not.
+
+    # Same as is done in register_user()
+    if _security.confirmable:
+        do_flash(*get_message("CONFIRM_REGISTRATION", email=form.email.data))
+
+    # 2 cases:
+    # 1) existing email (an already registered account) empty or same username
+    # 2) new email with existing username (which corresponds to some OTHER account)
+
+    if form.existing_email_user:
+        user_not_registered.send(
+            app._get_current_object(),
+            user=form.existing_email_user,
+            existing_email=True,
+            existing_username=form.existing_username_user is not None,
+            form_data=form.to_dict(only_user=False),
+        )
+        # Send a nice email saying they are already registered - tell them their
+        # existing username if they have one, and suggest how to reset password.
+        recovery_link = None
+        if _security.recoverable:
+            recovery_link = url_for_security("forgot_password", _external=True)
+        if cv("SEND_REGISTER_EMAIL"):
+            send_mail(
+                cv("EMAIL_SUBJECT_REGISTER"),
+                form.existing_email_user.email,
+                "welcome_existing",
+                user=form.existing_email_user,
+                recovery_link=recovery_link,
+            )
+    elif form.existing_username_user:
+        # New email, already taken username.
+        # Note that we send email to NEW email - so it is possible for a bad-actor
+        # to enumerate usernames (slowly).
+        user_not_registered.send(
+            app._get_current_object(),
+            user=None,
+            existing_email=False,
+            existing_username=True,
+            form_data=form.to_dict(only_user=False),
+        )
+        if cv("SEND_REGISTER_EMAIL"):
+            send_mail(
+                cv("EMAIL_SUBJECT_REGISTER"),
+                form.email.data,
+                "welcome_existing_username",
+                email=form.email.data,
+                username=form.username.data if hasattr(form, "username") else None,
+            )
+
+    return True

--- a/flask_security/signals.py
+++ b/flask_security/signals.py
@@ -5,7 +5,7 @@
     Flask-Security signals module
 
     :copyright: (c) 2012 by Matt Wright.
-    :copyright: (c) 2019-2021 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -16,6 +16,9 @@ signals = blinker.Namespace()
 user_authenticated = signals.signal("user-authenticated")
 
 user_registered = signals.signal("user-registered")
+
+# For cases of RETURN_GENERIC_RESPONSES with existing email/username
+user_not_registered = signals.signal("user-not-registered")
 
 user_confirmed = signals.signal("user-confirmed")
 

--- a/flask_security/templates/security/email/welcome_existing.html
+++ b/flask_security/templates/security/email/welcome_existing.html
@@ -1,0 +1,23 @@
+{# This template receives the following context:
+
+  user - the entire user model object
+  security - the Flask-Security configuration
+  recovery_link - forgot password link if enabled
+
+  This template is used when returning generic responses and don't/can't
+  provide detailed errors as part of form validation to avoid email/username
+  enumeration.
+#}
+<div>{{ _fsdomain('Hello %(email)s!', email=user.email) }}</div>
+
+<div>{{ _fsdomain('Someone (you?) tried to register this email - which is already in our system.') }}</div>
+
+{% if user.username %}
+<div>{{ _fsdomain('This account also has the following username associated with it: %(username)s.', username=user.username) }}</div>
+{% endif %}
+
+{% if recovery_link %}
+  <div>{{ _fsdomain('If you forgot your password you can reset it') }}
+  <a href="{{ recovery_link }}">{{ _fsdomain(' here.') }}</a>
+  </div>
+{% endif %}

--- a/flask_security/templates/security/email/welcome_existing.txt
+++ b/flask_security/templates/security/email/welcome_existing.txt
@@ -1,0 +1,22 @@
+{# This template receives the following context:
+
+  user - the entire user model object
+  security - the Flask-Security configuration
+  recovery_link - if enabled.
+
+  This template is used when returning generic responses and don't/can't
+  provide detailed errors as part of form validation to avoid email/username
+  enumeration.
+#}
+{{ _fsdomain('Hello %(email)s!', email=user.email) }}
+
+{{ _fsdomain('Someone (you?) tried to register this email - which is already in our system.') }}
+
+{% if user.username %}
+{{ _fsdomain('This account also has the following username associated with it: %(username)s', username=user.username) }}
+{% endif %}
+
+{% if recovery_link %}
+    {{ _fsdomain('If you forgot your password you can reset it with the following link:') }}
+    {{ recovery_link }}
+{% endif %}

--- a/flask_security/templates/security/email/welcome_existing_username.html
+++ b/flask_security/templates/security/email/welcome_existing_username.html
@@ -1,0 +1,16 @@
+{# This template receives the following context:
+
+  email - newly registered email
+  security - the Flask-Security configuration
+  username - existing username
+
+  This template is used when returning generic responses in the case of a
+  new email but an existing username. Note that this does effectively allow
+  for username enumeration.
+#}
+<div>{{ _fsdomain('Hello %(email)s!', email=email) }}</div>
+
+<div>{{ _fsdomain('You attempted to register with a username "%(username)s" that is already associated with another account.',
+  username=username) }}</div>
+
+<div>{{ _fsdomain('Please restart the registration process with a different username.') }}</div>

--- a/flask_security/templates/security/email/welcome_existing_username.txt
+++ b/flask_security/templates/security/email/welcome_existing_username.txt
@@ -1,0 +1,16 @@
+{# This template receives the following context:
+
+  email - newly registered email
+  security - the Flask-Security configuration
+  username - existing username
+
+  This template is used when returning generic responses in the case of a
+  new email but an existing username. Note that this does effectively allow
+  for username enumeration.
+#}
+{{ _fsdomain('Hello %(email)s!', email=email) }}
+
+{{ _fsdomain('You attempted to register with a username "%(username)s" that is already associated with another account.',
+  username=username) }}
+
+{{ _fsdomain('Please restart the registration process with a different username.') }}

--- a/flask_security/templates/security/register_user.html
+++ b/flask_security/templates/security/register_user.html
@@ -1,11 +1,12 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_form_errors %}
 
 {% block content %}
 {% include "security/_messages.html" %}
 <h1>{{ _fsdomain('Register') }}</h1>
 <form action="{{ url_for_security('register') }}" method="POST" name="register_user_form">
   {{ register_user_form.hidden_tag() }}
+  {{ render_form_errors(register_user_form) }}
   {{ render_field_with_errors(register_user_form.email) }}
   {% if security.username_enable %}
     {{ render_field_with_errors(register_user_form.username) }}

--- a/flask_security/templates/security/us_signin.html
+++ b/flask_security/templates/security/us_signin.html
@@ -1,5 +1,5 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 
 {% block content %}
     {% include "security/_messages.html" %}
@@ -7,6 +7,7 @@
       <form action="{{ url_for_security("us_signin") }}" method="POST"
           name="us_signin_form">
       {{ us_signin_form.hidden_tag() }}
+      {{ render_form_errors(us_signin_form) }}
       {{ render_field_with_errors(us_signin_form.identity) }}
       {{ render_field_with_errors(us_signin_form.passcode) }}
       {{ render_field_with_errors(us_signin_form.remember) }}
@@ -19,9 +20,6 @@
           {% endif %}
         {% endfor %}
         {{ render_field_errors(us_signin_form.chosen_method) }}
-        {% if code_sent %}
-          <p>{{ _fsdomain("Code has been sent") }}
-        {% endif %}
         {{ render_field(us_signin_form.submit_send_code, formaction=url_for_security('us_signin_send_code')) }}
       {% endif %}
       </form>

--- a/flask_security/username_util.py
+++ b/flask_security/username_util.py
@@ -80,6 +80,9 @@ class UsernameUtil:
         Input is restricted/validated via a call to check_username.
         Return value is a tuple (msg, normalized_username). msg will be None if
         properly validated.
+
+        It is important that None be returned if data is an empty string since
+        otherwise DBs will complain since the field is unique/nullable.
         """
         import bleach
 

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -582,7 +582,7 @@ def test_password_normalization(app, client, get_message):
     assert response.status_code == 200
     logout(client)
 
-    # make sure can log in with new password both normnalized or not
+    # make sure can log in with new password both normalized or not
     response = client.post(
         "/login",
         json=dict(email="matt@lp.com", password="HöheHöhe"),
@@ -601,3 +601,17 @@ def test_password_normalization(app, client, get_message):
     # verify actually logged in
     response = client.get("/profile", follow_redirects=False)
     assert response.status_code == 200
+
+
+@pytest.mark.settings(return_generic_responses=True)
+def test_generic_response(app, client, get_message):
+
+    # try unknown user
+    response = client.post("/reset", data=dict(email="whoami@test.com"))
+    assert (
+        get_message("PASSWORD_RESET_REQUEST", email="whoami@test.com") in response.data
+    )
+
+    response = client.post("/reset", json=dict(email="whoami@test.com"))
+    assert response.status_code == 200
+    assert not any(e in response.json["response"].keys() for e in ["error", "errors"])

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -154,7 +154,7 @@ def create_users(app, ds, count=None):
         ("jess@lp.com", "jess", None, [], True, 678901, None),
         ("gal@lp.com", "gal", "password", ["admin"], True, 112233, "sms"),
         ("gal2@lp.com", "gal2", "password", ["admin"], True, 223311, "authenticator"),
-        ("gal3@lp.com", "gal3", "password", ["admin"], True, 331122, "mail"),
+        ("gal3@lp.com", "gal3", "password", ["admin"], True, 331122, "email"),
     ]
     count = count or len(users)
 


### PR DESCRIPTION
The new SECURITY_RETURN_GENERIC_RESPONSES flag, if set to True will make Flask-Security consistent with the OWASP Authentication errors cheat-sheet recommendations.

close #585