### PR TITLE
Updates to work with Flask >=2.2 JSON serialization changes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,8 +25,10 @@ Features
   below. The default LoginForm and template should be the same as before.
 - (:pr:`638`) The JSON errors response has been unified. Please see backwards
   compatibility concerns below.
-- (:pr:`xxx`) The previously deprecated methods RoleMixin.add_permissions and
+- (:pr:`654`) The previously deprecated methods RoleMixin.add_permissions and
   RoleMixin.remove_permissions have been removed.
+- (:pr:`xxx`) The ability to pass in a json_encoder_cls as part of initialization has been removed
+  since Flask 2.2 has deprecated and replaced that functionality.
 
 Fixes
 +++++
@@ -45,7 +47,7 @@ Fixes
   has been added (defaults to ``True``).
 - (:issue:`479`) A new configuration option :py:data:`SECURITY_TWO_FACTOR_RESCUE_EMAIL` has been added
   that allows disabling that feature - defaults to backwards compatible ``True``
-- (:pr:`xxx`) Flask has deprecated @before_first_request. This was used mostly in examples/quickstart.
+- (:pr:`655`) Flask has deprecated @before_first_request. This was used mostly in examples/quickstart.
   These have been changed to use app.app_context() prior to running the app. FS itself used it in
   2 places - to populate `_` in jinja globals if Babel wasn't initialized and to perform
   various configuration sanity checks w.r.t. WTF CSRF. All FS templates have been converted
@@ -114,6 +116,8 @@ Other:
   DB type. For SQLAlchemy, this is mapped to a comma separated string (as before). For Mongo, a ListField can be directly used. For
   for SQLAlchemy DBs the Column type (UnicodeText) didn't change so no data migration should be required.
 - CSRF - As mentioned above, it is now required that `FlaskWTF::CSRFProtect()`, if used, must be called PRIOR to initializing Flask-Security.
+- json_encoder_cls - As mentioned above - Flask-Security initialization on longer accepts overriding the json_encoder class. If this is required,
+  update to Flask >=2.2 and implement Flask's JSONProvider interface.
 
 For templates:
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -204,7 +204,6 @@ Security() instantiation.
 .. autoclass:: flask_security.Totp
   :members: get_last_counter, set_last_counter, generate_qrcode
 
