### PR TITLE
Enable menu if two factor or webauthn is enabled

### DIFF
--- a/flask_security/templates/security/_menu.html
+++ b/flask_security/templates/security/_menu.html
@@ -1,4 +1,4 @@
-{% if security.registerable or security.recoverable or security.confirmable or security.unified_signin %}
+{% if security.registerable or security.recoverable or security.confirmable or security.unified_signin or security.two_factor or security.webauthn %}
 <hr>
 <h2>{{ _fsdomain('Menu') }}</h2>
 <ul>


### PR DESCRIPTION
The menu shows links for both features so makes sense to show the menu if the settings are enabled.