### PR TITLE
Completely change json error response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,29 +8,33 @@ Version 5.0.0
 
 Released TBD
 
+**PLEASE READ CHANGE NOTES CAREFULLY - THERE ARE LIKELY REQUIRED CHANGES YOU WILL HAVE TO MAKE**
+
 Features
 ++++++++
-- (:issue:`475`) Support for WebAuthn
-- (:issue:`479`) Support Two-factor recovery codes
-- (:pr:`532`) Support for Python 3.10
-- (:pr:`540`) Improve Templates in support of JS required by WebAuthn
+- (:issue:`475`) Support for WebAuthn.
+- (:issue:`479`) Support Two-factor recovery codes.
+- (:pr:`532`) Support for Python 3.10.
+- (:pr:`540`) Improve Templates in support of JS required by WebAuthn.
 - (:pr:`568`) Deprecate the old passwordless feature in favor of Unified Signin.
   Deprecate replacing login_manager so we can possibly vendor that in in the future.
 - (:pr:`608`) Add Icelandic translations. (ofurkusi)
 - (:issue:`256`) Add custom HTML attributes to improve user experience.
   This changed LoginForm quite a bit - please see backwards compatability concerns
   below. The default LoginForm and template should be the same as before.
+- (:pr:`xx`) The JSON errors response has been unified. Please see backwards
+  compatibility concerns below.
 
 Fixes
 +++++
-- (:pr:`591`) Make the required zxcvbn complexity score configurable (mephi42)
-- (:issue:`585`) Provide option to prevent user enumeration.
+- (:pr:`591`) Make the required zxcvbn complexity score configurable. (mephi42)
+- (:issue:`585`) Provide option to prevent user enumeration (i.e. Generic Responses).
 - (:issue:`531`) Get rid of Flask-Mail. Flask-Mailman is now the default preferred email package.
   Flask-Mail is still supported so there should be no backwards compatability issues.
 - (:issue:`597`) A delete option has been added to us-setup (form and view).
 - (:pr:`625`) Improve username support - the LoginForm now has a separate field for username if
   ``SECURITY_USERNAME_ENABLE`` is True, and properly displays input fields only if the associated
-  field is an identity attribute (as specified by :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES`)
+  field is an identity attribute (as specified by :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES`).
 - (:pr:`627`) Improve empty password handling. Prior, an unguessable password was set into the user
   record when a user registered without a password - now, the DB user model has been changed to
   allow nullable passwords. This provides a better user experience since Flask-Security now
@@ -90,6 +94,13 @@ Other:
 
     - `lost_device` -> `email`
     - `no_mail_access` -> `help`
+- JSON error responses. **THIS IS A BREAKING CHANGE**.
+  In earlier releases, the JSON error response could have either a `error` key which was for rare cases
+  where there was a single non-form related error, or an `errors` key which was a a dict as defined by WTForms.
+  Now, the `errors` key will contain a list of (localized) messages - both non-form related as well as any form related.
+  The key `field_errors` will contain the dict as specified by WTForms. Please note that starting with WTForms 3.0
+  form-level errors are supported and show up in the dict with the field name/key of "none". There are no changes to non-error
+  related JSON responses.
 
 For templates:
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -946,7 +946,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/UsSetupValidateJsonResponse"
         302:
-          description: Successfuly validated and persisted sign in method.
+          description: Successfully validated and persisted sign in method.
           headers:
             Location:
               description: |
@@ -1890,26 +1890,29 @@ components:
           properties:
             response:
               type: object
+              required: [ errors ]
               description: >
-                For form validation errors, the 'errors' key will be set with a list of errors per
-                invalid form input field. For non-form related errors, the 'error' key will be set
-                with a single (localized) error string.
+                For form validation errors, the 'field_errors' key will be set with a list of errors per
+                invalid form input field (i.e. a dict of 'field-name': list of error strings).
+                The 'errors' key will be a simple list of both form and non-form related
+                errors (all form errors will also be included here).
               properties:
-                errors:
+                field_errors:
                   type: object
                   description: >
                     Errors per input/form field
-                  properties:
-                    field-name:
-                      type: array
-                      items:
-                        type: string
-                        example: field validation error.
-                        description: Error message (localized)
-                error:
-                  type: string
-                  example: "Unauthenticated"
-                  description: Error message (localized)
+                  additionalProperties:
+                    type: array
+                    items:
+                      type: string
+                      example: field validation error.
+                      description: Error message (localized)
+                errors:
+                  type: array
+                  items:
+                    type: string
+                    example: "Unauthenticated"
+                    description: Error message (localized)
     Verify:
       type: object
       required: [ password ]
@@ -1995,37 +1998,30 @@ components:
           type: boolean
         tf_validity_token:
           type: string
-          description: Code verifying the user has successfully verfied 2FA in the past. If verified, the user is able to skip validation of the second factor. Only used when SECURITY_TWO_FACTOR_ALWAYS_VALIDATE is False.
+          description: Code verifying the user has successfully verified 2FA in the past. If verified, the user is able to skip validation of the second factor. Only used when SECURITY_TWO_FACTOR_ALWAYS_VALIDATE is False.
     UsSigninJsonResponse:
