### PR TITLE
Support for latest Werkzeug and Flask and Flask-Login

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.1
+    rev: v2.37.3
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -123,6 +123,15 @@ If you are using Alembic the schema migration is easy::
 If you want to allow for empty passwords as part of registration then set :py:data:`SECURITY_PASSWORD_REQUIRED` to ``False``.
 In addition you need to change your DB schema to allow the ``password`` field to be nullable.
 
+Version 4.1.5
+-------------
+
+Released July 28, 2022
+
+Fixes
++++++
+- (:pr:`644`) Fix test and other failures with newer Flask-Login/Werkzeug versions.
+
 Version 4.1.4
 -------------
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -22,7 +22,6 @@ import urllib.request
 import urllib.error
 
 from flask import (
-    _request_ctx_stack,
     after_this_request,
     current_app,
     flash,
@@ -81,12 +80,14 @@ def get_request_attr(name: str) -> t.Any:
     Returns None if attribute doesn't exist.
 
     .. versionadded:: 4.0.0
+    .. versionchanged:: 4.1.5
+        Use 'g' rather than request_ctx stack which is going away post Flask 2.2
     """
-    return getattr(_request_ctx_stack.top, name, None)
+    return getattr(g, name, None)
 
 
 def set_request_attr(name, value):
-    return setattr(_request_ctx_stack.top, name, value)
+    return setattr(g, name, value)
 
 
 """
@@ -497,7 +498,8 @@ def url_for_security(endpoint: str, **values: t.Union[str, bool]) -> str:
     :param _method: if provided this explicitly specifies an HTTP method.
     """
     endpoint = get_security_endpoint_name(endpoint)
-    return url_for(endpoint, **values)
+    # mypy is complaining about this - but I think it's wrong?
+    return url_for(endpoint, **values)  # type: ignore
 
 
 def validate_redirect_url(url: str) -> bool:

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("flask_security/__init__.py", encoding="utf8") as f:
     version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
 
 install_requires = [
-    "Flask>=2.0.0",
+    "Flask>=2.0.0,<2.3",
     "Flask-Login>=0.6.0",
     "Flask-Principal>=0.4.0",
     "Flask-WTF>=1.0.0",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -120,7 +120,7 @@ def app(request: pytest.FixtureRequest) -> "SecurityFixture":
             app.config["SECURITY_" + key.upper()] = value
 
     app.mail = Mail(app)  # type: ignore
-    app.json_encoder = JSONEncoder
+    app.json_encoder = JSONEncoder  # type: ignore
 
     # use babel marker to signify tests that need babel extension.
     babel = marker_getter("babel")

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -454,7 +454,6 @@ def test_no_email_sender(app, sqlalchemy_datastore):
     security.init_app(app, sqlalchemy_datastore)
 
     with app.app_context():
-        app.try_trigger_before_first_request_functions()
         user = TestUser("matt@lp.com")
         send_mail("Test Default Sender", user.email, "welcome", user=user)
         outbox = app.mail.outbox
@@ -478,7 +477,6 @@ def test_sender_tuple(app, sqlalchemy_datastore):
     security.init_app(app, sqlalchemy_datastore)
 
     with app.app_context():
-        app.try_trigger_before_first_request_functions()
         user = TestUser("matt@lp.com")
         send_mail("Test Tuple Sender", user.email, "welcome", user=user)
         outbox = app.mail.outbox

--- a/tests/test_passwordless.py
+++ b/tests/test_passwordless.py
@@ -213,6 +213,6 @@ def test_deprecated(app, sqlalchemy_datastore):
         warnings.simplefilter("always")
         security = Security()
         security.init_app(app, sqlalchemy_datastore)
-        assert len(w) == 1
+        assert len(w) == 1 or len(w) == 3  # @before_first_request Flask 2.2
         assert issubclass(w[-1].category, DeprecationWarning)
         assert "deprecated" in str(w[-1].message)


### PR DESCRIPTION
flask-login changed where they store the current user - we used that (it was internal). It is now on 'g' which is part of the app context so for
a couple unit tests - wasn't getting popped (it used to be on the request context).

Following Flask guidelines - changed our get/set of request attributes (fs_authn_via) over to 'g' as well.