### PR TITLE
Fix validation with USERNAME_ENABLE and USERNAME_REQUIRED

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Features
 - (:issue:`667`) Expose form instantiation. See :ref:`form_instantiation`.
 - (:issue:`693`) Option to encrypt recovery codes at rest.
 - (:pr:`716`) Support for authentication via 'social' oauth.
+- (:pr:`721`) Support for Python 3.11
 
 Fixes
 +++++
@@ -35,8 +36,11 @@ Fixes
 - (:pr:`728`) Support for Flask-Babel 3.0.0
 - (:issue:`692`) Add configuration option `SECURITY_TWO_FACTOR_POST_SETUP_VIEW` which
   is redirected to upon successful change of a two factor method.
-- (:pr:`xxx`) The ability to pass in a LoginManager instance which was deprecated in
+- (:pr:`733`) The ability to pass in a LoginManager instance which was deprecated in
   5.0 has been removed.
+- (:issue:`732`) If `SECURITY_USERNAME_REQUIRED` was ``True`` then users couldn't login
+  with just an email.
+- (:issue:`734`) If `SECURITY_USERNAME_ENABLE` is set, bleach is a requirement.
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -803,7 +803,7 @@ Registerable
     Validation and normalization is encapsulated in :class:`.UsernameUtil`.
     Note that the default validation restricts username input to be unicode
     letters and numbers. It also uses ``bleach`` to scrub any risky input. Be
-    sure your application requirements includes ``bleach``.
+    sure your application requirements includes `bleach`_.
 
     Default: ``False``
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -195,9 +195,11 @@ In this example we are injecting an external `service` into the form for use in 
 
 Customizing the Login Form
 ++++++++++++++++++++++++++
-This is an example of how to modify the registration and login form to add a username
-attribute (mimicking legacy Flask-Security behavior). Note that Flask-Security now has
-built-in support for username so this is unnecessary::
+This is an example of how to modify the registration and login form to add support for
+a single input field to accept both email and username (mimicking legacy Flask-Security behavior).
+Flask-Security supports username as a configuration option so this is not strictly needed
+any more, however, Flask-Security's LoginForm uses 2 different input fields (so that
+appropriate input attributes can be set)::
 
     from flask_security import (
             RegisterForm,

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -50,8 +50,8 @@ from .forms import (
     TwoFactorSetupForm,
     TwoFactorRescueForm,
     VerifyForm,
+    get_register_username_field,
     login_username_field,
-    register_username_field,
 )
 from .json import setup_json
 from .mail_util import MailUtil
@@ -1502,10 +1502,10 @@ class Security:
             # Add dynamic fields - probably overkill to check if these are our forms.
             fcls = self.forms["register_form"].cls
             if fcls and issubclass(fcls, RegisterFormMixin):
-                fcls.username = register_username_field
+                fcls.username = get_register_username_field(app)
             fcls = self.forms["confirm_register_form"].cls
             if fcls and issubclass(fcls, RegisterFormMixin):
-                fcls.username = register_username_field
+                fcls.username = get_register_username_field(app)
             fcls = self.forms["login_form"].cls
             if fcls and issubclass(fcls, LoginForm):
                 fcls.username = login_username_field
@@ -1616,6 +1616,9 @@ class Security:
 
         if cv("WEBAUTHN", app=app):
             self._check_modules("webauthn", "WEBAUTHN")
+
+        if cv("USERNAME_ENABLE", app=app):
+            self._check_modules("bleach", "USERNAME_ENABLE")
 
         # Register so other packages can reference our translations.
         app.jinja_env.globals["_fsdomain"] = self.i18n_domain.gettext

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -349,11 +349,21 @@ class CodeFormMixin:
     )
 
 
-register_username_field = StringField(
-    get_form_field_label("username"),
-    render_kw={"autocomplete": "username"},
-    validators=[username_validator, unique_username],
-)
+def get_register_username_field(app):
+    if cv("USERNAME_REQUIRED", app=app):
+        validators = [
+            Required(message="USERNAME_NOT_PROVIDED"),
+            username_validator,
+            unique_username,
+        ]
+    else:
+        validators = [username_validator, unique_username]
+    return StringField(
+        get_form_field_label("username"),
+        render_kw={"autocomplete": "username"},
+        validators=validators,
+    )
+
 
 login_username_field = StringField(
     get_form_field_label("username"),

--- a/flask_security/username_util.py
+++ b/flask_security/username_util.py
@@ -87,9 +87,6 @@ class UsernameUtil:
         import bleach
 
         if not username:
-            # Allow empty username unless specifically required.
-            if cv("USERNAME_REQUIRED"):
-                return get_message("USERNAME_NOT_PROVIDED")[0], None
             return None, None
         uclean = bleach.clean(username.strip(), strip=True)
         if uclean != username:

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -180,6 +180,16 @@ def test_login_form_username(client):
     assert re.search(b'<input[^>]*autocomplete="current-password"[^>]*>', response.data)
 
 
+@pytest.mark.settings(username_enable=True, username_required=True)
+def test_login_form_username_required(client):
+    # If username required - we should still be able to login with email alone
+    # given default user_identity_attributes
+    response = client.post(
+        "/login", data=dict(email="matt@lp.com", password="password")
+    )
+    assert response.location == "/"
+
+
 @pytest.mark.confirmable()
 @pytest.mark.settings(
     return_generic_responses=True, requires_confirmation_error_view="/confirm"

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -103,9 +103,9 @@ def create_app():
     app.config["SECURITY_FRESHNESS"] = datetime.timedelta(minutes=1)
     app.config["SECURITY_FRESHNESS_GRACE_PERIOD"] = datetime.timedelta(minutes=2)
     app.config["SECURITY_USERNAME_ENABLE"] = True
+    app.config["SECURITY_USERNAME_REQUIRED"] = True
     app.config["SECURITY_PASSWORD_REQUIRED"] = True
-    app.config["SECURITY_MULTI_FACTOR_RECOVERY_CODES"] = True
-    app.config["SECURITY_RETURN_GENERIC_RESPONSES"] = True
+    app.config["SECURITY_RETURN_GENERIC_RESPONSES"] = False
     # enable oauth - note that this assumes that app is passes XXX_CLIENT_ID and
     # XXX_CLIENT_SECRET as environment variables.
     app.config["SECURITY_OAUTH_ENABLE"] = True
@@ -136,6 +136,7 @@ def create_app():
         "two_factor",
         "unified_signin",
         "webauthn",
+        "multi_factor_recovery_codes",
     ]:
         app.config["SECURITY_" + opt.upper()] = True
 


### PR DESCRIPTION
If USERNAME_REQUIRED was set, Login would fail validation even if email was valid and accepted. Fixed by moving the check for whether username is required or not out of usernam_util::validate and up into the form(s) themselves. In fact only RegisterForm needs the data required form validator.

Updated documentation around building a form that has a single input for both email and username.

Added init time check for bleach being installed if USERNAME_ENABLE is set.

Thanks @hrishikeshrt for the issue and troubleshooting help.

closes #734
closes #732