-      type: object
-      description: >
-        The user successfully signed in. Note that depending on SECURITY_TWO_FACTOR and SECURITY_US_MFA_REQUIRED configuration variables, a second form of authentication might be required.
-      required: [meta, response]
-      properties:
-        meta:
-          type: object
-          required: [code]
+      allOf:
+        - $ref: '#/components/schemas/BaseJsonResponse'
+        - type: object
+          description: >
+            The user successfully signed in. Note that depending on SECURITY_TWO_FACTOR and SECURITY_US_MFA_REQUIRED configuration variables, a second form of authentication might be required.
           properties:
-            code:
-              type: integer
-              example: 200
-              description: Http status code
-        response:
-          type: object
-          properties:
-            authentication_token:
-              type: string
-              description: >
-                Token to be used in future token-based API calls. Only returned if "include_auth_token" parameter is set.
-            tf_required:
-              type: boolean
-              description: If two-factor authentication is required for caller.
-            tf_state:
-              type: string
-              description: if "setup_from_login" then the caller must go through two-factor setup endpoint. If "ready" then a code has been sent and should be supplied to SECURITY_TWO_FACTOR_TOKEN_VALIDATION_URL.
-            tf_primary_method:
-              type: string
-              description: Which method was used to send code.
+            response:
+              type: object
+              properties:
+                authentication_token:
+                  type: string
+                  description: >
+                    Token to be used in future token-based API calls. Only returned if "include_auth_token" parameter is set.
+                tf_required:
+                  type: boolean
+                  description: If two-factor authentication is required for caller.
+                tf_state:
+                  type: string
+                  description: if "setup_from_login" then the caller must go through two-factor setup endpoint. If "ready" then a code has been sent and should be supplied to SECURITY_TWO_FACTOR_TOKEN_VALIDATION_URL.
+                tf_primary_method:
+                  type: string
+                  description: Which method was used to send code.
     UsSigninSendCode:
       type: object
       required: [identity, chosen_method]
@@ -2064,39 +2060,32 @@ components:
           type: string
           description: phone number (this will be normalized). Required if chosen_method == "sms".
     UsSetupJsonResponse:
-      type: object
-      required: [meta, response]
-      properties:
-        meta:
-          type: object
-          required: [code]
+      allOf:
+        - $ref: '#/components/schemas/BaseJsonResponse'
+        - type: object
           properties:
-            code:
-              type: integer
-              example: 200
-              description: Http status code
-        response:
-          type: object
-          description: Response when setting up a new method. When deleting, nothing is returned.
-          properties:
-            chosen_method:
-              type: string
-              description: The chosen_method as passed into API.
-            phone:
-              type: string
-              description: The canonicalized phone number if setting up SMS
-            authr_key:
-              type: string
-              description: TOTP key for setting up authenticator (if chosen_method == 'authenticator')
-            authr_issuer:
-              type: string
-              description: Issuer as configured with TOTP_ISSUER (same as used in QRcode) (if chosen_method == 'authenticator')
-            authr_username:
-              type: string
-              description: Username (same as used in QRcode) (if chosen_method == 'authenticator')
-            state:
-              type: string
-              description: Opaque blob that must be pass to /us-setup/<state>. This is a signed, timed token.
+            response:
+              type: object
+              description: Response when setting up a new method. When deleting, nothing is returned.
+              properties:
+                chosen_method:
+                  type: string
+                  description: The chosen_method as passed into API.
+                phone:
+                  type: string
+                  description: The canonicalized phone number if setting up SMS
+                authr_key:
+                  type: string
+                  description: TOTP key for setting up authenticator (if chosen_method == 'authenticator')
+                authr_issuer:
+                  type: string
+                  description: Issuer as configured with TOTP_ISSUER (same as used in QRcode) (if chosen_method == 'authenticator')
+                authr_username:
+                  type: string
+                  description: Username (same as used in QRcode) (if chosen_method == 'authenticator')
+                state:
+                  type: string
+                  description: Opaque blob that must be pass to /us-setup/<state>. This is a signed, timed token.
     UsSetupValidateRequest:
       type: object
       required: [passcode]
@@ -2105,26 +2094,19 @@ components:
           type: string
           description: Code/Passcode as received from method being setup.
     UsSetupValidateJsonResponse:
-      type: object
-      required: [meta, response]
-      properties:
-        meta:
-          type: object
-          required: [code]
+      allOf:
+        - $ref: '#/components/schemas/BaseJsonResponse'
+        - type: object
           properties:
-            code:
-              type: integer
-              example: 200
-              description: Http status code
-        response:
-          type: object
-          properties:
-            chosen_method:
-              type: string
-              description: The chosen_method as passed into API.
-            phone:
-              type: string
-              description: Phone number if set.
+            response:
+              type: object
+              properties:
+                chosen_method:
+                  type: string
+                  description: The chosen_method as passed into API.
+                phone:
+                  type: string
+                  description: Phone number if set.
     TfSetup:
       type: object
       required: [setup]
@@ -2140,39 +2122,32 @@ components:
           description: phone number (this will be validated for format). Required if setup == "sms".
           example: 650-555-1212
     TfSetupJsonResponse:
-      type: object
-      required: [meta, response]
-      properties:
-        meta:
-          type: object
-          required: [code]
+      allOf:
+        - $ref: '#/components/schemas/BaseJsonResponse'
+        - type: object
           properties:
