### PR TITLE
Fixed issues related to upcomming flask-sqlalchemy 3.0.0 release

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -410,6 +410,10 @@ def sqlalchemy_setup(request, app, tmpdir, realdburl):
     else:
         app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
 
+    # In Flask-SQLAlchemy >= 3.0.0 queries are no longer logged automatically,
+    # even in debug or testing mode.
+    app.config["SQLALCHEMY_RECORD_QUERIES"] = True
+
     db = SQLAlchemy(app)
 
     fsqla.FsModels.set_db_info(db)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -201,9 +201,14 @@ def get_num_queries(datastore):
     return None if datastore doesn't support this.
     """
     if is_sqlalchemy(datastore):
-        from flask_sqlalchemy import get_debug_queries
+        try:
+            # Flask-SQLAlachemy >= 3.0.0
+            from flask_sqlalchemy.record_queries import get_recorded_queries
+        except ImportError:
+            # Flask-SQLAlchemy < 3.0.0
+            from flask_sqlalchemy import get_debug_queries as get_recorded_queries
 
-        return len(get_debug_queries())
+        return len(get_recorded_queries())
     return None
 
 


### PR DESCRIPTION
- rename of get_debug_queries to get_recorded_queries (and move to to new module)
- SQLALCHEMY_RECORD_QUERIES must be set explicit

See also https://github.com/Flask-Middleware/flask-security/issues/677