### PR TITLE
Fix #806 - Login shouldn't attempt email delivery validation.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Fixes
 - (:pr:`809`) Fix MongoDB support by eliminating dependency on flask-mongoengine.
   Improve MongoDB quickstart.
 - (:issue:`801`) Fix Quickstart for SQLAlchemy with scoped session.
+- (:issue:`806`) Login no longer, by default, check for email deliverability.
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -169,6 +169,8 @@ Utils
 
 .. autofunction:: flask_security.tf_send_security_token
 
+.. autoclass:: flask_security.AsaList
+
 .. autoclass:: flask_security.SmsSenderBaseClass
   :members: send_sms
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -220,11 +220,16 @@ These configuration keys are used globally across all features.
 
 .. py:data:: SECURITY_EMAIL_VALIDATOR_ARGS
 
-    Email address are validated using the `email_validator`_ package. Its methods
-    have some configurable options - these can be set here and will be passed in.
+    Email address are validated and normalized via the ``mail_util_cls`` which
+    defaults to :class:`.MailUtil`. That uses the `email_validator`_ package whose methods
+    have configurable options - these can be set here and will be passed in.
     For example setting this to: ``{"check_deliverability": False}`` is useful
     when unit testing if the emails are fake.
 
+    ``mail_util_cls`` has 2 methods - ``normalize`` and ``validate``. Both
+    ensure the passed value is a valid email address, and returns a normalized
+    version. ``validate`` additionally, by default, verifies that the email
+    address can likely actually receive an email.
 
     Default: ``None``, meaning use the defaults from email_validator package.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -38,11 +38,11 @@ Your application will also need a database backend:
 * Sqlite is supported out of the box.
 * For PostgreSQL install `psycopg2`_.
 * For MySQL install `pymysql`_.
-* For MongoDB install `Flask-Mongoengine`_.
+* For MongoDB install `Mongoengine`_.
 
 For additional details on configuring your database engine connector - refer to `sqlalchemy_engine`_
 
 .. _psycopg2: https://pypi.org/project/psycopg2/
 .. _pymysql: https://pypi.org/project/PyMySQL/
-.. _Flask-Mongoengine: https://pypi.org/project/flask-mongoengine/
+.. _Mongoengine: https://pypi.org/project/mongoengine/
 .. _sqlalchemy_engine: https://docs.sqlalchemy.org/en/14/core/engines.html

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -49,13 +49,16 @@ Additional Functionality
 ------------------------
 
 Depending on the application's configuration, additional fields may need to be
-added to your `User` model.
+added to your database models. Note some fields are specified as 'list of string'
+the ORM you are using is responsible for translating the list of string to a suitable
+DB data type. For standard SQL-like databases, Flask-Security provides a utility
+method :class:`.AsaList`.
 
 Confirmable
 ^^^^^^^^^^^
 
 If you enable account confirmation by setting your application's
-`SECURITY_CONFIRMABLE` configuration value to `True`, your `User` model will
+:py:data:`SECURITY_CONFIRMABLE` configuration value to `True`, your `User` model will
 require the following additional field:
 
 * ``confirmed_at`` (datetime)
@@ -63,7 +66,7 @@ require the following additional field:
 Trackable
 ^^^^^^^^^
 
-If you enable user tracking by setting your application's `SECURITY_TRACKABLE`
+If you enable user tracking by setting your application's :py:data:`SECURITY_TRACKABLE`
 configuration value to `True`, your `User` model will require the following
 additional fields:
 
@@ -76,14 +79,14 @@ additional fields:
 Two_Factor
 ^^^^^^^^^^
 
-If you enable two-factor by setting your application's `SECURITY_TWO_FACTOR`
+If you enable two-factor by setting your application's :py:data:`SECURITY_TWO_FACTOR`
 configuration value to `True`, your `User` model will require the following
 additional fields:
 
 * ``tf_totp_secret`` (string, 255 bytes, nullable)
 * ``tf_primary_method`` (string)
 
-If you include 'sms' in `SECURITY_TWO_FACTOR_ENABLED_METHODS`, your `User` model
+If you include 'sms' in :py:data:`SECURITY_TWO_FACTOR_ENABLED_METHODS`, your `User` model
 will require the following additional field:
 
 * ``tf_phone_number`` (string, 128 bytes, nullable)

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -39,8 +39,14 @@ try:
     import sqlalchemy.types as types
 
     class AsaList(types.TypeDecorator):
-        # SQL-like DBs don't have a List type - so do that here by converting to a comma
-        # separate string.
+        """
+        SQL-like DBs don't have a List type - so do that here by converting to a comma
+        separate string.
+        For SQLAlchemy-based datastores, this can be used as::
+
+            Column(MutableList.as_mutable(AsaList()), nullable=True)
+        """
+
         impl = types.UnicodeText
 
         def process_bind_param(self, value, dialect):
@@ -58,6 +64,14 @@ try:
 except ImportError:  # pragma: no cover
 
     class AsaList:  # type: ignore
+        """
+        SQL-like DBs don't have a List type - so do that here by converting to a comma
+        separate string.
+        For SQLAlchemy-based datastores, this can be used as::
+
+            Column(MutableList.as_mutable(AsaList()), nullable=True)
+        """
+
         pass
 
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -30,6 +30,5 @@ requests
 sqlalchemy
 sqlalchemy-utils
 webauthn
-pydantic<2.0
 werkzeug
 zxcvbn

--- a/requirements_low/tests.txt
+++ b/requirements_low/tests.txt
@@ -19,16 +19,11 @@ mongoengine==0.27.0
 mongomock==4.1.2
 pony==0.7.16;python_version<'3.11'
 phonenumberslite==8.13.11
-# issue with pyopenssl requiring very new cryptography
-pyopenssl==23.1.1
 qrcode==7.4.2
 # authlib requires requests
 requests
 sqlalchemy==2.0.12
 sqlalchemy-utils==0.41.1
-# These 2 come from webauthn requirements
-cryptography==40.0.2
-webauthn==1.8.0;python_version>='3.8'
-pydantic<2.0
+webauthn==1.9.0
 werkzeug==2.3.3
 zxcvbn==4.4.28

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,9 @@ babel=
     babel>=2.12.1
     flask_babel>=3.1.0
 fsqla=
-    flask_sqlalchemy>=3.0.2
-    sqlalchemy>=1.4.35
-    sqlalchemy-utils>=0.38.3
+    flask_sqlalchemy>=3.0.3
+    sqlalchemy>=2.0.12
+    sqlalchemy-utils>=0.41.1
 common=
     bcrypt>=4.0.1
     flask_mailman>=0.3.0
@@ -14,7 +14,7 @@ mfa=
     cryptography>=40.0.2
     qrcode>=7.4.2
     phonenumberslite>=8.13.11
-    webauthn>=1.8.0
+    webauthn>=1.9.0
 
 [aliases]
 test=pytest
@@ -28,7 +28,7 @@ domain = flask_security
 
 [extract_messages]
 project= Flask-Security
-version=5.2.0
+version=5.3.0
 msgid_bugs_address = jwag956@github.com
 mapping-file = babel.ini
 output-file = flask_security/translations/flask_security.pot


### PR DESCRIPTION
Enpoints that need to actually send email - such as registration, forgot, confirmation continue to use the email_validator that by default checks for proper syntax as well as deliverability. /login no longer does - it just checks for syntax.

- Removed a reference to Flask-Mongoengine in docs.
- Document API AsaList()
- remove pydantic dependency since webauthn has fixed it on their end.
- bump package dependency requirements for extras.

closes #806