-            code:
-              type: integer
-              example: 200
-              description: Http status code
-        response:
-          type: object
-          properties:
-            tf_state:
-              type: string
-              description: >
-                Current state of Two Factor configuration. Not present when disabling 2FA. This will be set to 'validating_profile'
-                indicating the caller needs to call '/tf-validate' with the correct code.
-              example: validating_profile
-            tf_primary_method:
-              type: string
-              description: Current method being congfigured.
-              example: sms
-            tf_authr_key:
-              type: string
-              description: TOTP key for setting up authenticator (if tf_primary_method == 'authenticator')
-            tf_authr_issuer:
-              type: string
-              description: Issuer as configured with TOTP_ISSUER (same as used in QRcode) (if tf_primary_method == 'authenticator')
-            tf_authr_username:
-              type: string
-              description: Username (same as used in QRcode) (if tf_primary_method == 'authenticator')
+            response:
+              type: object
+              properties:
+                tf_state:
+                  type: string
+                  description: >
+                    Current state of Two Factor configuration. Not present when disabling 2FA. This will be set to 'validating_profile'
+                    indicating the caller needs to call '/tf-validate' with the correct code.
+                  example: validating_profile
+                tf_primary_method:
+                  type: string
+                  description: Current method being configured.
+                  example: sms
+                tf_authr_key:
+                  type: string
+                  description: TOTP key for setting up authenticator (if tf_primary_method == 'authenticator')
+                tf_authr_issuer:
+                  type: string
+                  description: Issuer as configured with TOTP_ISSUER (same as used in QRcode) (if tf_primary_method == 'authenticator')
+                tf_authr_username:
+                  type: string
+                  description: Username (same as used in QRcode) (if tf_primary_method == 'authenticator')
     TfValidateJsonResponse:
       type: object
       properties:

--- a/flask_security/tf_plugin.py
+++ b/flask_security/tf_plugin.py
@@ -32,7 +32,6 @@ from .utils import (
     get_message,
     get_within_delta,
     get_url,
-    json_error_response,
     login_user,
     simple_render_json,
     suppress_form_csrf,
@@ -327,7 +326,8 @@ def tf_illegal_state(form, redirect_to):
         do_flash(m, c)
         return redirect(get_url(redirect_to))
     else:
-        return _security._render_json(json_error_response(m), 400, None, None)
+        form.form_errors.append(m)
+        return base_render_json(form, include_user=False)
 
 
 def tf_clean_session():

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -942,8 +942,8 @@ def us_setup_validate(token: str) -> "ResponseValue":
         m, c = get_message("US_SETUP_EXPIRED", within=cv("US_SETUP_WITHIN"))
     if invalid or expired:
         if _security._want_json(request):
-            payload = json_error_response(errors=m)
-            return _security._render_json(payload, 400, None, None)
+            form.form_errors.append(m)
+            return base_render_json(form, include_user=False)
         do_flash(m, c)
         return redirect(url_for_security("us_setup"))
 

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -664,7 +664,8 @@ def reset_password(token):
 
     if invalid or expired:
         if _security._want_json(request):
-            return _security._render_json(json_error_response(m), 400, None, None)
+            form.form_errors.append(m)
+            return base_render_json(form, include_user=False)
         else:
             return redirect(url_for_security("forgot_password"))
 

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -82,7 +82,6 @@ from .utils import (
     check_and_get_token_status,
     config_value as cv,
     do_flash,
-    json_error_response,
     get_message,
     get_post_login_redirect,
     get_post_verify_redirect,
@@ -497,8 +496,8 @@ def webauthn_register_response(token: str) -> "ResponseValue":
         m, c = get_message("WEBAUTHN_EXPIRED", within=cv("WAN_REGISTER_WITHIN"))
     if invalid or expired:
         if _security._want_json(request):
-            payload = json_error_response(errors=m)
-            return _security._render_json(payload, 400, None, None)
+            form.form_errors.append(m)
+            return base_render_json(form, include_user=False)
         do_flash(m, c)
         return redirect(url_for_security("wan_register"))
 
@@ -651,8 +650,8 @@ def webauthn_signin_response(token: str) -> "ResponseValue":
         m, c = get_message("WEBAUTHN_EXPIRED", within=cv("WAN_SIGNIN_WITHIN"))
     if invalid or expired:
         if _security._want_json(request):
-            payload = json_error_response(errors=m)
-            return _security._render_json(payload, 400, None, None)
+            form.form_errors.append(m)
+            return base_render_json(form, include_user=False)
         do_flash(m, c)
         return redirect(url_for_security("wan_signin"))
 
@@ -815,8 +814,8 @@ def webauthn_verify_response(token: str) -> "ResponseValue":
         m, c = get_message("WEBAUTHN_EXPIRED", within=cv("WAN_SIGNIN_WITHIN"))
     if invalid or expired:
         if _security._want_json(request):
-            payload = json_error_response(errors=m)
-            return _security._render_json(payload, 400, None, None)
+            form.form_errors.append(m)
+            return base_render_json(form, include_user=False)
         do_flash(m, c)
         return redirect(url_for_security("wan_verify"))
 

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -157,7 +157,7 @@ def test_changeable_flag(app, client, get_message):
         "/change", data=data, headers={"Content-Type": "application/json"}
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["new_password"] == [
+    assert response.json["response"]["field_errors"]["new_password"] == [
         "Password not provided"
     ]
 
@@ -469,7 +469,7 @@ def test_easy_password(app, client):
     response = __test_easy_password(client)
     assert response.status_code == 400
     # Response from zxcvbn
-    assert "Repeats like" in response.json["response"]["errors"]["new_password"][0]
+    assert "Repeats like" in response.json["response"]["errors"][0]
 
 
 @pytest.mark.settings(password_complexity_checker="zxcvbn", zxcvbn_minimum_score=0)
@@ -503,7 +503,7 @@ def test_my_validator(app, sqlalchemy_datastore):
     )
     assert response.headers["Content-Type"] == "application/json"
     assert response.status_code == 400
-    assert "Are you crazy" in response.json["response"]["errors"]["new_password"][0]
+    assert "Are you crazy" in response.json["response"]["errors"][0]
 
 
 @pytest.mark.settings(password_length_min=12)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -182,15 +182,15 @@ def test_generic_response(app, client, get_message):
         "/login", json=dict(email="mattwho@lp.com", password="forgot")
     )
     # make sure just 'null' key in errors.
-    assert list(response.json["response"]["errors"].keys()) == ["null"]
-    assert len(response.json["response"]["errors"]["null"]) == 1
-    assert response.json["response"]["errors"]["null"][0].encode(
-        "utf-8"
-    ) == get_message("GENERIC_AUTHN_FAILED")
+    assert list(response.json["response"]["field_errors"].keys()) == ["null"]
+    assert len(response.json["response"]["field_errors"]["null"]) == 1
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "GENERIC_AUTHN_FAILED"
+    )
     response = client.post("/login", json=dict(email="matt@lp.com", password="forgot"))
