### PR TITLE
Remove dependence on pkg_resources (replace with importlib_resources).

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: pyupgrade
         args: [--py37-plus]
 -   repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 23.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
@@ -30,7 +30,7 @@ repos:
           - flake8-bugbear
           - flake8-implicit-str-concat
 -   repo: https://github.com/Riverside-Healthcare/djLint
-    rev: v1.19.16
+    rev: v1.19.17
     hooks:
       - id: djlint-jinja
         files: "\\.html"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,18 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version Next
+------------
+
+Released TBD
+
+Fixes
++++++
+
+- (:issue:`764`) Remove old Werkzeug compatibility check.
+- (:issue:`777`) Compatibility with Quart.
+- (:pr:`xx`) Remove dependence on pkg_resources / setuptools (use importlib_resources package)
+
 Version 5.1.2
 -------------
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -62,9 +62,10 @@ These configuration keys are used globally across all features.
 
     Specifies the directory containing the ``MO`` files used for translations.
     When using flask-babel this can also be a list of directory names - this
-    enables application to override a subset of messages if desired.
+    enables application to override a subset of messages if desired. The
+    default ``builtin`` uses translations shipped with Flask-Security.
 
-    Default: ``[PATH_LIB]/flask_security/translations``.
+    Default: ``builtin``.
 
 .. py:data:: SECURITY_PASSWORD_HASH
 

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -319,7 +319,7 @@ and/or a specific translation). Adding the following to your app::
 
     app.config["SECURITY_MSG_INVALID_PASSWORD"] = ("Password no-worky", "error")
 
-Will change the default message in english.
+will change the default message in english.
 
 .. tip::
     The string messages themselves are a 'key' into the translation .po/.mo files.
@@ -344,7 +344,7 @@ Then compile it with::
 
 Finally add your translations directory to your configuration::
 
-    app.config["SECURITY_I18N_DIRNAME"] = [pkg_resources.resource_filename("flask_security", "translations"), "translations"]
+    app.config["SECURITY_I18N_DIRNAME"] = ["builtin", "translations"]
 
 .. note::
     This only works when using Flask-Babel since Flask-BabelEx doesn't support a list of translation directories.

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -18,7 +18,6 @@ import re
 import typing as t
 import warnings
 
-import pkg_resources
 from flask import current_app, g
 from flask_login import AnonymousUserMixin, LoginManager
 from flask_login import UserMixin as BaseUserMixin
@@ -130,7 +129,7 @@ _default_config: t.Dict[str, t.Any] = {
     "FLASH_MESSAGES": True,
     "RETURN_GENERIC_RESPONSES": False,
     "I18N_DOMAIN": "flask_security",
-    "I18N_DIRNAME": pkg_resources.resource_filename("flask_security", "translations"),
+    "I18N_DIRNAME": "builtin",
     "EMAIL_VALIDATOR_ARGS": None,
     "PASSWORD_HASH": "bcrypt",
     "PASSWORD_SALT": None,
@@ -1404,8 +1403,7 @@ class Security:
 
         # set all (SECURITY) config items as attributes (minus the SECURITY_ prefix)
         for key, value in get_config(app).items():
-            # need to start getting rid of this - especially things like *_URL which
-            # should never be referenced
+            # need to start getting rid of this - very confusing.
             if not key.endswith("_URL"):
                 setattr(self, key.lower(), value)
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -5,7 +5,7 @@
     Flask-Security utils module
 
     :copyright: (c) 2012-2019 by Matt Wright.
-    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 import abc
@@ -14,7 +14,6 @@ import datetime
 from functools import partial
 import hashlib
 import hmac
-from pkg_resources import parse_version
 import time
 import typing as t
 from urllib.parse import parse_qsl, parse_qs, urlsplit, urlunsplit, urlencode
@@ -40,7 +39,6 @@ from flask_principal import AnonymousIdentity, Identity, identity_changed, Need
 from flask_wtf import csrf
 from wtforms import ValidationError
 from itsdangerous import BadSignature, SignatureExpired
-from werkzeug import __version__ as werkzeug_version
 from werkzeug.local import LocalProxy
 
 from .quart_compat import best, get_quart_status
@@ -926,10 +924,7 @@ def csrf_cookie_handler(response: "Response") -> "Response":
 
     if op == "clear":
         # Alas delete_cookie only accepts some of the keywords set_cookie does
-        # and Werkzeug didn't accept samesite, secure, httponly until 2.0
         allowed = ["path", "domain", "secure", "httponly", "samesite"]
-        if parse_version(werkzeug_version) < parse_version("2.0.0"):  # pragma: no cover
-            allowed = ["path", "domain"]
         args = {k: csrf_cookie.get(k) for k in allowed if k in csrf_cookie}
         response.delete_cookie(csrf_cookie_name, **args)
         session.pop("fs_cc")

--- a/pytest.ini
+++ b/pytest.ini
@@ -20,9 +20,11 @@ filterwarnings =
     ignore:.*'app.json_encoder' is deprecated.*:DeprecationWarning:flask:0
     ignore:.*Setting 'json_encoder'.*:DeprecationWarning:flask:0
     ignore:.*'JSONEncoder'.*:DeprecationWarning:flask:0
+    ignore:.*'locked_cached_property'.*:DeprecationWarning:flask:0
     ignore::DeprecationWarning:mongoengine:
     ignore:.*passwordless feature.*:DeprecationWarning:flask_security:0
     ignore:.*passing settings to bcrypt.*:DeprecationWarning:passlib:0
     ignore:.*'crypt' is deprecated.*:DeprecationWarning:passlib:0
+    ignore:.*pkg_resources is deprecated.*:DeprecationWarning:pkg_resources:0
     ignore:.*'sms' was enabled in SECURITY_US_ENABLED_METHODS;.*:UserWarning:flask_security:0
     ignore:.*'get_token_status' is deprecated.*:DeprecationWarning:flask_security:0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("flask_security/__init__.py", encoding="utf8") as f:
     version = re.search(r'__version__ = "(.*?)"', f.read()).group(1)
 
 install_requires = [
-    "Flask>=2.1.0,<2.3",
+    "Flask>=2.1.0",
     "Flask-Login>=0.6.0",
     "Flask-Principal>=0.4.0",
     "Flask-WTF>=1.0.0",
@@ -19,7 +19,7 @@ install_requires = [
     "passlib>=1.7.4",
     "blinker>=1.4",
     "wtforms>=3.0.0",  # for form-level errors
-    "setuptools",  # for pkg_resources
+    "importlib_resources>=5.10.0",
 ]
 
 packages = find_packages(exclude=["tests"])


### PR DESCRIPTION
pkg_resources now throws a warning that we really really shouldn't be using it.

To replace pkg_resources version parsing:
  - remove old Werkzeug version compatibility check
  - change flask json compatibility to use checks on attributes rather than version numbers. This should also fix the #777 (Quart compatibility) and allowed us to remove the upper bound Flask version check (which is considered bad form).

To replace pkg_resources 'files' API which we use to find Babel translations - change SECURITY_I18N_DIRNAME to default to 'builtin' which is checked and initialized as part of configuring our Flask-Babel Domain instance.

This also allows to remove the (recently added) dependence on setuptools.

close: #777
close: #764 
