### PR TITLE
Added missing permissions column line in quickstart models.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.1
+    rev: v2.37.2
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -224,6 +224,7 @@ and models.py.
         id = Column(Integer(), primary_key=True)
         name = Column(String(80), unique=True)
         description = Column(String(255))
+        permissions = Column(String(255))
 
     class User(Base, UserMixin):
         __tablename__ = 'user'

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -211,7 +211,7 @@ and models.py.
     from sqlalchemy import create_engine
     from sqlalchemy.orm import relationship, backref
     from sqlalchemy import Boolean, DateTime, Column, Integer, \
-                           String, ForeignKey
+                        String, ForeignKey, UnicodeText
 
     class RolesUsers(Base):
         __tablename__ = 'roles_users'
@@ -224,7 +224,7 @@ and models.py.
         id = Column(Integer(), primary_key=True)
         name = Column(String(80), unique=True)
         description = Column(String(255))
-        permissions = Column(String(255))
+        permissions = Column(UnicodeText)
 
     class User(Base, UserMixin):
         __tablename__ = 'user'


### PR DESCRIPTION
### Background

In the quickstart doc, there is a [section covering usage with SQLAlchemy](https://flask-security-too.readthedocs.io/en/stable/quickstart.html#id4). This example has 3 files, `app.py`, `database.py` and `models.py`. The model `Role` specifies what a user is or is not allowed to do,  in a column `permissions`.

In the SQLAlchemy section, this field is missing. Note that the field is present in the other database samples, look here [Peewee](https://flask-security-too.readthedocs.io/en/stable/quickstart.html#peewee-application) and here  [MongoEngine/MongoDB](https://flask-security-too.readthedocs.io/en/stable/quickstart.html#mongoengine-application).

### Error

This isn't immediately evident because `app.py` includes an example creating a user, but not one of adding a role. 

If we wanted to add a role, [as demonstrated in the example dir here](https://github.com/Flask-Middleware/flask-security/blob/693a0840b28f8d1475799877c8eb92f364549a35/examples/fsqlalchemy1/app.py#L104) we could do like so, inside `create_user()`, next to where we create a user:
```python
# app.py
...
    user_datastore.find_or_create_role(
        name="admin",
        permissions={"admin-read", "admin-write", "user-read", "user-write"},
    )
...
```
However since `permissions` is not defined in models, running the app now throws an exception:

```python
  TypeError: 'permissions' is an invalid keyword argument for Role
```

### Fix

This is fixed simply by adding the missing `permissions = Column(String(255))` line (see PR). While it's trivial it's also important because adding roles is a core feature _IMO_, and this is where a new developer would get started and learn how to this library.

### Change made

Just that one line in quickstart has been added.