-    assert response.json["response"]["errors"]["null"][0].encode(
-        "utf-8"
-    ) == get_message("GENERIC_AUTHN_FAILED")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "GENERIC_AUTHN_FAILED"
+    )
 
     # make sure don't get confirmation required
     response = client.post(
@@ -221,11 +221,11 @@ def test_generic_response_username(app, client, get_message):
 
     response = client.post("/login", json=dict(username="dude2", password="forgot"))
     # make sure just 'null' key in errors.
-    assert list(response.json["response"]["errors"].keys()) == ["null"]
-    assert len(response.json["response"]["errors"]["null"]) == 1
-    assert response.json["response"]["errors"]["null"][0].encode(
-        "utf-8"
-    ) == get_message("GENERIC_AUTHN_FAILED")
+    assert list(response.json["response"]["field_errors"].keys()) == ["null"]
+    assert len(response.json["response"]["field_errors"]["null"]) == 1
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "GENERIC_AUTHN_FAILED"
+    )
 
 
 def test_unprovided_username(client, get_message):
@@ -578,7 +578,7 @@ def test_http_auth_no_authentication(client, get_message):
 def test_http_auth_no_authentication_json(client, get_message):
     response = client.get("/http", headers={"accept": "application/json"})
     assert response.status_code == 401
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "UNAUTHENTICATED"
     )
     assert response.headers["Content-Type"] == "application/json"
@@ -610,7 +610,7 @@ def test_invalid_http_auth_invalid_username_json(client, get_message):
         },
     )
     assert response.status_code == 401
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "UNAUTHENTICATED"
     )
     assert response.headers["Content-Type"] == "application/json"
@@ -802,7 +802,7 @@ def test_anon_required_json(client, get_message):
     authenticate(client, follow_redirects=False)
     response = client.get("/register", headers={"Accept": "application/json"})
     assert response.status_code == 400
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "ANONYMOUS_USER_REQUIRED"
     )
 

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -479,7 +479,7 @@ def test_two_factor_json(app, client, get_message):
     # make sure not logged in
     response = client.get("/profile", headers={"accept": "application/json"})
     assert response.status_code == 401
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "UNAUTHENTICATED"
     )
 
@@ -516,7 +516,7 @@ def test_email_not_identity(app, client, get_message):
         "/register", data=data, headers={"Accept": "application/json"}
     )
     assert response.status_code == 400
-    assert "is already associated" in response.json["response"]["errors"]["username"][0]
+    assert "is already associated" in response.json["response"]["errors"][0]
 
     # verify that email field not present
     response = client.get("/login")  # this one has a flash containing 'email confirmed'

--- a/tests/test_csrf.py
+++ b/tests/test_csrf.py
@@ -197,7 +197,7 @@ def test_login_csrf_unauth_double(app, client, get_message):
     # login in again - should work
     response = client.post("/login", content_type="application/json", json=data)
     assert response.status_code == 400
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "ANONYMOUS_USER_REQUIRED"
     )
 

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -167,9 +167,9 @@ def test_recoverable_json(app, client, get_message):
             headers={"Content-Type": "application/json"},
         )
         assert response.status_code == 400
-        assert response.json["response"]["errors"]["email"][0].encode(
-            "utf-8"
-        ) == get_message("USER_DOES_NOT_EXIST")
+        assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+            "USER_DOES_NOT_EXIST"
+        )
 
         # Test submitting a new password but leave out 'confirm'
         response = client.post(
@@ -178,9 +178,9 @@ def test_recoverable_json(app, client, get_message):
             headers={"Content-Type": "application/json"},
         )
         assert response.status_code == 400
