### PR TITLE
Fix issues with properly propagating ?next parameter across multipl…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.2.0
+    rev: v3.2.2
     hooks:
     -   id: pyupgrade
         args: [--py37-plus]
@@ -22,8 +22,8 @@ repos:
     rev: 22.10.0
     hooks:
     -   id: black
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+-   repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         additional_dependencies:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,11 @@ Fixes
 
 - (:pr:`678`) Fixes for Flask-SQLAlchemy 3.0.0. (jrast)
 - (:pr:`680`) Fixes for sqlalchemy 2.0.0 (jrast)
+- (:issue:`697`) Webauthn and Unified signin features now properly take into
+  account blueprint prefixes.
+- (:issue:`699`) Properly propagate `?next=/xx` - the verify, webauthn, and unified
+  signin endpoints, that had multiple redirects, needed fixes.
+- (:pr:`696`) Add Hungarian translations (xQwexx)
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -337,7 +337,7 @@ sends the following signals.
 .. data:: tf_security_token_sent
 
     Sent when a two factor security/access code is sent. In addition to the app
-    (which is the sender), it is passed `user`, `method`, and `token` arguments.
+    (which is the sender), it is passed `user`, `method`, `login_token` and `token` (deprecated) arguments.
 
     .. versionadded:: 3.3.0
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -679,6 +679,7 @@ Login/Logout
 
     Specifies the default view to redirect to after a user logs in. This value can be set to a URL
     or an endpoint name. Defaults to the Flask config ``APPLICATION_ROOT`` value which itself defaults to ``"/"``.
+    Note that if the request URL or form has a ``next`` parameter, that will take precedence.
 
     Default: ``APPLICATION_ROOT``.
 
@@ -686,6 +687,7 @@ Login/Logout
 
     Specifies the default view to redirect to after a user logs out. This value can be set to a URL
     or an endpoint name. Defaults to the Flask config ``APPLICATION_ROOT`` value which itself defaults to ``"/"``.
+    Note that if the request URL or form has a ``next`` parameter, that will take precedence.
 
     Default: ``APPLICATION_ROOT``.
 
@@ -761,6 +763,7 @@ Registerable
     Specifies the view to redirect to after a user successfully registers.
     This value can be set to a URL or an endpoint name. If this value is
     ``None``, the user is redirected to the value of ``SECURITY_POST_LOGIN_VIEW``.
+    Note that if the request URL or form has a ``next`` parameter, that will take precedence.
 
     Default: ``None``.
 .. py:data:: SECURITY_REGISTER_URL
@@ -1240,7 +1243,7 @@ Unified Signin
     Specifies the view to redirect to after a user successfully setups an authentication method (non-json).
     This value can be set to a URL or an endpoint name.
 
-    Default: ``"/us-setup"``
+    Default: ``.us-setup"``
 
 .. py:data:: SECURITY_US_SIGNIN_TEMPLATE
 
@@ -1413,7 +1416,7 @@ WebAuthn
     Specifies the view to redirect to after a user successfully registers a new WebAuthn key (non-json).
     This value can be set to a URL or an endpoint name.
 
