### PR TITLE
Declare a dependency on setuptools (for pkg_resources)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ install_requires = [
     "passlib>=1.7.4",
     "blinker>=1.4",
     "wtforms>=3.0.0",  # for form-level errors
+    "setuptools",  # for pkg_resources
 ]
 
 packages = find_packages(exclude=["tests"])


### PR DESCRIPTION
This ensures flask-secutiry-too works when installed into an environment without setuptools (and hence without pkg_resources).

pkg_resources.parse_version is used in flask_security/utils.py.

In the long term, a dependency on packaging might be lighter (as pkg_resources.parse_version uses vendored packaging anyway).