### PR TITLE
Support for latest Werkzeug and Flask and Flask-Login

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
     python: python3.8
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
@@ -14,12 +14,12 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v2.37.3
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.6.0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,15 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 4.1.5
+-------------
+
+Released July 28, 2022
+
+Fixes
++++++
+- (:pr:`644`) Fix test and other failures with newer Flask-Login/Werkzeug versions.
+
 Version 4.1.4
 -------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ author = "Matt Wright & Chris Wagner"
 # built documents.
 #
 # The short X.Y version.
-version = "4.1.4"
+version = "4.1.5"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -6,7 +6,7 @@
     security via Flask-Login, Flask-Principal, Flask-WTF, and passlib.
 
     :copyright: (c) 2012-2019 by Matt Wright.
-    :copyright: (c) 2019-2020 by J. Christopher Wagner.
+    :copyright: (c) 2019-2022 by J. Christopher Wagner.
     :license: MIT, see LICENSE for more details.
 """
 
@@ -105,4 +105,4 @@ from .utils import (
     verify_and_update_password,
 )
 
-__version__ = "4.1.4"
+__version__ = "4.1.5"

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -17,7 +17,7 @@ import typing as t
 import warnings
 
 import pkg_resources
-from flask import _request_ctx_stack, current_app
+from flask import current_app, g
 from flask.json import JSONEncoder
 from flask_login import AnonymousUserMixin, LoginManager
 from flask_login import UserMixin as BaseUserMixin
@@ -79,6 +79,7 @@ from .utils import (
     get_identity_attribute,
     get_identity_attributes,
     get_message,
+    get_request_attr,
     localize_callback,
     set_request_attr,
     uia_email_mapper,
@@ -474,9 +475,20 @@ def _request_loader(request):
     # decorator @auth_token_required can call us.
     # N.B. we don't call current_user here since that in fact might try and LOAD
     # a user - which would call us again.
-    if all(hasattr(_request_ctx_stack.top, k) for k in ["fs_authn_via", "user"]):
-        if _request_ctx_stack.top.fs_authn_via == "token":
-            return _request_ctx_stack.top.user
+    if get_request_attr("fs_authn_via") == "token":
+        # Flask-Login 0.6.2 and post Flask 2.2
+        if hasattr(g, "_login_user"):
+            return g._login_user
+        else:  # pragma: no cover
+            # pre flask_login 0.6.2 and handle that flask 2.3 is deprecating
+            # _request_ctx_stack
+            try:
+                from flask import _request_ctx_stack
+
+                if hasattr(_request_ctx_stack.top, "user"):
+                    return _request_ctx_stack.top.user
+            except ImportError:
+                pass
 
     header_key = _security.token_authentication_header
     args_key = _security.token_authentication_key
@@ -523,6 +535,7 @@ def _identity_loader():
     if not isinstance(current_user._get_current_object(), AnonymousUserMixin):
         identity = Identity(current_user.fs_uniquifier)
         return identity
+    return None
 
 
 def _on_identity_loaded(sender, identity):
@@ -1210,8 +1223,6 @@ class Security:
             # This is only not registered if Flask-Babel isn't installed...
             if "_" not in app.jinja_env.globals:
                 current_app.jinja_env.globals["_"] = self.i18n_domain.gettext
-            # Register so other packages can reference our translations.
-            current_app.jinja_env.globals["_fsdomain"] = self.i18n_domain.gettext
 
         @app.before_first_request
         def _csrf_init():
@@ -1305,6 +1316,9 @@ class Security:
         self.pwd_context = _get_pwd_context(app)
         self.hashing_context = _get_hashing_context(app)
         self.i18n_domain = FsDomain(app)
+
+        # Register so other packages can reference our translations.
+        app.jinja_env.globals["_fsdomain"] = self.i18n_domain.gettext
 
         if cv("USERNAME_ENABLE", app):
             if hasattr(self.datastore, "user_model") and not hasattr(
@@ -1599,8 +1613,8 @@ class Security:
 
     def _run_ctx_processor(self, endpoint: str) -> t.Dict[str, t.Any]:
         rv: t.Dict[str, t.Any] = {}
-        for g in ["global", endpoint]:
-            for fn in self._context_processors.setdefault(g, []):
+        for gl in ["global", endpoint]:
+            for fn in self._context_processors.setdefault(gl, []):
                 rv.update(fn())
         return rv
 

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -14,7 +14,7 @@ import datetime
 from functools import wraps
 import typing as t
 
-from flask import Response, _request_ctx_stack, abort, current_app, g, redirect, request
+from flask import Response, abort, current_app, g, redirect, request
 from flask_login import current_user, login_required  # noqa: F401
 from flask_principal import Identity, Permission, RoleNeed, identity_changed
 from flask_wtf.csrf import CSRFError
@@ -149,7 +149,6 @@ def _check_token():
 
     if user and user.is_authenticated:
         app = current_app._get_current_object()
-        _request_ctx_stack.top.user = user
         identity_changed.send(app, identity=Identity(user.fs_uniquifier))
         return True
 
@@ -166,8 +165,8 @@ def _check_http_auth():
 
     if user and user.verify_and_update_password(auth.password):
         _security.datastore.commit()
+        _security.login_manager._update_request_context_with_user(user)
         app = current_app._get_current_object()
-        _request_ctx_stack.top.user = user
         identity_changed.send(app, identity=Identity(user.fs_uniquifier))
         return True
 
@@ -208,7 +207,7 @@ def handle_csrf(method: t.Optional[str]) -> None:
         if method in config_value("CSRF_PROTECT_MECHANISMS"):
             _csrf.protect()  # type: ignore
         else:
-            _request_ctx_stack.top.fs_ignore_csrf = True
+            set_request_attr("fs_ignore_csrf", True)
 
 
 def http_auth_required(realm: t.Any) -> DecoratedView:
@@ -439,7 +438,7 @@ def unauth_csrf(
                 config_value("CSRF_IGNORE_UNAUTH_ENDPOINTS")
                 and not current_user.is_authenticated
             ):
-                _request_ctx_stack.top.fs_ignore_csrf = True
+                set_request_attr("fs_ignore_csrf", True)
             else:
                 try:
                     _csrf.protect()

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -23,7 +23,6 @@ import urllib.request
 import urllib.error
 
 from flask import (
-    _request_ctx_stack,
     after_this_request,
     current_app,
     flash,
@@ -80,12 +79,14 @@ def get_request_attr(name: str) -> t.Any:
     Returns None if attribute doesn't exist.
 
     .. versionadded:: 4.0.0
+    .. versionchanged:: 4.1.5
+        Use 'g' rather than request_ctx stack which is going away post Flask 2.2
     """
