### PR TITLE
Remove deprecated add/remove_permissions methods.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,21 +14,23 @@ Features
 ++++++++
 - (:issue:`475`) Support for WebAuthn.
 - (:issue:`479`) Support Two-factor recovery codes.
+- (:issue:`585`) Provide option to prevent user enumeration (i.e. Generic Responses).
 - (:pr:`532`) Support for Python 3.10.
 - (:pr:`540`) Improve Templates in support of JS required by WebAuthn.
 - (:pr:`568`) Deprecate the old passwordless feature in favor of Unified Signin.
-  Deprecate replacing login_manager so we can possibly vendor that in in the future.
+- (:pr:`568`) Deprecate replacing login_manager so we can possibly vendor that in in the future.
 - (:pr:`608`) Add Icelandic translations. (ofurkusi)
 - (:issue:`256`) Add custom HTML attributes to improve user experience.
   This changed LoginForm quite a bit - please see backwards compatability concerns
   below. The default LoginForm and template should be the same as before.
 - (:pr:`638`) The JSON errors response has been unified. Please see backwards
   compatibility concerns below.
+- (:pr:`xxx`) The previously deprecated methods RoleMixin.add_permissions and
+  RoleMixin.remove_permissions have been removed.
 
 Fixes
 +++++
 - (:pr:`591`) Make the required zxcvbn complexity score configurable. (mephi42)
-- (:issue:`585`) Provide option to prevent user enumeration (i.e. Generic Responses).
 - (:issue:`531`) Get rid of Flask-Mail. Flask-Mailman is now the default preferred email package.
   Flask-Mail is still supported so there should be no backwards compatability issues.
 - (:issue:`597`) A delete option has been added to us-setup (form and view).
@@ -101,6 +103,9 @@ Other:
   The key `field_errors` will contain the dict as specified by WTForms. Please note that starting with WTForms 3.0
   form-level errors are supported and show up in the dict with the field name/key of "none". There are no changes to non-error
   related JSON responses.
+- Permissions - The Role Model now stores permissions as a list, and requires that the underlying DB ORM map that to a supported
+  DB type. For SQLAlchemy, this is mapped to a comma separated string (as before). For Mongo, a ListField can be directly used. For
+  for SQLAlchemy DBs the Column type (UnicodeText) didn't change so no data migration should be required.
 
 For templates:
 
@@ -313,7 +318,7 @@ Fixed
   Flask-Babel (>=2.00), Flask-BabelEx, as well as no translation support. Please see backwards compatibility notes below.
 - (:pr:`352`) Fix issue with adding/deleting permissions - all mutating methods must be at the datastore layer so that
   db.put() can be called. Added :meth:`.UserDatastore.add_permissions_to_role` and :meth:`.UserDatastore.remove_permissions_from_role`.
-  The methods :meth:`.RoleMixin.add_permissions` and :meth:`.RoleMixin.remove_permissions` have been deprecated.
+  The methods `.RoleMixin.add_permissions` and `.RoleMixin.remove_permissions` have been deprecated.
 - (:issue:`395`) Provide ability to change table names for User and Role tables in the fsqla model.
 - (:issue:`338`) All sessions are invalidated when a user changes or resets their password. This is accomplished by
   changing the user's `fs_uniquifier`. The user is automatically re-logged in (and a new session

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -121,7 +121,7 @@ Permissions
 If you want to protect endpoints with permissions, and assign permissions to roles
 that are then assigned to users, the ``Role`` model requires:
 
-* ``permissions`` (UnicodeText)
+* ``permissions`` (list of string/UnicodeText, nullable)
 
 WebAuthn
 ^^^^^^^^
@@ -140,7 +140,7 @@ The 'WebAuthn' model requires the following fields:
 * ``credential_id`` (binary, 1024 bytes, indexed, non-nullable, unique)
 * ``public_key`` (binary, 1024 bytes, non-nullable)
 * ``sign_count`` (integer, default=0, non-nullable)
-* ``transports`` (list of string)
+* ``transports`` (list of string/UnicodeText, nullable)
 * ``extensions`` (string, 255 bytes)
 * ``lastuse_datetime`` (datetime, non-nullable)
 * ``name`` (string, 64 bytes, non-nullable)
@@ -205,11 +205,7 @@ Recovery Codes
 If :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES` is set to ``True`` then
 the `User` model needs the following field:
 
-* ``mfa_recovery_codes`` (list of string, nullable)
-
-The length depends on how many codes are created :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES_N`
-and how long each code is (default 14 bytes). Suggest 1024 bytes for datastores that use a single
-string column to hold the codes.
+* ``mfa_recovery_codes`` (list of string/UnicodeText, nullable)
 
 A recovery code can be used in place of any configured second-factor authenticator
 (e.g. SMS, WebAuthn, ...).