-    Default: ``"/wan-register"``
+    Default: ``".wan-register"``
 
 .. py:data:: SECURITY_WAN_REGISTER_TEMPLATE
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -299,7 +299,7 @@ _default_config: t.Dict[str, t.Any] = {
     "US_VERIFY_URL": "/us-verify",
     "US_VERIFY_SEND_CODE_URL": "/us-verify/send-code",
     "US_VERIFY_LINK_URL": "/us-verify-link",
-    "US_POST_SETUP_VIEW": "/us-setup",
+    "US_POST_SETUP_VIEW": ".us_setup",  # endpoint or URL
     "US_SIGNIN_TEMPLATE": "security/us_signin.html",
     "US_SETUP_TEMPLATE": "security/us_setup.html",
     "US_VERIFY_TEMPLATE": "security/us_verify.html",
@@ -329,7 +329,7 @@ _default_config: t.Dict[str, t.Any] = {
     "USERNAME_NORMALIZE_FORM": "NFKD",
     "WEBAUTHN": False,
     "WAN_CHALLENGE_BYTES": None,  # uses system default
-    "WAN_POST_REGISTER_VIEW": "/wan-register",
+    "WAN_POST_REGISTER_VIEW": ".wan_register",  # endpoint or URL
     "WAN_RP_NAME": "My Flask App",
     "WAN_SALT": "wan-salt",
     "WAN_REGISTER_TIMEOUT": 60000,  # milliseconds

--- a/flask_security/templates/security/_macros.html
+++ b/flask_security/templates/security/_macros.html
@@ -39,3 +39,7 @@
     </div>
   {% endif %}
 {% endmacro %}
+
+{% macro prop_next() -%}
+  {% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}
+{%- endmacro %}

--- a/flask_security/templates/security/login_user.html
+++ b/flask_security/templates/security/login_user.html
@@ -1,10 +1,10 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors, prop_next %}
 
 {% block content %}
 {% include "security/_messages.html" %}
 <h1>{{ _fsdomain('Login') }}</h1>
-  <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
+  <form action="{{ url_for_security('login') }}{{ prop_next() }}" method="POST" name="login_user_form">
     {{ login_user_form.hidden_tag() }}
     {{ render_form_errors(login_user_form) }}
     {% if "email" in identity_attributes %}
@@ -28,7 +28,7 @@
     <div>
       <form method="GET" id="wan-signin-form" name="wan_signin_form">
         <input id="wan_signin" name="wan_signin" type="submit" value="{{ _fsdomain('Sign in with WebAuthn') }}"
-          formaction="{{ url_for_security("wan_signin") }}">
+          formaction="{{ url_for_security("wan_signin") }}{{ prop_next() }}">
       </form>
     </div>
   {% endif %}

--- a/flask_security/templates/security/two_factor_verify_code.html
+++ b/flask_security/templates/security/two_factor_verify_code.html
@@ -1,18 +1,18 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, prop_next %}
 
 {% block content %}
     {% include "security/_messages.html" %}
     <h1>{{ _fsdomain("Two-factor Authentication") }}</h1>
     <h2>{{ _fsdomain("Please enter your authentication code generated via: %(method)s", method=chosen_method) }}</h2>
-    <form action="{{ url_for_security("two_factor_token_validation") }}" method="POST"
+    <form action="{{ url_for_security("two_factor_token_validation") }}{{ prop_next() }}" method="POST"
           name="two_factor_verify_code_form">
         {{ two_factor_verify_code_form.hidden_tag() }}
         {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder="enter code") }}
         {{ render_field(two_factor_verify_code_form.submit) }}
     </form>
     <hr class="fs-gap">
-    <form action="{{ url_for_security("two_factor_rescue") }}" method="POST" name="two_factor_rescue_form">
+    <form action="{{ url_for_security("two_factor_rescue") }}{{  prop_next() }}" method="POST" name="two_factor_rescue_form">
         {{ two_factor_rescue_form.hidden_tag() }}
         {{ render_field_with_errors(two_factor_rescue_form.help_setup) }}
         {% if problem=="email" %}

--- a/flask_security/templates/security/us_signin.html
+++ b/flask_security/templates/security/us_signin.html
@@ -1,10 +1,10 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors, prop_next %}
 
 {% block content %}
     {% include "security/_messages.html" %}
     <h1>{{ _fsdomain("Sign In") }}</h1>
-      <form action="{{ url_for_security("us_signin") }}" method="POST"
+      <form action="{{ url_for_security("us_signin") }}{{ prop_next() }}" method="POST"
           name="us_signin_form">
       {{ us_signin_form.hidden_tag() }}
       {{ render_form_errors(us_signin_form) }}