-    return getattr(_request_ctx_stack.top, name, None)
+    return getattr(g, name, None)
 
 
 def set_request_attr(name, value):
-    return setattr(_request_ctx_stack.top, name, value)
+    return setattr(g, name, value)
 
 
 """
@@ -512,7 +513,8 @@ def url_for_security(endpoint: str, **values: t.Union[str, bool]) -> str:
     :param _method: if provided this explicitly specifies an HTTP method.
     """
     endpoint = get_security_endpoint_name(endpoint)
-    return url_for(endpoint, **values)
+    # mypy is complaining about this - but I think it's wrong?
+    return url_for(endpoint, **values)  # type: ignore
 
 
 def validate_redirect_url(url: str) -> bool:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,3 +1,3 @@
 Pallets-Sphinx-Themes~=2.0
-Sphinx~=4.0
-sphinx-issues~=1.2
+Sphinx~=5.0
+sphinx-issues==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("flask_security/__init__.py", encoding="utf8") as f:
     version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
 
 install_requires = [
-    "Flask>=1.1.1",
+    "Flask>=1.1.1,<2.3",
     "Flask-Login>=0.4.1",
     "Flask-Principal>=0.4.0",
     "Flask-WTF>=0.14.3",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,7 +106,7 @@ def app(request: pytest.FixtureRequest) -> "Flask":
             app.config["SECURITY_" + key.upper()] = value
 
     app.mail = Mail(app)  # type: ignore
-    app.json_encoder = JSONEncoder
+    app.json_encoder = JSONEncoder  # type: ignore
 
     # use babel marker to signify tests that need babel extension.
     babel = marker_getter("babel")

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -812,24 +812,24 @@ def test_change_token_uniquifier(app):
         )
         ds.commit()
 
-        client_nc = app.test_client(use_cookies=False)
+    client_nc = app.test_client(use_cookies=False)
 
-        response = json_authenticate(client_nc)
-        token = response.json["response"]["user"]["authentication_token"]
-        verify_token(client_nc, token)
+    response = json_authenticate(client_nc)
+    token = response.json["response"]["user"]["authentication_token"]
+    verify_token(client_nc, token)
 
-        # now change uniquifier
-        with app.test_request_context("/"):
-            user = app.security.datastore.find_user(email="matt@lp.com")
-            app.security.datastore.reset_user_access(user)
-            app.security.datastore.commit()
+    # now change uniquifier
+    with app.test_request_context("/"):
+        user = app.security.datastore.find_user(email="matt@lp.com")
+        app.security.datastore.reset_user_access(user)
+        app.security.datastore.commit()
 
-        verify_token(client_nc, token, status=401)
+    verify_token(client_nc, token, status=401)
 
-        # get new token and verify it works
-        response = json_authenticate(client_nc)
-        token = response.json["response"]["user"]["authentication_token"]
-        verify_token(client_nc, token)
+    # get new token and verify it works
+    response = json_authenticate(client_nc)
+    token = response.json["response"]["user"]["authentication_token"]
+    verify_token(client_nc, token)
 
 
 def test_null_token_uniquifier(app):
@@ -876,24 +876,21 @@ def test_null_token_uniquifier(app):
         verify_token(client_nc, token)
 
 
-def test_token_query(in_app_context):
+def test_token_query(app, client_nc):
     # Verify that when authenticating with auth token (and not session)
     # that there is just one DB query to get user.