--- a/examples/fsqlalchemy1/tests/test_api.py
+++ b/examples/fsqlalchemy1/tests/test_api.py
@@ -2,13 +2,11 @@
 
 from fsqlalchemy1.app import Blog
 
-from .test_utils import create_fake_role, create_fake_user, set_current_user
+from .test_utils import create_fake_user, set_current_user
 
 
 def test_monitor_404(myapp):
-    user = create_fake_user(
-        myapp.user_cls, roles=create_fake_role(myapp.role_cls, "basic")
-    )
+    user = create_fake_user(myapp.user_cls, roles=myapp.role_cls(name="basic"))
     set_current_user(myapp.app, user)
 
     # This requires "monitor" role
@@ -20,9 +18,7 @@ def test_monitor_404(myapp):
 
 
 def test_blog_write(myapp):
-    user_role = create_fake_role(
-        myapp.role_cls, "user", permissions="user-read, user-write"
-    )
+    user_role = myapp.role_cls(name="user", permissions={"user-read", "user-write"})
     user = create_fake_user(myapp.user_cls, roles=user_role)
     set_current_user(myapp.app, user)
 

--- a/examples/fsqlalchemy1/tests/test_utils.py
+++ b/examples/fsqlalchemy1/tests/test_utils.py
@@ -37,9 +37,3 @@ def create_fake_user(user_cls, email="unittest@me.com", userid=1, roles=None):
         else:
             user.roles = [roles]
     return user
-
-
-def create_fake_role(role_cls, name, permissions=None):
-    if permissions:
-        permissions = ",".join(p.strip() for p in permissions.split(","))
-    return role_cls(name=name, permissions=permissions)

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -5,7 +5,7 @@
     Command Line Interface for managing accounts and roles.
 
     :copyright: (c) 2016 by CERN.
-    :copyright: (c) 2019-2021 by J. Christopher Wagner
+    :copyright: (c) 2019-2022 by J. Christopher Wagner
     :license: MIT, see LICENSE for more details.
 """
 
@@ -231,7 +231,8 @@ def roles_add_permissions(role, permissions):
     role = _datastore._prepare_role_modify_args(role)
     if role is None:
         raise click.UsageError("Cannot find role.")
-    if _datastore.add_permissions_to_role(role, permissions):
+    permlist = [s.strip() for s in permissions.split(",")]
+    if _datastore.add_permissions_to_role(role, permlist):
         click.secho(
             f'Permission(s) "{permissions}" added to role "{role.name}" successfully.',
             fg="green",
@@ -254,7 +255,8 @@ def roles_remove_permissions(role, permissions):
     role = _datastore._prepare_role_modify_args(role)
     if role is None:
         raise click.UsageError("Cannot find role.")
-    if _datastore.remove_permissions_from_role(role, permissions):
+    permlist = [s.strip() for s in permissions.split(",")]
+    if _datastore.remove_permissions_from_role(role, permlist):
         click.secho(
             f'Permission(s) "{permissions}" removed from role'
             f' "{role.name}" successfully.',

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -729,8 +729,7 @@ class RoleMixin:
     if t.TYPE_CHECKING:  # pragma: no cover
 
         def __init__(self):
-            # Depends on how the user creates the DB data model
-            self.permissions: t.Union[str, set, list, None]
+            self.permissions: t.Optional[t.List[str]]
 
     def __eq__(self, other):
         return self.name == other or self.name == getattr(other, "name", None)
@@ -745,71 +744,11 @@ class RoleMixin:
         """
         Return set of permissions associated with role.
 