-        assert response.json["response"]["errors"]["password_confirm"][0].encode(
-            "utf-8"
-        ) == get_message("PASSWORD_NOT_PROVIDED")
+        assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+            "PASSWORD_NOT_PROVIDED"
+        )
 
         # Test submitting a new password
         response = client.post(
@@ -225,7 +225,7 @@ def test_recoverable_json(app, client, get_message):
             json=dict(password="newpassword", password_confirm="newpassword"),
             headers={"Content-Type": "application/json"},
         )
-        assert response.json["response"]["error"].encode("utf-8") == get_message(
+        assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
             "INVALID_RESET_PASSWORD_TOKEN"
         )
     assert len(flashes) == 0

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -277,9 +277,9 @@ def test_simple_signin_json(app, client_nc, get_message):
             follow_redirects=True,
         )
         assert response.status_code == 400
-        assert response.json["response"]["errors"]["passcode"][0].encode(
-            "utf-8"
-        ) == get_message("INVALID_PASSWORD_CODE")
+        assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+            "INVALID_PASSWORD_CODE"
+        )
 
         # Login successfully with code
         response = client_nc.post(
@@ -446,9 +446,9 @@ def test_us_passwordless_confirm_json(app, client, get_message):
         "/us-signin/send-code",
         json=dict(identity="nopasswd-dude@lp.com", chosen_method="email"),
     )
-    assert response.json["response"]["errors"]["identity"][0].encode(
-        "utf-8"
-    ) == get_message("CONFIRMATION_REQUIRED")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "CONFIRMATION_REQUIRED"
+    )
 
     # grab welcome email which has confirmation link (test version of welcome.txt)
     outbox = app.mail.outbox
@@ -512,9 +512,9 @@ def test_admin_setup_user_reset(app, client_nc, get_message):
         follow_redirects=True,
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["chosen_method"][0].encode(
-        "utf-8"
-    ) == get_message("US_METHOD_NOT_AVAILABLE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "US_METHOD_NOT_AVAILABLE"
+    )
     # Nothing should have been sent.
     assert len(sms_sender.messages) == 1
 
@@ -547,9 +547,9 @@ def test_admin_setup_reset(app, client_nc, get_message):
         follow_redirects=True,
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["chosen_method"][0].encode(
-        "utf-8"
-    ) == get_message("US_METHOD_NOT_AVAILABLE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "US_METHOD_NOT_AVAILABLE"
+    )
     # Nothing should have been sent.
     assert len(sms_sender.messages) == 1
 
@@ -584,7 +584,7 @@ def test_post_already_authenticated(client, get_message):
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
     response = client.post("/us-signin", json=data, headers=headers)
     assert response.status_code == 400
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "ANONYMOUS_USER_REQUIRED"
     )
 
@@ -830,9 +830,9 @@ def test_setup_json(app, client_nc, get_message):
         "/us-setup/" + state, json=dict(passcode=12344), headers=headers
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["passcode"][0].encode(
-        "utf-8"
-    ) == get_message("INVALID_PASSWORD_CODE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "INVALID_PASSWORD_CODE"
+    )
     code = sms_sender.messages[0].split()[-1].strip(".")
     response = client_nc.post(
         "/us-setup/" + state, json=dict(passcode=code), headers=headers
@@ -908,7 +908,7 @@ def test_setup_bad_token(app, client, get_message):
         "/us-setup/not a token", json=dict(passcode=12345), headers=headers
     )
     assert response.status_code == 400
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "API_ERROR"
     )
 
@@ -941,7 +941,7 @@ def test_setup_timeout(app, client, get_message):
         "/us-setup/" + state, json=dict(passcode=code), headers=headers
     )
     assert response.status_code == 400
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "US_SETUP_EXPIRED", within=app.config["SECURITY_US_SETUP_WITHIN"]
     )
 
@@ -1038,15 +1038,18 @@ def test_verify_json(app, client, get_message):
     # Try bad code
     response = client.post("us-verify", json=dict(passcode=42), headers=headers)
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["passcode"][0].encode(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "INVALID_PASSWORD_CODE"
+    )
+    assert response.json["response"]["field_errors"]["passcode"][0].encode(
         "utf-8"
     ) == get_message("INVALID_PASSWORD_CODE")
 
     response = client.post("us-verify", json=dict(passcode=None), headers=headers)
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["passcode"][0].encode(
-        "utf-8"
-    ) == get_message("INVALID_PASSWORD_CODE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "INVALID_PASSWORD_CODE"
+    )
 
     code = sms_sender.messages[0].split()[-1].strip(".")
     response = client.post("us-verify", json=dict(passcode=code), headers=headers)