@@ -29,7 +29,7 @@
     <div>
       <form method="GET" id="wan-signin-form" name="wan_signin_form">
         <input id="wan_signin" name="wan_signin" type="submit" value="{{ _fsdomain('Sign in with WebAuthn') }}"
-          formaction="{{ url_for_security("wan_signin") }}">
+          formaction="{{ url_for_security("wan_signin") }}{{ prop_next() }}">
       </form>
     </div>
   {% endif %}

--- a/flask_security/templates/security/us_verify.html
+++ b/flask_security/templates/security/us_verify.html
@@ -1,10 +1,10 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, prop_next %}
 
 {% block content %}
     {% include "security/_messages.html" %}
     <h1>{{ _fsdomain("Please Reauthenticate") }}</h1>
-      <form action="{{ url_for_security("us_verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
+      <form action="{{ url_for_security("us_verify") }}{{ prop_next() }}" method="POST"
           name="us_verify_form">
       {{ us_verify_form.hidden_tag() }}
       {{ render_field_with_errors(us_verify_form.passcode) }}
@@ -20,13 +20,13 @@
         {% if code_sent %}
           <p>{{ _fsdomain("Code has been sent") }}
         {% endif %}
-        <div class="fs-gap">{{ render_field(us_verify_form.submit_send_code, formaction=send_code_to) }}</div>
+        <div class="fs-gap">{{ render_field(us_verify_form.submit_send_code, formaction=url_for_security("us_verify_send_code")~prop_next()) }}</div>
       {% endif %}
       </form>
       {% if has_webauthn_verify_credential %}
         <hr class="fs-gap">
         <h2>{{ _fsdomain("Use a WebAuthn Security Key to Reauthenticate") }}</h2>
-        <form action="{{ url_for_security("wan_verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
+        <form action="{{ url_for_security("wan_verify") }}{{ prop_next() }}" method="POST"
           name="wan_verify_form">
             {{ wan_verify_form.hidden_tag() }}
             {{ render_field(wan_verify_form.submit) }}

--- a/flask_security/templates/security/verify.html
+++ b/flask_security/templates/security/verify.html
@@ -1,10 +1,10 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, prop_next %}
 
 {% block content %}
     {% include "security/_messages.html" %}
     <h1>{{ _fsdomain("Please Reauthenticate") }}</h1>
-    <form action="{{ url_for_security("verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
+    <form action="{{ url_for_security("verify") }}{{ prop_next() }}" method="POST"
           name="verify_form">
         {{ verify_form.hidden_tag() }}
         {{ render_field_with_errors(verify_form.password) }}
@@ -13,7 +13,7 @@
    {% if has_webauthn_verify_credential %}
       <hr class="fs-gap">
       <h2>Use a WebAuthn Security Key to Reauthenticate</h2>
-      <form action="{{ url_for_security("wan_verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
+      <form action="{{ url_for_security("wan_verify") }}{{ prop_next() }}" method="POST"
         name="wan_verify_form">
           {{ wan_verify_form.hidden_tag() }}
           {{ render_field(wan_verify_form.submit) }}

--- a/flask_security/templates/security/wan_signin.html
+++ b/flask_security/templates/security/wan_signin.html
@@ -3,7 +3,7 @@
 #}
 
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, prop_next %}
 
 {% block head_scripts %}
   {{ super() }}
@@ -20,7 +20,7 @@
     <h1>{{ _fsdomain("Use Your WebAuthn Security Key as a Second Factor") }}</h1>
   {% endif %}
   {% if not credential_options %}
-    <form action="{{ url_for_security("wan_signin") }}" method="POST"
+    <form action="{{ url_for_security("wan_signin") }}{{ prop_next() }}" method="POST"
           name="wan_signin_form" id="wan-signin-form">
       {{ wan_signin_form.hidden_tag() }}
       {% if not is_secondary %}
@@ -31,7 +31,7 @@
       {{ render_field(wan_signin_form.submit) }}
     </form>
   {% else %}