-.. autoclass:: flask_security.FsJsonEncoder
 
 Forms
 -----

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -91,7 +91,6 @@ from .unified_signin import (
 )
 from .username_util import UsernameUtil
 from .utils import (
-    FsJsonEncoder,
     SmsSenderBaseClass,
     SmsSenderFactory,
     check_and_get_token_status,

--- a/flask_security/json.py
+++ b/flask_security/json.py
@@ -1,0 +1,71 @@
+"""
+    Flask-Security JSON extensions.
+
+    :copyright: (c) 2022-2022 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+
+    Pieces of this code liberally copied from flask-mongoengine.
+"""
+from flask import __version__ as flask_version
+
+
+def use_json_provider() -> bool:
+    """Split Flask before 2.2.0 and after, to use/not use JSON provider approach."""
+    version = list(flask_version.split("."))
+    return int(version[0]) > 2 or (int(version[0]) == 2 and int(version[1]) > 1)
+
+
+def _use_encoder(superclass):  # pragma: no cover
+    """Flask < 2.2"""
+
+    class FsJsonEncoder(superclass):
+        """Flask-Security JSON encoder.
+        Extends Flask's JSONencoder to handle lazy-text.
+        """
+
+        def default(self, obj):
+            from .babel import is_lazy_string
+
+            if is_lazy_string(obj):
+                return str(obj)
+            else:
+                return super().default(obj)
+
+    return FsJsonEncoder
+
+
+def _use_provider(superclass):
+    """Flask 2.2 onwards - customize JSONProvider"""
+
+    class FSJsonProvider(superclass):
+        @staticmethod
+        def default(obj):
+            from .babel import is_lazy_string
+
+            if is_lazy_string(obj):
+                return str(obj)
+            return super(FSJsonProvider, FSJsonProvider).default(obj)
+
+    return FSJsonProvider
+
+
+def setup_json(app, bp=None):
+    # Called at init_app time.
+    if use_json_provider():
+        from flask import __version__
+
+        app.json_provider_class = _use_provider(app.json_provider_class)
+        app.json = app.json_provider_class(app)
+        # a bit if a hack - if a package (e.g. flask-mongoengine) hasn't
+        # converted yet - they might use json_encoder. This ONLY applies
+        # to this specific version of Flask that happens to use _json_encoder to
+        # signal if any app/extension has registered an old style encoder.
+        # (app.json_encoder is always set)
+        # (If they do, then Flask 2.2.2 won't use json_provider at all)
+        # Of course if they do this AFTER we're initialized all bets are off.
+        if __version__ == "2.2.2":
+            if app._json_encoder:
+                app.json_encoder = _use_encoder(app.json_encoder)
+
+    elif bp:  # pragma: no cover
+        bp.json_encoder = _use_encoder(app.json_encoder)

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -31,7 +31,6 @@ from flask import (
     session,
     url_for,
 )
-from flask.json import JSONEncoder
 from flask_login import login_user as _login_user
 from flask_login import logout_user as _logout_user
 from flask_login import current_user
@@ -1049,22 +1048,6 @@ def json_error_response(
     response_json["errors"] = plain_errors
 
     return response_json
-
-
-class FsJsonEncoder(JSONEncoder):
-    """Flask-Security JSON encoder.
-    Extends Flask's JSONencoder to handle lazy-text.
-
-    .. versionadded:: 3.3.0
-    """
-
-    def default(self, obj):
-        from .babel import is_lazy_string
-
-        if is_lazy_string(obj):
-            return str(obj)
-        else:
-            return JSONEncoder.default(self, obj)
 
 
 def default_render_template(*args, **kwargs):

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -1196,7 +1196,7 @@ def mf_recovery():
     )
 
 
-def create_blueprint(app, state, import_name, json_encoder=None):
+def create_blueprint(app, state, import_name):
     """Creates the security extension blueprint"""
 
     bp = Blueprint(
@@ -1206,8 +1206,6 @@ def create_blueprint(app, state, import_name, json_encoder=None):
         subdomain=state.subdomain,
         template_folder="templates",
     )
-    if json_encoder:
-        bp.json_encoder = json_encoder
 
     if state.logout_methods is not None:
         bp.route(state.logout_url, methods=state.logout_methods, endpoint="logout")(

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,3 +12,14 @@ markers =
     trackable
     unified_signin
     webauthn
+
+filterwarnings =
+    error
+    ignore:.*'_app_ctx_stack' is deprecated.*:DeprecationWarning:flask:0
+    ignore:.*'app.json_encoder' is deprecated.*:DeprecationWarning:flask:0
+    ignore:.*Setting 'json_encoder'.*:DeprecationWarning:flask:0
+    ignore:.*'JSONEncoder'.*:DeprecationWarning:flask:0
+    ignore::DeprecationWarning:mongoengine:
+    ignore:.*passwordless feature.*:DeprecationWarning:flask_security:0
+    ignore:.*passing settings to bcrypt.*:DeprecationWarning:passlib:0
+    ignore:.*'sms' was enabled in SECURITY_US_ENABLED_METHODS;.*:UserWarning:flask_security:0

--- a/requirements_low/tests.txt
+++ b/requirements_low/tests.txt
@@ -1,9 +1,10 @@
 # Lowest supported versions
 Flask==2.0.0
-Flask-SQLAlchemy==2.4.4
+Flask-SQLAlchemy==2.5.0
 Flask-Babel==2.0.0
 Flask-Mailman==0.3.0
 Flask-Mongoengine==1.0.0
+Flask-Login==0.5.0
 peewee==3.11.2
 argon2_cffi==20.1.0
 babel==2.9.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -388,7 +388,8 @@ def sqlalchemy_setup(request, app, tmpdir, realdburl):
         security_number = db.Column(db.Integer, unique=True)
 
         def get_security_payload(self):
-            # Make sure we still properly hook up to flask JSONEncoder
+            # Make sure we still properly hook up to flask's JSON extension
+            # which handles datetime
             return {"email": str(self.email), "last_update": self.update_datetime}
 
     with app.app_context():
@@ -538,7 +539,8 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl):
             return relationship("WebAuthn", backref="users", cascade="all, delete")
 
         def get_security_payload(self):
-            # Make sure we still properly hook up to flask JSONEncoder
+            # Make sure we still properly hook up to flask's JSON extension
+            # which handles datetime
             return {"email": str(self.email), "last_update": self.update_datetime}
 
     with app.app_context():

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -5,6 +5,7 @@
     Entity tests
 """
 import inspect
+import pytest
 
 from sqlalchemy import Column
 from flask_security import AnonymousUser, RoleMixin, UserMixin
@@ -53,6 +54,7 @@ def get_user_attributes(cls):
     return [item for item in inspect.getmembers(cls) if item[0] not in boring]
 
 
+@pytest.mark.filterwarnings("ignore::sqlalchemy.exc.SAWarning")
 def test_fsqla_fields():
     # basic test to verify no one modified fsqla after shipping.
     # Not perfect since not checking relationships etc.

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -354,6 +354,9 @@ def test_password_unicode_password_salt(client):
     assert b"Welcome matt@lp.com" in response.data
 
 
+@pytest.mark.filterwarnings(
+    "ignore:.*'unauthorized_handler' has been replaced.*:DeprecationWarning"
+)
 def test_set_unauthorized_handler(app, client):
     @app.security.unauthorized_handler
     def unauthorized():
@@ -1215,6 +1218,7 @@ def test_nodatastore(app):
         s.init_app(app)
 
 
+@pytest.mark.filterwarnings("ignore:.*Replacing login_manager.*:DeprecationWarning")
 def test_reuse_security_object(sqlalchemy_datastore):
     # See: https://github.com/Flask-Middleware/flask-security/issues/518
     # Let folks re-use the Security object (mostly for testing).

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{37,38,39,310,py38}-{low,release}
+    py{37,38,39,310,py39}-{low,release}
     mypy
     nowebauthn
     nobabel
@@ -10,20 +10,27 @@ envlist =
     makedist
 skip_missing_interpreters = true
 
-[testenv:py{37,38,39,310,py38}-release]
+[testenv:pypy39-release]
+deps =
+    -r requirements/tests.txt
+commands =
+    python setup.py compile_catalog
+    pytest -W ignore --basetemp={envtmpdir} {posargs:tests}
+
+[testenv:py{37,38,39,310}-release]
 deps =
     -r requirements/tests.txt
 commands =
     python setup.py compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}
 
-[testenv:py{37,38,39,310,py38}-low]
+[testenv:py{37,38,39,310,py39}-low]
 deps =
     pytest
     -r requirements_low/tests.txt
 commands =
     python setup.py compile_catalog
-    pytest --basetemp={envtmpdir} {posargs:tests}
+    pytest -W ignore --basetemp={envtmpdir} {posargs:tests}
 
 # manual test to check how we're keeping up with Pallets latest
 [testenv:py38-main]


### PR DESCRIPTION
Flask in 2.2 deprecated JSONEncoder and created a JSONProvider interface. In addition, Flask deprecated placing a json serializer on the blueprint (which
Flask-Security did).

Now, Flask-Security subclasses JSONProvder interface and adds its support for serializing lazy_strings. It still supports older Flask JSONEncoder interface.
Since the JSONEncoder is going away, remove the support for applications to pass in their own JSONEncoder as part of FS initialization - not sure anyone actually
did that - they can always update to Flask 2.2 and implement the JSONProvider interface.

Update pytest.ini to error out on warnings - needs a bunch of overrides right now - but is a good practice.