@@ -1083,9 +1086,9 @@ def test_invalid_method(app, client, get_message):
         follow_redirects=True,
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["chosen_method"][0].encode(
-        "utf-8"
-    ) == get_message("US_METHOD_NOT_AVAILABLE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "US_METHOD_NOT_AVAILABLE"
+    )
 
     # verify form error
     response = client.post(
@@ -1114,9 +1117,9 @@ def test_invalid_method_setup(app, client, get_message):
         follow_redirects=True,
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["chosen_method"][0].encode(
-        "utf-8"
-    ) == get_message("US_METHOD_NOT_AVAILABLE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "US_METHOD_NOT_AVAILABLE"
+    )
 
     response = client.post(
         "/us-setup",
@@ -1380,9 +1383,12 @@ def test_empty_password(app, client, get_message):
 
     response = client.post("/us-signin", json=dict(identity="trp@lp.com", passcode=""))
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["passcode"][0].encode(
+    assert response.json["response"]["field_errors"]["passcode"][0].encode(
         "utf-8"
     ) == get_message("INVALID_PASSWORD_CODE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "INVALID_PASSWORD_CODE"
+    )
 
 
 @pytest.mark.settings(
@@ -1581,9 +1587,9 @@ def test_bad_sender(app, client, get_message):
 
     response = client.post("us-signin/send-code", json=data, headers=headers)
     assert response.status_code == 500
-    assert response.json["response"]["errors"]["chosen_method"][0].encode(
-        "utf-8"
-    ) == get_message("FAILED_TO_SEND_CODE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "FAILED_TO_SEND_CODE"
+    )
 
     # Now test setup
     set_email(app)
@@ -1594,9 +1600,9 @@ def test_bad_sender(app, client, get_message):
 
     response = client.post("us-setup", json=data, headers=headers)
     assert response.status_code == 500
-    assert response.json["response"]["errors"]["chosen_method"][0].encode(
-        "utf-8"
-    ) == get_message("FAILED_TO_SEND_CODE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "FAILED_TO_SEND_CODE"
+    )
 
     # Test us-verify
     data = dict(chosen_method="sms")
@@ -1604,7 +1610,7 @@ def test_bad_sender(app, client, get_message):
     assert get_message("FAILED_TO_SEND_CODE") in response.data
     response = client.post("us-verify/send-code", json=data)
     assert response.status_code == 500
-    assert response.json["response"]["errors"]["chosen_method"][0].encode(
+    assert response.json["response"]["field_errors"]["chosen_method"][0].encode(
         "utf-8"
     ) == get_message("FAILED_TO_SEND_CODE")
 
@@ -1884,9 +1890,9 @@ def test_setup_delete(app, client, get_message):
     )
 
     response = client.post("us-setup", json=dict(delete_method="email"))
-    assert response.json["response"]["errors"]["delete_method"][0].encode(
-        "utf-8"
-    ) == get_message("US_METHOD_NOT_AVAILABLE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "US_METHOD_NOT_AVAILABLE"
+    )
 
 
 def test_setup_delete_json(app, client, get_message):
@@ -1916,9 +1922,9 @@ def test_setup_delete_json(app, client, get_message):
     assert not response.json["response"]["active_methods"]
 
     response = client.post("us-setup", json=dict(delete_method="email"))
-    assert response.json["response"]["errors"]["delete_method"][0].encode(
-        "utf-8"
-    ) == get_message("US_METHOD_NOT_AVAILABLE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "US_METHOD_NOT_AVAILABLE"
+    )
 
     # setup and delete SMS
     sms_sender = SmsSenderFactory.createSender("test")
@@ -1974,7 +1980,9 @@ def test_generic_response(app, client, get_message):
     # for JSON still return 200 as if everything is fine and a code was sent.
     response = client.post("/us-signin/send-code", json=data)
     assert response.status_code == 200
-    assert not any(e in response.json["response"].keys() for e in ["error", "errors"])
+    assert not any(
+        e in response.json["response"].keys() for e in ["field_errors", "errors"]
+    )
 
     # Unknown identity should return same thing
     data = dict(identity="matt2@lp.com", chosen_method="email")
@@ -1984,7 +1992,9 @@ def test_generic_response(app, client, get_message):
     # for JSON still return 200 as if everything is fine and a code was sent.
     response = client.post("/us-signin/send-code", json=data)
     assert response.status_code == 200
-    assert not any(e in response.json["response"].keys() for e in ["error", "errors"])
+    assert not any(
+        e in response.json["response"].keys() for e in ["field_errors", "errors"]
+    )
 
     #
     # Now test us-signin itself
@@ -1996,11 +2006,14 @@ def test_generic_response(app, client, get_message):
     data = dict(identity="matt@lp.com", code="12345")
     response = client.post("/us-signin", json=data)
     assert response.status_code == 400
-    assert list(response.json["response"]["errors"].keys()) == ["null"]
-    assert len(response.json["response"]["errors"]["null"]) == 1
-    assert response.json["response"]["errors"]["null"][0].encode(
+    assert list(response.json["response"]["field_errors"].keys()) == ["null"]
+    assert len(response.json["response"]["field_errors"]["null"]) == 1
+    assert response.json["response"]["field_errors"]["null"][0].encode(
         "utf-8"
     ) == get_message("GENERIC_AUTHN_FAILED")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "GENERIC_AUTHN_FAILED"
+    )
 
     # same with unknown user
     data = dict(identity="matt2@lp.com", code="12345")
@@ -2010,11 +2023,14 @@ def test_generic_response(app, client, get_message):
     data = dict(identity="matt2@lp.com", code="12345")
     response = client.post("/us-signin", json=data)
     assert response.status_code == 400
-    assert list(response.json["response"]["errors"].keys()) == ["null"]
-    assert len(response.json["response"]["errors"]["null"]) == 1
-    assert response.json["response"]["errors"]["null"][0].encode(
+    assert list(response.json["response"]["field_errors"].keys()) == ["null"]
+    assert len(response.json["response"]["field_errors"]["null"]) == 1
+    assert response.json["response"]["field_errors"]["null"][0].encode(
         "utf-8"
     ) == get_message("GENERIC_AUTHN_FAILED")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "GENERIC_AUTHN_FAILED"
+    )
 
     #
     # Test /us-verify-link

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -377,9 +377,9 @@ def test_basic_json(app, clients, get_message):
     # post with no name
     response = clients.post("/wan-register", json=dict())
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["name"][0].encode(
-        "utf-8"
-    ) == get_message("WEBAUTHN_NAME_REQUIRED")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "WEBAUTHN_NAME_REQUIRED"
+    )
 
     register_options, response_url = _register_start_json(clients, usage="first")
     assert register_options["rp"]["name"] == "My Flask App"
@@ -483,9 +483,9 @@ def test_usage(app, client, get_message):
         json=dict(credential=json.dumps(SIGNIN_DATA1)),
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
-        "utf-8"
-    ) == get_message("WEBAUTHN_CREDENTIAL_WRONG_USAGE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "WEBAUTHN_CREDENTIAL_WRONG_USAGE"
+    )
 
 
 @pytest.mark.settings(webauthn_util_cls=HackWebauthnUtil)
@@ -502,9 +502,9 @@ def test_constraints(app, clients, get_message):
     # register same name again
     response = clients.post("wan-register", json=dict(name="testr3"))
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["name"][0].encode(
-        "utf-8"
-    ) == get_message("WEBAUTHN_NAME_INUSE", name="testr3")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "WEBAUTHN_NAME_INUSE", name="testr3"
+    )
 
     logout(clients)
 
@@ -518,9 +518,9 @@ def test_constraints(app, clients, get_message):
     register_options, response_url = _register_start_json(clients, name="testr4")
     response = clients.post(response_url, json=dict(credential=json.dumps(REG_DATA1)))
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
-        "utf-8"
-    ) == get_message("WEBAUTHN_CREDENTIAL_ID_INUSE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "WEBAUTHN_CREDENTIAL_ID_INUSE"
+    )
 
 
 @pytest.mark.settings(webauthn_util_cls=HackWebauthnUtil)