-    <form action="{{ url_for_security("wan_signin_response", token=wan_state) }}" method="POST"
+    <form action="{{ url_for_security("wan_signin_response", token=wan_state) }}{{ prop_next() }}" method="POST"
           name="wan_signin_response_form" id="wan-signin-response-form">
       {{ wan_signin_response_form.hidden_tag() }}
       {{ render_field_errors(wan_signin_form.remember) }}

--- a/flask_security/templates/security/wan_verify.html
+++ b/flask_security/templates/security/wan_verify.html
@@ -1,5 +1,14 @@
+{#
+  This template receives the following pieces of context in addition to the form:
+
+  wan_verify_form -
+  wan_signin_response_form -
+  skip_login_menu - True
+  Any other context provided by the "wan_verify" context processer.
+#}
+
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, prop_next %}
 
 {% block head_scripts %}
   {{ super() }}
@@ -12,13 +21,13 @@
   {% include "security/_messages.html" %}
   <h1>{{ _fsdomain("Please Re-Authenticate Using Your WebAuthn Security Key") }}</h1>
   {% if not credential_options %}
-    <form action="{{ url_for_security("wan_verify") }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
+    <form action="{{ url_for_security("wan_verify") }}{{ prop_next() }}" method="POST"
           name="wan_verify_form">
         {{ wan_verify_form.hidden_tag() }}
         {{ render_field(wan_verify_form.submit) }}
     </form>
   {% else %}
-    <form action="{{ url_for_security("wan_verify_response", token=wan_state) }}{% if 'next' in request.args %}?next={{ request.args.next|urlencode }}{% endif %}" method="POST"
+    <form action="{{ url_for_security("wan_verify_response", token=wan_state) }}{{ prop_next() }}" method="POST"
           name="wan_signin_response_form" id="wan-signin-response-form">
       {{ wan_signin_response_form.hidden_tag() }}
       <div id="wan-errors"></div>

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -21,6 +21,7 @@ from .utils import (
     config_value as cv,
     do_flash,
     json_error_response,
+    propagate_next,
     send_mail,
     url_for_security,
 )
@@ -79,6 +80,7 @@ def tf_send_security_token(user, method, totp_secret, phone_number):
         user=user,
         method=method,
         token=token_to_be_sent,
+        login_token=token_to_be_sent,
         phone_number=phone_number,
     )
 
@@ -202,7 +204,11 @@ class CodeTfPlugin(TfPluginBase):
                         return _security._render_json(payload, 500, None, None)
 
             if not _security._want_json(request):
-                return redirect(url_for_security("two_factor_token_validation"))
+                return redirect(
+                    url_for_security(
+                        "two_factor_token_validation", next=propagate_next(request.url)
+                    )
+                )
 
         # JSON response - Fake up a form - doesn't really matter which.
         form = DummyForm(formdata=None)

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -79,7 +79,6 @@ from .utils import (
     json_error_response,
     login_user,
     lookup_identity,
-    propagate_next,
     send_mail,
     url_for_security,
     view_commit,
@@ -510,10 +509,6 @@ def us_verify_send_code() -> "ResponseValue":
             code_methods=code_methods,
             chosen_method=form.chosen_method.data,
             skip_login_menu=True,
-            send_code_to=get_url(
-                _security.us_verify_send_code_url,
-                qparams={"next": propagate_next(request.url)},
-            ),
             **_security._run_ctx_processor("us_verify")
         )
 
@@ -527,10 +522,6 @@ def us_verify_send_code() -> "ResponseValue":
         available_methods=cv("US_ENABLED_METHODS"),
         code_methods=code_methods,
         skip_login_menu=True,
-        send_code_to=get_url(
-            _security.us_verify_send_code_url,
-            qparams={"next": propagate_next(request.url)},
-        ),
         **_security._run_ctx_processor("us_verify")
     )
 
@@ -670,10 +661,6 @@ def us_verify() -> "ResponseValue":
         us_verify_form=form,
         code_methods=code_methods,
         skip_login_menu=True,
