### PR TITLE
Update webauthn transports support.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.2
+    rev: v3.8.0
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]
@@ -30,7 +30,7 @@ repos:
           - flake8-bugbear
           - flake8-implicit-str-concat
 -   repo: https://github.com/Riverside-Healthcare/djLint
-    rev: v1.25.0
+    rev: v1.31.1
     hooks:
       - id: djlint-jinja
         files: "\\.html"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,23 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 5.3.0
+-------------
+
+Released TBD
+
+Fixes
+++++++
+
+- (:pr:`xxx`) Webauthn Updates to handling of transport.
+
+Backwards Compatibility Concerns
++++++++++++++++++++++++++++++++++
+
+- To align with the W3C WebAuthn Level2 and 3 spec - transports are now part of the registration response.
+  This has been changed BOTH in the server code (using py_webauth data structures) as well as the sample
+  javascript code. If an application has their own javascript front end code - it might need to be changed.
+
 Version 5.2.0
 -------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ author = "Matt Wright & Chris Wagner"
 # built documents.
 #
 # The short X.Y version.
-version = "5.2.0"
+version = "5.3.0"
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -134,4 +134,4 @@ from .webauthn import (
 )
 from .webauthn_util import WebauthnUtil
 
-__version__ = "5.2.0"
+__version__ = "5.3.0"

--- a/flask_security/static/js/webauthn.js
+++ b/flask_security/static/js/webauthn.js
@@ -110,9 +110,8 @@ const transformNewAssertionForServer = (newAssertion) => {
         id: newAssertion.id,
         rawId: b64enc(rawId),
         type: newAssertion.type,
-        response: {"attestationObject": b64enc(attObj), "clientDataJSON": b64enc(clientDataJSON)},
+        response: {"attestationObject": b64enc(attObj), "clientDataJSON": b64enc(clientDataJSON), "transports": transports},
         extensions: JSON.stringify(registrationClientExtensions),
-        transports: transports,
     }
 }
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -31,5 +31,6 @@ requests
 sqlalchemy
 sqlalchemy-utils
 webauthn
+pydantic<2.0
 werkzeug
 zxcvbn

--- a/requirements_low/tests.txt
+++ b/requirements_low/tests.txt
@@ -30,5 +30,6 @@ sqlalchemy-utils==0.41.1
 # These 2 come from webauthn requirements
 cryptography==40.0.2
 webauthn==1.8.0;python_version>='3.8'
+pydantic<2.0
 werkzeug==2.3.3
 zxcvbn==4.4.28

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -4,7 +4,7 @@
 
     WebAuthn tests
 
-    :copyright: (c) 2021-2022 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2021-2023 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 
 """
@@ -60,9 +60,9 @@ REG_DATA1 = {
         "FEybDVYMnN5UTNGUmVXUlRVVjlyVUVWcVZqVmhNbVF3UVhCbVlYUmpjRk"
         "V4WVZoRWJWRlFidyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2NhbGhvc3Q6NT"
         "AwMSIsImNyb3NzT3JpZ2luIjpmYWxzZX0",
+        "transports": ["usb"],
     },
     "extensions": '{"credProps": {}}',
-    "transports": ["usb"],
 }
 SIGNIN_DATA1 = {
     "id": "wUUqNOjY35dcT-vpikZpZx-T91NjIe4PqrV8j7jYPOc",
@@ -94,9 +94,9 @@ REG_DATA2 = {
         "YzIxRFEybDVYMnN5UTNGUmVXUlRVVjlyVUVWcVZqVmhNbVF3UV"
         "hCbVlYUmpjRkV4WVZoRWJWRlFidyIsIm9yaWdpbiI6Imh0dHA6L"
         "y9sb2NhbGhvc3Q6NTAwMSIsImNyb3NzT3JpZ2luIjpmYWxzZX0",
+        "transports": ["nfc", "usb"],
     },
     "extensions": '{"credProps": {"rk": True}}',
-    "transports": ["nfc", "usb"],
 }
 
 # This has user_verification=True - i.e. a multi-factor capable key
@@ -115,9 +115,9 @@ REG_DATA_UV = {
         "xRFEybDVYMnN5UTNGUmVXUlRVVjlyVUVWcVZqVmhNbVF3UVhCbVlY"
         "UmpjRkV4WVZoRWJWRlFidyIsIm9yaWdpbiI6Imh0dHA6Ly9sb2Nhb"
         "Ghvc3Q6NTAwMSIsImNyb3NzT3JpZ2luIjpmYWxzZX0",
+        "transports": ["nfc", "usb"],
     },
     "extensions": '{"credProps":{"rk":true}}',
-    "transports": ["nfc", "usb"],
 }
 
 SIGNIN_DATA_UV = {
@@ -154,9 +154,9 @@ REG_DATA_UH = {
         "yVUVWcVZqVmhNbVF3UVhCbVlYUmpjRkV4WVZoRWJWRlFidyIsIm9yaWdpbi"
         "I6Imh0dHA6Ly9sb2NhbGhvc3"
         "Q6NTAwMSIsImNyb3NzT3JpZ2luIjpmYWxzZX0",
+        "transports": ["nfc", "usb"],
     },
     "extensions": '{"credProps":{"rk": true}}"',
-    "transports": ["nfc", "usb"],
 }
 SIGNIN_DATA_UH = {
     "id": "rHb1OXVM--dgGcWg0u3cfomyc-Tu4l4kK8GjVkS8bms-foXmBAlWHyTzuhgGgCnx",


### PR DESCRIPTION
Move to registration response - as per L2 and L3 spec. This is supported by py_webauthn.

Update versions for upcoming 5.3

Update pre-commit, etc.