### PR TITLE
Pass full context to MailUtil

### DIFF
--- a/flask_security/mail_util.py
+++ b/flask_security/mail_util.py
@@ -50,7 +50,6 @@ class MailUtil:
         sender: t.Union[str, tuple],
         body: str,
         html: t.Optional[str],
-        user: "User",
         **kwargs: t.Any,
     ) -> None:
         """Send an email via the Flask-Mailman or Flask-Mail or other mail extension.
@@ -62,7 +61,7 @@ class MailUtil:
         :param sender: who to send email as (see :py:data:`SECURITY_EMAIL_SENDER`)
         :param body: the rendered body (text)
         :param html: the rendered body (html)
-        :param user: the user model
+        :param kwargs: keyword arguments including the User model, confirmation link, reset password link, etc.
 
         It is possible that sender is a lazy_string for localization (unlikely but..)
         so we cast to str() here to force localization.

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -699,7 +699,7 @@ def send_mail(subject, recipient, template, **context):
         sender = sender._get_current_object()
 
     _security._mail_util.send_mail(
-        template, subject, recipient, sender, body, html, context.get("user", None)
+        template, subject, recipient, sender, body, html, **context
     )
 
 


### PR DESCRIPTION
Pass full context kwargs to MailUtil when sending emails. This enables applications to be more flexible with email sending in a custom MailUtil (for example, passing the confirmation link to the Postmark or SendGrid API for use as a variable in their email templates).

Closes #689