-        send_code_to=get_url(
-            cv("US_VERIFY_SEND_CODE_URL"),
-            qparams={"next": propagate_next(request.url)},
-        ),
         has_webauthn_verify_credential=webauthn_available,
         wan_verify_form=build_form("wan_verify_form"),
         **_security._run_ctx_processor("us_verify")

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -95,7 +95,6 @@ from .utils import (
     get_within_delta,
     login_user,
     lookup_identity,
-    propagate_next,
     simple_render_json,
     url_for_security,
     view_commit,
@@ -787,10 +786,6 @@ def webauthn_verify() -> "ResponseValue":
         wan_verify_form=form,
         wan_signin_response_form=build_form("wan_signin_response_form"),
         skip_login_menu=True,
-        response_to=get_url(
-            cv("WAN_VERIFY_URL"),
-            qparams={"next": propagate_next(request.url)},
-        ),
         **_security._run_ctx_processor("wan_verify")
     )
 

--- a/requirements_low/tests.txt
+++ b/requirements_low/tests.txt
@@ -14,10 +14,12 @@ python-dateutil==2.8.2
 jinja2==3.0.0
 itsdangerous==2.0.0
 markupsafe==2.0.1
-mongoengine==0.22.1
+mongoengine==0.23.1
 mongomock==3.22.0
 pony==0.7.14;python_version<'3.10'
 phonenumberslite==8.11.1
