### PR TITLE
Final 5.1.1 changes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Here you can see the full list of changes between each Flask-Security release.
 Version 5.1.1
 -------------
 
-Released TBD
+Released March 1, 2023
 
 Fixes
 +++++
@@ -18,6 +18,7 @@ Fixes
 - (:pr:`757`) Fix json/flask backwards compatibility hack.
 - (:issue:`759`) Fix quickstarts - make sure they run using `flask run`
 - (:pr:`755`) Fix unified signup when two-factor not enabled. (sebdroid)
+- (:pr:`763`) Add dependency on setuptools (pkg_resources). (hroncok)
 
 Version 5.1.0
 -------------

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -6,7 +6,7 @@
     security via Flask-Login, Flask-Principal, Flask-WTF, and passlib.
 
     :copyright: (c) 2012-2019 by Matt Wright.
-    :copyright: (c) 2019-2022 by J. Christopher Wagner.
+    :copyright: (c) 2019-2023 by J. Christopher Wagner.
     :license: MIT, see LICENSE for more details.
 """
 
@@ -81,6 +81,7 @@ from .signals import (
     user_authenticated,
     user_confirmed,
     user_registered,
+    user_not_registered,
     us_security_token_sent,
     us_profile_changed,
     wan_deleted,

--- a/flask_security/json.py
+++ b/flask_security/json.py
@@ -1,18 +1,18 @@
 """
     Flask-Security JSON extensions.
 
-    :copyright: (c) 2022-2022 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2022-2023 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 
     Pieces of this code liberally copied from flask-mongoengine.
 """
 from flask import __version__ as flask_version
+from pkg_resources import parse_version
 
 
 def use_json_provider() -> bool:
     """Split Flask before 2.2.0 and after, to use/not use JSON provider approach."""
-    version = list(flask_version.split("."))
-    return int(version[0]) > 2 or (int(version[0]) == 2 and int(version[1]) > 1)
+    return parse_version(flask_version) >= parse_version("2.2.0")
 
 
 def _use_encoder(superclass):  # pragma: no cover
@@ -61,9 +61,8 @@ def setup_json(app, bp=None):
         # (app.json_encoder is always set)
         # (If they do, then Flask 2.2.x won't use json_provider at all)
         # Of course if they do this AFTER we're initialized all bets are off.
-        version = list(flask_version.split("."))
-        if int(version[0]) == 2 and int(version[1]) == 2:
-            if app._json_encoder:
+        if parse_version(flask_version) >= parse_version("2.2.0"):
+            if getattr(app, "_json_encoder", None):
                 app.json_encoder = _use_encoder(app.json_encoder)
 
     elif bp:  # pragma: no cover


### PR DESCRIPTION
Improve json encoder hack - use getattr in case Flask remove _json_encoder, and use real package version semantic version checking.