### PR TITLE
Fix json backwards compat hack.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
           - flake8-bugbear
           - flake8-implicit-str-concat
 -   repo: https://github.com/Riverside-Healthcare/djLint
-    rev: v1.19.13
+    rev: v1.19.15
     hooks:
       - id: djlint-jinja
         files: "\\.html"

--- a/flask_security/json.py
+++ b/flask_security/json.py
@@ -52,8 +52,6 @@ def _use_provider(superclass):
 def setup_json(app, bp=None):
     # Called at init_app time.
     if use_json_provider():
-        from flask import __version__
-
         app.json_provider_class = _use_provider(app.json_provider_class)
         app.json = app.json_provider_class(app)
         # a bit if a hack - if a package (e.g. flask-mongoengine) hasn't
@@ -61,9 +59,10 @@ def setup_json(app, bp=None):
         # to this specific version of Flask that happens to use _json_encoder to
         # signal if any app/extension has registered an old style encoder.
         # (app.json_encoder is always set)
-        # (If they do, then Flask 2.2.2 won't use json_provider at all)
+        # (If they do, then Flask 2.2.x won't use json_provider at all)
         # Of course if they do this AFTER we're initialized all bets are off.
-        if __version__ == "2.2.2":
+        version = list(flask_version.split("."))
+        if int(version[0]) == 2 and int(version[1]) == 2:
             if app._json_encoder:
                 app.json_encoder = _use_encoder(app.json_encoder)
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,7 +21,6 @@ filterwarnings =
     ignore:.*Setting 'json_encoder'.*:DeprecationWarning:flask:0
     ignore:.*'JSONEncoder'.*:DeprecationWarning:flask:0
     ignore::DeprecationWarning:mongoengine:
-    ignore:.*The 'sqlalchemy.orm.mapper()' symbol is deprecated.*:DeprecationWarning:sqlalchemy_utils:0
     ignore:.*passwordless feature.*:DeprecationWarning:flask_security:0
     ignore:.*passing settings to bcrypt.*:DeprecationWarning:passlib:0
     ignore:.*'crypt' is deprecated.*:DeprecationWarning:passlib:0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -28,8 +28,7 @@ pytest
 qrcode
 # authlib requires requests
 requests
-# sqlalchemy_utils hasn't caught up with sqlalchemy 2.0
-sqlalchemy<2.0.0
+sqlalchemy
 sqlalchemy-utils
 webauthn>=1.6.0;python_version>='3.8'
 werkzeug


### PR DESCRIPTION
Allow the _json_encoder hack for Flask 2.2.x rather than just 2.2.2.

SQLAlchemy_utils now supports 2.x so allow that in our tests.