+# issue with pyopenssl requiring very new cryptography
+pyopenssl==22.0.0
 qrcode==7.3.1
 sqlalchemy==1.4.15
 sqlalchemy-utils==0.37.4

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -21,6 +21,7 @@ from flask_security import uia_email_mapper
 from tests.test_utils import (
     authenticate,
     get_auth_token_version_3x,
+    get_form_action,
     get_num_queries,
     hash_password,
     json_authenticate,
@@ -72,6 +73,19 @@ def test_authenticate_with_invalid_malformed_next(client, get_message):
     data = dict(email="matt@lp.com", password="password")
     response = client.post("/login?next=http:///google.com", data=data)
     assert get_message("INVALID_REDIRECT") in response.data
+
+
+def test_login_template_next(client):
+    # Test that our login template propagates next.
+    response = client.get("/profile", follow_redirects=True)
+    assert "?next=%2Fprofile" in response.request.url
+    login_url = get_form_action(response)
+    response = client.post(
+        login_url,
+        data=dict(email="matt@lp.com", password="password"),
+        follow_redirects=True,
+    )
+    assert b"Profile Page" in response.data
 
 
 def test_authenticate_with_subdomain_next(app, client, get_message):

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -25,6 +25,7 @@ from tests.test_utils import (
     authenticate,
     capture_flashes,
     capture_reset_password_requests,
+    get_form_action,
     logout,
     reset_fresh,
 )
@@ -747,12 +748,8 @@ def test_setup(app, client, get_message):
     assert response.status_code == 200
     assert b"Submit Code" in response.data
     assert b"Enter code here to complete setup" in response.data
-    matcher = re.match(
-        r'.*<form action="([^\s]*)".*',
-        response.data.decode("utf-8"),
-        re.IGNORECASE | re.DOTALL,
-    )
-    verify_url = matcher.group(1)
+
+    verify_url = get_form_action(response, 1)
 
     # Try invalid code
     response = client.post(verify_url, data=dict(passcode=12345), follow_redirects=True)
@@ -774,12 +771,7 @@ def test_setup_email(app, client, get_message):
     assert b"Enter code here to complete setup" in response.data
     outbox = app.mail.outbox
 
-    matcher = re.match(
-        r'.*<form action="([^\s]*)".*',
-        response.data.decode("utf-8"),
-        re.IGNORECASE | re.DOTALL,
-    )
-    verify_url = matcher.group(1)
+    verify_url = get_form_action(response, 1)
 
     # verify no magic link - us_authenticate received first email - we want the second
     matcher = re.findall(r"\w+:.*", outbox[1].body, re.IGNORECASE)
@@ -1005,10 +997,7 @@ def test_verify(app, client, get_message):
     response = client.get("us-setup", follow_redirects=True)
     form_response = response.data.decode("utf-8")
     assert "Please Reauthenticate" in form_response
-    matcher = re.match(
-        r'.*formaction="([^"]*)".*', form_response, re.IGNORECASE | re.DOTALL
-    )
-    send_code_url = matcher.group(1)
+    send_code_url = get_form_action(response, 1)
 
     # Send unknown method
     response = client.post(
@@ -1237,12 +1226,7 @@ def test_qrcode(app, client, get_message):
     code = totp.generate().token
 
     # get verify link e.g. /us-setup/{state}
-    matcher = re.match(
-        r'.*<form action="([^\s]*)".*',
-        response.data.decode("utf-8"),
-        re.IGNORECASE | re.DOTALL,
-    )
-    verify_url = matcher.group(1)
+    verify_url = get_form_action(response, 1)
 
     response = client.post(verify_url, data=dict(passcode=code), follow_redirects=True)
     assert response.status_code == 200
@@ -1581,12 +1565,7 @@ def test_tf_not(app, client, get_message):
     response = client.post(
         "us-setup", data=dict(chosen_method="sms", phone="650-555-1212")
     )
-    matcher = re.match(
-        r'.*<form action="([^\s]*)".*',
-        response.data.decode("utf-8"),
-        re.IGNORECASE | re.DOTALL,
-    )
-    verify_url = matcher.group(1)
+    verify_url = get_form_action(response, 1)
     code = sms_sender.messages[0].split()[-1].strip(".")
     response = client.post(verify_url, data=dict(passcode=code), follow_redirects=True)
     assert response.status_code == 200
@@ -2117,3 +2096,21 @@ def test_generic_response(app, client, get_message):
         "us-verify-link?email=matt@lp.com&code=12345", follow_redirects=True
     )
     assert get_message("GENERIC_AUTHN_FAILED") in response.data
+
+
+@pytest.mark.settings(url_prefix="/auth", us_signin_replaces_login=True)
+def test_propagate_next(app, client):
+    # verify we propagate the ?next param all the way through a unified signin
+    # Also test blueprint prefix since we rarely actually test that.
+    set_phone(app)
+    with capture_send_code_requests() as codes:
+        response = client.get("profile", follow_redirects=True)
+        assert "?next=%2Fprofile" in response.request.url
+        signin_url = get_form_action(response, 0)
+        sendcode_url = get_form_action(response, 1)
+        response = client.post(
+            sendcode_url, data=dict(identity="matt@lp.com", chosen_method="sms")
+        )
+        data = dict(identity="matt@lp.com", passcode=codes[0]["login_token"])
+        response = client.post(signin_url, data=data, follow_redirects=False)
+        assert "/profile" in response.location

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -110,6 +110,7 @@ def create_app():
     app.config["SECURITY_PASSWORD_REQUIRED"] = True
     app.config["SECURITY_MULTI_FACTOR_RECOVERY_CODES"] = True
     app.config["SECURITY_RETURN_GENERIC_RESPONSES"] = True
+    # app.config["SECURITY_URL_PREFIX"] = "/fs"
 
     class TestWebauthnUtil(WebauthnUtil):
         def generate_challenge(self, nbytes: t.Optional[int] = None) -> str:


### PR DESCRIPTION
…e redirects.

This affected verify, us_verify, webauthn, us_signin, and login.

Added a template macro (prop_next()) for easy re-use across templates.

Removed send_code_to from us_verify template and use url_for_security() in template - this fixes issue with blueprint prefixes. Removed response_to from wan_verify template (not used). Fix default US_POST_SETUP_VIEW and WAN_POST_REGISTER_VIEW - they need to be endpoints (.wan_register) not URLS (/wan-register) so that blueprint prefixes work.

closes #699
Closes #697