-        Supports permissions being a comma separated string, an iterable, or a set
-        based on how the underlying DB model was built.
-
         .. versionadded:: 3.3.0
         """
-
-        # This set, list stuff wasn't completely implemented - since add/remove
-        # permissions don't actually accept them. And they aren't really
-        # deprecated since UserDatastore still calls them - they just aren't
-        # public. And the unit tests don't really test this stuff. sigh.
         if hasattr(self, "permissions") and self.permissions:
-            if isinstance(self.permissions, set):
-                return self.permissions
-            elif isinstance(self.permissions, list):
-                return set(self.permissions)
-            else:
-                # Assume this is a comma separated list
-                return set(self.permissions.split(","))
+            return set(self.permissions)
         return set()
-
-    def add_permissions(self, permissions: t.Union[set, list, str]) -> None:
-        """
-        Add one or more permissions to role.
-
-        :param permissions: a set, list, or single string.
-
-        .. versionadded:: 3.3.0
-
-        .. deprecated:: 3.4.4
-            Use :meth:`.UserDatastore.add_permissions_to_role`
-        """
-        if hasattr(self, "permissions"):
-            current_perms = self.get_permissions()
-            if isinstance(permissions, set):
-                perms = permissions
-            elif isinstance(permissions, list):
-                perms = set(permissions)
-            else:
-                perms = {permissions}
-            self.permissions = ",".join(current_perms.union(perms))
-        else:  # pragma: no cover
-            raise NotImplementedError("Role model doesn't have permissions")
-
-    def remove_permissions(self, permissions: t.Union[set, list, str]) -> None:
-        """
-        Remove one or more permissions from role.
-
-        :param permissions: a set, list, or single string.
-
-        .. versionadded:: 3.3.0
-
-        .. deprecated:: 3.4.4
-            Use :meth:`.UserDatastore.remove_permissions_from_role`
-        """
-        if hasattr(self, "permissions"):
-            current_perms = self.get_permissions()
-            if isinstance(permissions, set):
-                perms = permissions
-            elif isinstance(permissions, list):
-                perms = set(permissions)
-            else:
-                perms = {permissions}
-            self.permissions = ",".join(current_perms.difference(perms))
-        else:  # pragma: no cover
-            raise NotImplementedError("Role model doesn't have permissions")
 
 
 class UserMixin(BaseUserMixin):

--- a/flask_security/models/fsqla_v3.py
+++ b/flask_security/models/fsqla_v3.py
@@ -37,7 +37,7 @@ from flask_security import WebAuthnMixin
 class AsaList(types.TypeDecorator):
     # SQL-like DBs don't have a List type - so do that here by converting to a comma
     # separate string.
-    impl = types.String
+    impl = types.UnicodeText
 
     def process_bind_param(self, value, dialect):
         # produce a string from an iterable
@@ -57,7 +57,9 @@ class FsModels(FsModelsV2):
 
 
 class FsRoleMixin(FsRoleMixinV2):
-    pass
+    permissions = Column(
+        MutableList.as_mutable(AsaList()), nullable=True  # type: ignore
+    )
 
 
 class FsUserMixin(FsUserMixinV2):
@@ -75,7 +77,7 @@ class FsUserMixin(FsUserMixinV2):
     fs_webauthn_user_handle = Column(String(64), unique=True)
 
     # MFA - one time recovery codes - comma separated.
-    mf_recovery_codes = Column(MutableList.as_mutable(AsaList(1024)), nullable=True)
+    mf_recovery_codes = Column(MutableList.as_mutable(AsaList()), nullable=True)
 
     # Change password to nullable so we can tell after registration whether
     # a user has a password or not.
@@ -99,7 +101,7 @@ class FsWebAuthnMixin(WebAuthnMixin):
     credential_id = Column(LargeBinary(1024), index=True, unique=True, nullable=False)
     public_key = Column(LargeBinary, nullable=False)
     sign_count = Column(Integer, default=0)
-    transports = Column(MutableList.as_mutable(AsaList(1024)), nullable=True)
+    transports = Column(MutableList.as_mutable(AsaList()), nullable=True)
     backup_state = Column(Boolean, nullable=False)  # Upcoming post V3 spec
     device_type = Column(String(64), nullable=False)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -220,6 +220,7 @@ def test_cli_addremove_role(script_info):
 def test_cli_addremove_permissions(script_info):
     """Test add/remove permissions."""
     runner = CliRunner()
+    app = script_info.load_app()
 
     result = runner.invoke(
         roles_create, ["superusers", "-d", "Test description"], obj=script_info
@@ -235,6 +236,11 @@ def test_cli_addremove_permissions(script_info):
     result = runner.invoke(
         roles_add_permissions, ["superusers", "read, write"], obj=script_info
     )
+
+    with app.app_context():
+        srole = app.security.datastore.find_role("superusers")
+        assert srole.get_permissions() == {"read", "write"}
+
     assert all(p in result.output for p in ["read", "write", "superusers"])
 
     # remove permission to non-existent role
@@ -253,6 +259,9 @@ def test_cli_addremove_permissions(script_info):
     )
     # remove permissions doesn't check if existing or not.
     assert all(p in result.output for p in ["read", "superusers"])
+    with app.app_context():
+        srole = app.security.datastore.find_role("superusers")
+        assert srole.get_permissions() == set()
 
 
 def test_cli_activate_deactivate(script_info):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -137,7 +137,7 @@ def create_roles(ds):
     ]
     for role in roles:
         if hasattr(ds.role_model, "permissions") and role[1]:
-            ds.create_role(name=role[0], permissions=",".join(role[1]))
+            ds.create_role(name=role[0], permissions=role[1])
         else:
             ds.create_role(name=role[0])
     ds.commit()


### PR DESCRIPTION
The Role Object stores permissions as a list always - the underlying DB ORM implementations now
convert that to an appropriate DB type. For SQLAlchemy derived DBs - that is still a comma separated string.
There should be no DB migration required since the Column type is still UnicodeText.

Changed the AsAlist DB type to be UnicodeText so we have a unlimited size for these comma separated strings.