### PR TITLE
Fix multi-app and USERNAME_ENABLE

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,20 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 5.1.1
+-------------
+
+Released TBD
+
+Fixes
++++++
+
+- (:issue:`740`) Fix 2 Flask apps in same thread with USERNAME_ENABLE set.
+  There was a too aggressive config check.
+- (:pr:`739`) Update Russian translations. (ademaro)
+- (:pr:`743`) Run all templates through a linter. (ademaro)
+- (:pr:`744`) Errors with SQLAlchemy 2.0 (sqlalchemy-utils isn't ready).
+
 Version 5.1.0
 -------------
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1470,20 +1470,6 @@ class Security:
                     "User model must contain 'username' if"
                     " SECURITY_USERNAME_ENABLE is True"
                 )
-            # if they want USERNAME_ENABLE - then they better not have defined
-            # username in their own forms
-            if any(
-                hasattr(self.forms[f].cls, "username")
-                for f in [
-                    "register_form",
-                    "confirm_register_form",
-                    "login_form",
-                ]
-            ):  # pragma: no cover
-                raise ValueError(
-                    "Your login_form or register_form has a"
-                    " 'username' attribute already"
-                )
             # if not already listed in user identity attributes, add it at the end
             uialist = []
             for uia in cv("USER_IDENTITY_ATTRIBUTES", app=app):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,7 +5,7 @@
     Lots of tests
 
     :copyright: (c) 2012 by Matt Wright.
-    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -1387,3 +1387,32 @@ def test_static_url(app, sqlalchemy_datastore):
 
         static_url = url_for(".static", filename="js/webauthn.js")
         assert static_url == "/mystatic/fs/js/webauthn.js"
+
+
+def test_multi_app(app, sqlalchemy_datastore):
+    # test that 2 different app with 2 different FS
+    # with USERNAME_ENABLE which dynamically changes the class definition
+    app = Flask(__name__)
+    app.response_class = Response
+    app.debug = True
+    app.config["SECRET_KEY"] = "secret"
+    app.config["TESTING"] = True
+    app.config["SECURITY_USERNAME_ENABLE"] = True
+
+    security = Security(datastore=sqlalchemy_datastore)
+    security.init_app(app)
+    assert hasattr(security.forms["register_form"].cls, "username")
+    assert "username" in security.user_identity_attributes[1].keys()
+
+    app = Flask(__name__)
+    app.response_class = Response
+    app.debug = True
+    app.config["SECRET_KEY"] = "secret"
+    app.config["TESTING"] = True
+    app.config["SECURITY_USERNAME_ENABLE"] = True
+
+    security2 = Security(datastore=sqlalchemy_datastore)
+    security2.init_app(app)
+
+    assert hasattr(security2.forms["register_form"].cls, "username")
+    assert "username" in security2.user_identity_attributes[1].keys()


### PR DESCRIPTION
We were checking if the Login/Register form already had a username attribute - if user wants 2 apps and 2 security instances - it would fail.

closes #740