### PR TITLE
Fix quickstarts.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,9 @@ Fixes
   There was a too aggressive config check.
 - (:pr:`739`) Update Russian translations. (ademaro)
 - (:pr:`743`) Run all templates through a linter. (ademaro)
-- (:pr:`744`) Errors with SQLAlchemy 2.0 (sqlalchemy-utils isn't ready).
+- (:pr:`757`) Fix json/flask backwards compatibility hack.
+- (:issue:`759`) Fix quickstarts - make sure they run using `flask run`
+- (:pr:`755`) Fix unified signup when two-factor not enabled. (sebdroid)
 
 Version 5.1.0
 -------------

--- a/docs/two_factor_configurations.rst
+++ b/docs/two_factor_configurations.rst
@@ -108,14 +108,15 @@ possible using SQLAlchemy:
     def home():
         return render_template_string("Hello {{ current_user.email }}")
 
-    if __name__ == '__main__':
-        with app.app_context():
-            # Create a user to test with
-            db.create_all()
-            if not app.security.datastore.find_user(email='test@me.com'):
-                app.security.datastore.create_user(email='test@me.com', password='password')
-            db.session.commit()
+    # one time setup
+    with app.app_context():
+        # Create a user to test with
+        db.create_all()
+        if not app.security.datastore.find_user(email='test@me.com'):
+            app.security.datastore.create_user(email='test@me.com', password='password')
+        db.session.commit()
 
+    if __name__ == '__main__':
         app.run()
 
 Adding SMS


### PR DESCRIPTION
When changing from @app.before_first_request which Flask deprecated, the entire DB initial setup was placed in the __main__ block - thus using flask run to start the examples didn't work.

closes #759