-    app = in_app_context
-    populate_data(app)
-    client_nc = app.test_client(use_cookies=False)
+    with app.app_context():
+        response = json_authenticate(client_nc)
+        token = response.json["response"]["user"]["authentication_token"]
+        assert get_num_queries(app.security.datastore) == 1
 
-    response = json_authenticate(client_nc)
-    token = response.json["response"]["user"]["authentication_token"]
-    current_nqueries = get_num_queries(app.security.datastore)
-
-    response = client_nc.get(
-        "/token",
-        headers={"Content-Type": "application/json", "Authentication-Token": token},
-    )
-    assert response.status_code == 200
-    end_nqueries = get_num_queries(app.security.datastore)
-    assert current_nqueries is None or end_nqueries == (current_nqueries + 1)
+    with app.app_context():
+        response = client_nc.get(
+            "/token",
+            headers={"Content-Type": "application/json", "Authentication-Token": token},
+        )
+        assert response.status_code == 200
+        assert get_num_queries(app.security.datastore) == 1
 
 
 def test_session_query(in_app_context):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -442,7 +442,6 @@ def test_no_email_sender(app, sqlalchemy_datastore):
     security.init_app(app, sqlalchemy_datastore)
 
     with app.app_context():
-        app.try_trigger_before_first_request_functions()
         user = TestUser("matt@lp.com")
         with app.mail.record_messages() as outbox:
             send_mail("Test Default Sender", user.email, "welcome", user=user)
@@ -464,7 +463,6 @@ def test_sender_tuple(app, sqlalchemy_datastore):
     security.init_app(app, sqlalchemy_datastore)
 
     with app.app_context():
-        app.try_trigger_before_first_request_functions()
         user = TestUser("matt@lp.com")
         with app.mail.record_messages() as outbox:
             send_mail("Test Tuple Sender", user.email, "welcome", user=user)

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -261,21 +261,21 @@ from sqlalchemy.orm import relationship, backref
 from sqlalchemy import Boolean, DateTime, Column, Integer, String, Text, ForeignKey
 
 
-class RolesUsers(Base):
+class RolesUsers(Base):  # type: ignore
     __tablename__ = "roles_users"
     id = Column(Integer(), primary_key=True)
     user_id = Column("user_id", Integer(), ForeignKey("user.id"))
     role_id = Column("role_id", Integer(), ForeignKey("role.id"))
 
 
-class Role(Base, RoleMixin):
+class Role(Base, RoleMixin):  # type: ignore
     __tablename__ = "role"
     id = Column(Integer(), primary_key=True)
     name = Column(String(80), unique=True)
     description = Column(String(255))
 
 
-class User(Base, UserMixin):
+class User(Base, UserMixin):  # type: ignore
     __tablename__ = "user"
     id = Column(Integer, primary_key=True)
     fs_uniquifier = Column(String(64), unique=True, nullable=False)

--- a/tox.ini
+++ b/tox.ini
@@ -26,6 +26,7 @@ deps =
     Flask-Babel==2.0.0
     Flask-Mail==0.9.1
     Flask-Mongoengine==1.0.0
+    FLask-Login==0.5.0
     peewee==3.11.2
     argon2_cffi==20.1.0
     babel==2.7.0
@@ -43,7 +44,7 @@ deps =
     pyqrcode==1.2
     sqlalchemy==1.3.19
     sqlalchemy-utils==0.36.5
-    werkzeug==0.16.1
+    werkzeug==1.0.1
     zxcvbn==4.4.28
 commands =
     python setup.py compile_catalog
@@ -53,12 +54,12 @@ commands =
 [testenv:py38-main]
 deps =
     -r requirements/tests.txt
-    git+git://github.com/pallets/werkzeug@main#egg=werkzeug
-    git+git://github.com/pallets/flask@main#egg=flask
-    git+git://github.com/pallets/flask-sqlalchemy@main#egg=flask-sqlalchemy
-    git+git://github.com/pallets/jinja@main#egg=jinja2
-    git+git://github.com/wtforms/wtforms@master#egg=wtforms
-    git+git://github.com/maxcountryman/flask-login@main#egg=flask-login
+    git+https://github.com/pallets/werkzeug@main#egg=werkzeug
+    git+https://github.com/pallets/flask@main#egg=flask
+    git+https://github.com/pallets/flask-sqlalchemy@main#egg=flask-sqlalchemy
+    git+https://github.com/pallets/jinja@main#egg=jinja2
+    git+https://github.com/wtforms/wtforms@master#egg=wtforms
+    git+https://github.com/maxcountryman/flask-login@main#egg=flask-login
 commands =
     python setup.py compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}


### PR DESCRIPTION
flask-login changed where they store the current user - we used that (it was internal). It is now on 'g' which is part of the app context so for
a couple unit tests - wasn't getting popped (it used to be on the request context).

Following Flask guidelines - changed our get/set of request attributes (fs_authn_via) over to 'g' as well.