@@ -531,27 +531,27 @@ def test_bad_data_register(app, client, get_message):
     # first try mangling json - should get API_ERROR
     response = client.post(response_url, json=dict(credential="hi there"))
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
-        "utf-8"
-    ) == get_message("API_ERROR")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "API_ERROR"
+    )
 
     # Now pass incorrect keys
     bad_register = copy.deepcopy(REG_DATA1)
     del bad_register["rawId"]
     response = client.post(response_url, json=dict(credential=json.dumps(bad_register)))
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
-        "utf-8"
-    ) == get_message("API_ERROR")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "API_ERROR"
+    )
 
     # now muck with attestation - should get VERIFY ERROR
     bad_register = copy.deepcopy(REG_DATA1)
     bad_register["rawId"] = "unknown"
     response = client.post(response_url, json=dict(credential=json.dumps(bad_register)))
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
-        "utf-8"
-    ) == get_message("WEBAUTHN_NO_VERIFY", cause="id and raw_id were not equivalent")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "WEBAUTHN_NO_VERIFY", cause="id and raw_id were not equivalent"
+    )
 
     # same with forms
     with capture_flashes() as flashes:
@@ -579,18 +579,18 @@ def test_bad_data_signin(app, client, get_message):
     signin_options, response_url, _ = _signin_start_json(client, "matt@lp.com")
     response = client.post(response_url, json=dict(credential="hi there"))
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
-        "utf-8"
-    ) == get_message("API_ERROR")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "API_ERROR"
+    )
 
     # Now pass incorrect keys
     bad_signin = copy.deepcopy(SIGNIN_DATA1)
     del bad_signin["rawId"]
     response = client.post(response_url, json=dict(credential=json.dumps(bad_signin)))
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
-        "utf-8"
-    ) == get_message("API_ERROR")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "API_ERROR"
+    )
 
     # now muck with attestation - should get VERIFY ERROR
     bad_signin = copy.deepcopy(SIGNIN_DATA1)
@@ -599,9 +599,7 @@ def test_bad_data_signin(app, client, get_message):
     )
     response = client.post(response_url, json=dict(credential=json.dumps(bad_signin)))
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
-        "utf-8"
-    ) == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "WEBAUTHN_NO_VERIFY", cause="Could not verify authentication signature"
     )
 
@@ -666,15 +664,15 @@ def test_delete_json(app, clients, get_message):
 
     response = clients.post("/wan-delete", json=dict())
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["name"][0].encode(
-        "utf=8"
-    ) == get_message("WEBAUTHN_NAME_REQUIRED")
+    assert response.json["response"]["errors"][0].encode("utf=8") == get_message(
+        "WEBAUTHN_NAME_REQUIRED"
+    )
 
     response = clients.post("/wan-delete", json=dict(name="testr1"))
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["name"][0].encode(
-        "utf=8"
-    ) == get_message("WEBAUTHN_NAME_NOT_FOUND", name="testr1")
+    assert response.json["response"]["errors"][0].encode("utf=8") == get_message(
+        "WEBAUTHN_NAME_NOT_FOUND", name="testr1"
+    )
 
     response = clients.post("/wan-delete", json=dict(name="testr3"))
     assert response.status_code == 200
