### PR TITLE
Form instantiation generalization.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,12 +14,12 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.0.0
+    rev: v3.1.0
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
     -   id: black
 -   repo: https://gitlab.com/pycqa/flake8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,28 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 5.1.0
+-------------
+
+Released TBD
+
+Features
+++++++++
+
+- (:issue:`667`) Expose form instantiation. See :ref:`form_instantiation`.
+
+Fixes
++++++
+
+- (:pr:`678`) Fixes for Flask-SQLAlchemy 3.0.0. (jrast)
+- (:pr:`680`) Fixes for sqlalchemy 2.0.0 (jrast)
+
+Backwards Compatibility Concerns
++++++++++++++++++++++++++++++++++
+
+- Each form class used to be set as an attribute on the Security object. With
+  the new form instantiation model, they no longer are.
+
 Version 5.0.2
 -------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -233,6 +233,8 @@ Forms
 .. autoclass:: flask_security.WebAuthnSigninResponseForm
 .. autoclass:: flask_security.WebAuthnDeleteForm
 .. autoclass:: flask_security.WebAuthnVerifyForm
+.. autoclass:: flask_security.Form
+.. autoclass:: flask_security.FormInfo
 
 .. _signals_topic:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ author = "Matt Wright & Chris Wagner"
 # built documents.
 #
 # The short X.Y version.