@@ -716,9 +714,9 @@ def test_disabled_account(app, client, get_message):
         json=dict(credential=json.dumps(SIGNIN_DATA1)),
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
-        "utf-8"
-    ) == get_message("DISABLED_ACCOUNT")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "DISABLED_ACCOUNT"
+    )
 
 
 @pytest.mark.settings(webauthn_util_cls=HackWebauthnUtil)
@@ -743,7 +741,7 @@ def test_unk_credid(app, client, get_message):
         json=dict(credential=json.dumps(bad_signin)),
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
+    assert response.json["response"]["field_errors"]["credential"][0].encode(
         "utf-8"
     ) == get_message("WEBAUTHN_UNKNOWN_CREDENTIAL_ID")
 
@@ -970,7 +968,7 @@ def test_register_timeout(app, client, get_message):
 
     response = client.post(response_url, json=dict(credential=json.dumps(REG_DATA1)))
     assert response.status_code == 400
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "WEBAUTHN_EXPIRED", within=app.config["SECURITY_WAN_REGISTER_WITHIN"]
     )
 
@@ -992,7 +990,7 @@ def test_signin_timeout(app, client, get_message):
         json=dict(credential=json.dumps(SIGNIN_DATA1)),
     )
     assert response.status_code == 400
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "WEBAUTHN_EXPIRED", within=app.config["SECURITY_WAN_SIGNIN_WITHIN"]
     )
 
@@ -1003,7 +1001,7 @@ def test_bad_token(app, client, get_message):
 
     response = client.post("/wan-register/not a token", json=dict())
     assert response.status_code == 400
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "API_ERROR"
     )
     # same w/o json
@@ -1019,7 +1017,7 @@ def test_bad_token(app, client, get_message):
     # Test wan-verify
     response = client.post("/wan-verify/not a token", json=dict())
     assert response.status_code == 400
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "API_ERROR"
     )
     # same w/o json
@@ -1037,7 +1035,7 @@ def test_bad_token(app, client, get_message):
 
     response = client.post("/wan-signin/not a token", json=dict())
     assert response.status_code == 400
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "API_ERROR"
     )
     # same w/o json
@@ -1222,7 +1220,7 @@ def test_user_handle(app, client, get_message):
     response = client.post(
         response_url, json=dict(credential=json.dumps(SIGNIN_DATA_UH))
     )
-    assert response.json["response"]["errors"]["credential"][0].encode(
+    assert response.json["response"]["field_errors"]["credential"][0].encode(
         "utf-8"
     ) == get_message("WEBAUTHN_MISMATCH_USER_HANDLE")
 
@@ -1347,7 +1345,7 @@ def test_verify_timeout(app, client, get_message):
     response_url = f'wan-verify/{response.json["response"]["wan_state"]}'
     response = client.post(response_url, json=dict(credential=json.dumps(SIGNIN_DATA1)))
     assert response.status_code == 400
-    assert response.json["response"]["error"].encode("utf-8") == get_message(
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "WEBAUTHN_EXPIRED", within=app.config["SECURITY_WAN_SIGNIN_WITHIN"]
     )
 
@@ -1366,7 +1364,7 @@ def test_verify_validate_error(app, client, get_message):
         response_url, json=dict(credential=json.dumps(SIGNIN_DATA_UH))
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
+    assert response.json["response"]["field_errors"]["credential"][0].encode(
         "utf-8"
     ) == get_message("WEBAUTHN_UNKNOWN_CREDENTIAL_ID")
 
@@ -1443,9 +1441,9 @@ def test_verify_usage_first_json(app, client, get_message):
         response_url, json=dict(credential=json.dumps(keys["secondary"]["signin"]))
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
-        "utf-8"
-    ) == get_message("WEBAUTHN_CREDENTIAL_WRONG_USAGE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "WEBAUTHN_CREDENTIAL_WRONG_USAGE"
+    )
 
 
 @pytest.mark.settings(
@@ -1470,9 +1468,9 @@ def test_verify_usage_secondary_json(app, client, get_message):
         response_url, json=dict(credential=json.dumps(keys["first"]["signin"]))
     )
     assert response.status_code == 400
-    assert response.json["response"]["errors"]["credential"][0].encode(
-        "utf-8"
-    ) == get_message("WEBAUTHN_CREDENTIAL_WRONG_USAGE")
+    assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
+        "WEBAUTHN_CREDENTIAL_WRONG_USAGE"
+    )
     response = client.post(
         response_url, json=dict(credential=json.dumps(keys["secondary"]["signin"]))
     )
@@ -1594,7 +1592,7 @@ def test_uv_required(client):
     assert response.status_code == 400
     assert (
         "User verification is required"
-        in response.json["response"]["errors"]["credential"][0]
+        in response.json["response"]["field_errors"]["credential"][0]
     )
 
     logout(client)


### PR DESCRIPTION
Now return errors is always a simple list of errors.
we also return field_errors - which is the old wtforms dict of errors.

Support new wtforms 3.0 form level errors.