-version = "5.0.2"
+version = "5.1.0"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -18,6 +18,7 @@ from .core import (
     UserMixin,
     WebAuthnMixin,
     AnonymousUser,
+    FormInfo,
     current_user,
 )
 from .datastore import (
@@ -43,6 +44,7 @@ from .decorators import (
     unauth_csrf,
 )
 from .forms import (
+    Form,
     ChangePasswordForm,
     ForgotPasswordForm,
     LoginForm,
@@ -127,4 +129,4 @@ from .webauthn import (
 )
 from .webauthn_util import WebauthnUtil
 
-__version__ = "5.0.2"
+__version__ = "5.1.0"

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -14,11 +14,11 @@ import functools
 
 import click
 from flask import current_app
-from werkzeug.datastructures import MultiDict
 from werkzeug.local import LocalProxy
 from .quart_compat import get_quart_status
 
 from .changeable import admin_change_password
+from .forms import build_form
 from .utils import (
     lookup_identity,
     get_identity_attributes,
@@ -128,7 +128,7 @@ def users_create(attributes, password, active):
         kwargs[attr] = attrarg
     kwargs.update(**{"password": password})
 
-    form = _security.confirm_register_form(MultiDict(kwargs), meta={"csrf": False})
+    form = build_form("confirm_register_form", meta={"csrf": False}, **kwargs)
 
     if form.validate():
         # We don't use the form directly to provide values so that this CLI can actually
@@ -343,7 +343,7 @@ def users_change_password(user, password):
         raise click.UsageError("User not found.")
 
     kwargs = {"password": password, "password_confirm": password}
-    form = _security.reset_password_form(MultiDict(kwargs), meta={"csrf": False})
+    form = build_form("reset_password_form", meta={"csrf": False}, **kwargs)
 
     if form.validate():
         # validation will normalize password

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -855,7 +855,7 @@ class SQLAlchemySessionUserDatastore(SQLAlchemyUserDatastore, SQLAlchemyDatastor
 
         SQLAlchemyUserDatastore.__init__(
             self,
-            PretendFlaskSQLAlchemyDb(session),
+            PretendFlaskSQLAlchemyDb(session),  # type: ignore
             user_model,
             role_model,
             webauthn_model,

--- a/flask_security/tf_plugin.py
+++ b/flask_security/tf_plugin.py
@@ -13,10 +13,10 @@
 import typing as t
 
 from flask import request, redirect, session
-from werkzeug.datastructures import MultiDict
 
 from .decorators import unauth_csrf
 from .forms import (
+    build_form_from_request,
     get_form_field_xlate,
     Form,
     RadioField,
@@ -34,7 +34,6 @@ from .utils import (
     get_url,
     login_user,
     simple_render_json,
-    suppress_form_csrf,
     url_for_security,
 )
 
@@ -58,11 +57,7 @@ class TwoFactorSelectForm(Form):
 def tf_select() -> "ResponseValue":
     # Ask user which MFA method they want to use.
     # This is used when a user has setup more than one type of 2FA.
-    form_class = _security.two_factor_select_form
-    form_data = None
-    if request.content_length:
-        form_data = MultiDict(request.get_json()) if request.is_json else request.form
-    form = form_class(formdata=form_data, meta=suppress_form_csrf())
+    form = build_form_from_request("two_factor_select_form")
 
     # This endpoint is unauthenticated - make sure we're in a valid state
     if not all(k in session for k in ["tf_user_id", "tf_select"]):

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -11,9 +11,8 @@
 import typing as t
 
 from flask import current_app as app, redirect, request, session
-from werkzeug.datastructures import MultiDict
 
-from .forms import TwoFactorRescueForm
+from .forms import DummyForm, TwoFactorRescueForm
 from .proxies import _security, _datastore
 from .tf_plugin import TfPluginBase, tf_clean_session
 from .utils import (
@@ -206,6 +205,6 @@ class CodeTfPlugin(TfPluginBase):
                 return redirect(url_for_security("two_factor_token_validation"))
 
         # JSON response - Fake up a form - doesn't really matter which.
-        form = _security.login_form(MultiDict([]))
+        form = DummyForm(formdata=None)
         form.user = user
         return base_render_json(form, include_user=False, additional=json_payload)

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -42,7 +42,6 @@ from wtforms import ValidationError
 from itsdangerous import BadSignature, SignatureExpired
 from werkzeug import __version__ as werkzeug_version
 from werkzeug.local import LocalProxy
-from werkzeug.datastructures import MultiDict
 
 from .quart_compat import best, get_quart_status
 from .proxies import _security, _datastore, _pwd_context, _hashing_context
@@ -114,7 +113,9 @@ def find_csrf_field_name():
     overridable.
     We take the field name from the login_form as set by the configuration.
     """
-    form = _security.login_form(MultiDict([]))
+    from .forms import DummyForm
+
+    form = DummyForm(formdata=None)
     if hasattr(form.meta, "csrf_field_name"):
         return form.meta.csrf_field_name
     return None
@@ -1063,9 +1064,6 @@ def default_render_template(*args, **kwargs):
 
 
 class SmsSenderBaseClass(metaclass=abc.ABCMeta):
-    def __init__(self, *args, **kwargs):
-        pass
-
     @abc.abstractmethod
     def send_sms(
         self, from_number: str, to_number: str, msg: str

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -45,7 +45,6 @@ from functools import partial
 from flask import abort, after_this_request, request, session
 from flask import current_app as app
 from flask_login import current_user
-from werkzeug.datastructures import MultiDict
 from wtforms import BooleanField, HiddenField, RadioField, StringField, SubmitField
 
 try:
@@ -71,7 +70,14 @@ except ImportError:  # pragma: no cover
     pass
 
 from .decorators import anonymous_user_required, auth_required, unauth_csrf
-from .forms import Form, Required, get_form_field_label, get_form_field_xlate
+from .forms import (
+    Form,
+    Required,
+    build_form_from_request,
+    build_form,
+    get_form_field_label,
+    get_form_field_xlate,
+)
 from .proxies import _security, _datastore
 from .quart_compat import get_quart_status
 from .signals import wan_registered, wan_deleted
@@ -91,7 +97,6 @@ from .utils import (
     lookup_identity,
     propagate_next,
     simple_render_json,
-    suppress_form_csrf,
     url_for_security,
     view_commit,
 )
@@ -381,11 +386,7 @@ def webauthn_register() -> "ResponseValue":
     """
     payload: t.Dict[str, t.Any]
 
-    form_class = _security.wan_register_form
-    form_data = None
-    if request.content_length:
-        form_data = MultiDict(request.get_json()) if request.is_json else request.form
-    form = form_class(formdata=form_data, meta=suppress_form_csrf())
+    form = build_form_from_request("wan_register_form")
 
     if form.validate_on_submit():
         challenge = _security._webauthn_util.generate_challenge(
@@ -441,7 +442,7 @@ def webauthn_register() -> "ResponseValue":
         return _security.render_template(
             cv("WAN_REGISTER_TEMPLATE"),
             wan_register_form=form,
-            wan_register_response_form=WebAuthnRegisterResponseForm(formdata=None),
+            wan_register_response_form=build_form("wan_register_response_form"),
             wan_state=state_token,
             credential_options=json.dumps(co_json),
             **_security._run_ctx_processor("wan_register")
@@ -478,7 +479,7 @@ def webauthn_register() -> "ResponseValue":
     return _security.render_template(
         cv("WAN_REGISTER_TEMPLATE"),
         wan_register_form=form,
-        wan_delete_form=_security.wan_delete_form(formdata=None),
+        wan_delete_form=build_form("wan_delete_form"),
         registered_credentials=current_creds,
         **_security._run_ctx_processor("wan_register")
     )
@@ -487,12 +488,7 @@ def webauthn_register() -> "ResponseValue":
 @auth_required(lambda: cv("API_ENABLED_METHODS"))
 def webauthn_register_response(token: str) -> "ResponseValue":
     """Response from browser."""
-
-    form_class = _security.wan_register_response_form
-    form_data = None
-    if request.content_length:
-        form_data = MultiDict(request.get_json()) if request.is_json else request.form
-    form = form_class(formdata=form_data, meta=suppress_form_csrf())
+    form = build_form_from_request("wan_register_response_form")
 
     expired, invalid, state = check_and_get_token_status(
         token, "wan", get_within_delta("WAN_REGISTER_WITHIN")
@@ -599,12 +595,8 @@ def webauthn_signin() -> "ResponseValue":
         pass
     else:
         abort(404)
-    form_class = _security.wan_signin_form
-    form_data = None
-    if request.content_length:
-        form_data = MultiDict(request.get_json()) if request.is_json else request.form
-    form = form_class(formdata=form_data, meta=suppress_form_csrf())
 
+    form = build_form_from_request("wan_signin_form")
     form.is_secondary = is_secondary
     if form.validate_on_submit():
         o_json, state_token = _signin_common(
@@ -624,8 +616,8 @@ def webauthn_signin() -> "ResponseValue":
         return _security.render_template(
             cv("WAN_SIGNIN_TEMPLATE"),
             wan_signin_form=form,
-            wan_signin_response_form=WebAuthnSigninResponseForm(
-                remember=form.remember.data
+            wan_signin_response_form=build_form(
+                "wan_signin_response_form", remember=form.remember.data
             ),
             wan_state=state_token,
             credential_options=json.dumps(o_json),
@@ -638,7 +630,7 @@ def webauthn_signin() -> "ResponseValue":
     return _security.render_template(
         cv("WAN_SIGNIN_TEMPLATE"),
         wan_signin_form=form,
-        wan_signin_response_form=WebAuthnSigninResponseForm(formdata=None),
+        wan_signin_response_form=build_form("wan_signin_response_form"),
         is_secondary=is_secondary,
         **_security._run_ctx_processor("wan_signin")
     )
@@ -650,11 +642,7 @@ def webauthn_signin_response(token: str) -> "ResponseValue":
         "tf_state"
     ] in ["ready"]
 
-    form_class = _security.wan_signin_response_form
-    form_data = None
-    if request.content_length:
-        form_data = MultiDict(request.get_json()) if request.is_json else request.form
-    form = form_class(formdata=form_data, meta=suppress_form_csrf())
+    form = build_form_from_request("wan_signin_response_form")
 
     expired, invalid, state = check_and_get_token_status(
         token, "wan", get_within_delta("WAN_SIGNIN_WITHIN")
@@ -742,12 +730,7 @@ def webauthn_signin_response(token: str) -> "ResponseValue":
 )
 def webauthn_delete() -> "ResponseValue":
     """Deletes an existing registered credential."""
-
-    form_class = _security.wan_delete_form
-    form_data = None
-    if request.content_length:
-        form_data = MultiDict(request.get_json()) if request.is_json else request.form
-    form = form_class(formdata=form_data, meta=suppress_form_csrf())
+    form = build_form_from_request("wan_delete_form")
 
     if form.validate_on_submit():
         # validate made sure form.name.data exists.
@@ -780,12 +763,7 @@ def webauthn_verify() -> "ResponseValue":
     will have filled in ?next=xxx - which we want to carefully not lose as we
     go through these steps.
     """
-    form_class = _security.wan_verify_form
-
-    form_data = None
-    if request.content_length:
-        form_data = MultiDict(request.get_json()) if request.is_json else request.form
-    form = form_class(formdata=form_data, meta=suppress_form_csrf())
+    form = build_form_from_request("wan_verify_form")
 
     if form.validate_on_submit():
         o_json, state_token = _signin_common(form.user, cv("WAN_ALLOW_AS_VERIFY"))
@@ -796,7 +774,7 @@ def webauthn_verify() -> "ResponseValue":
         return _security.render_template(
             cv("WAN_VERIFY_TEMPLATE"),
             wan_verify_form=form,
-            wan_signin_response_form=WebAuthnSigninResponseForm(formdata=None),
+            wan_signin_response_form=build_form("wan_signin_response_form"),
             wan_state=state_token,
             credential_options=json.dumps(o_json),
             **_security._run_ctx_processor("wan_verify")
@@ -807,7 +785,7 @@ def webauthn_verify() -> "ResponseValue":
     return _security.render_template(
         cv("WAN_VERIFY_TEMPLATE"),
         wan_verify_form=form,
-        wan_signin_response_form=WebAuthnSigninResponseForm(formdata=None),
+        wan_signin_response_form=build_form("wan_signin_response_form"),
         skip_login_menu=True,
         response_to=get_url(
             cv("WAN_VERIFY_URL"),
@@ -819,11 +797,7 @@ def webauthn_verify() -> "ResponseValue":
 
 @auth_required(lambda: cv("API_ENABLED_METHODS"))
 def webauthn_verify_response(token: str) -> "ResponseValue":
-    form_class = _security.wan_signin_response_form
-    form_data = None
-    if request.content_length:
-        form_data = MultiDict(request.get_json()) if request.is_json else request.form
-    form = form_class(formdata=form_data, meta=suppress_form_csrf())
+    form = build_form_from_request("wan_signin_response_form")
 
     expired, invalid, state = check_and_get_token_status(
         token, "wan", get_within_delta("WAN_SIGNIN_WITHIN")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -275,12 +275,9 @@ def app(request: pytest.FixtureRequest) -> "SecurityFixture":
     def revert_forms():
         # Some forms/tests have dynamic fields - be sure to revert them.
         if hasattr(app, "security"):
-            if hasattr(app.security.login_form, "username"):
-                del app.security.login_form.username
-            if hasattr(app.security.register_form, "username"):
-                del app.security.register_form.username
-            if hasattr(app.security.confirm_register_form, "username"):
-                del app.security.confirm_register_form.username
+            for form_name in ["login_form", "register_form", "confirm_register_form"]:
+                if hasattr(app.security.forms[form_name].cls, "username"):
+                    del app.security.forms[form_name].cls.username
 
     request.addfinalizer(revert_forms)
     return app

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -208,8 +208,8 @@ def test_init_app_kwargs_override_constructor_kwargs(app, datastore):
     )
     security.init_app(app, login_form=InitLoginForm)
 
-    assert security.login_form == InitLoginForm
-    assert security.register_form == ConRegisterForm
+    assert security.forms["login_form"].cls == InitLoginForm
+    assert security.forms["register_form"].cls == ConRegisterForm
 
 
 def test_create_user_with_roles_and_permissions(app, datastore):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -75,6 +75,15 @@ def json_logout(client, token, endpoint=None):
     )
 
 
+def get_csrf_token(client):
+    response = client.get(
+        "/login",
+        data={},
+        headers={"Accept": "application/json"},
+    )
+    return response.json["response"]["csrf_token"]
+
+
 def get_session(response):
     """Return session cookie contents.
     This a base64 encoded json.


### PR DESCRIPTION
Allow for applications to set their own form instantiation callback. This allows an application to have complete control over the methods and services that validation (and instantiation) requires.

This also de-couples form classes from Flask-Security views - the default classes can be completely re-defined (although of course the views require certain attributes!).

The unit tests show 2 possible patterns - an application form factory and a self-cloning form.

NOTE: not complete yet - not all forms have been converted... proof-of-concept only.