### PR TITLE
Fix session-only authentication.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Fixes
   Improve MongoDB quickstart.
 - (:issue:`801`) Fix Quickstart for SQLAlchemy with scoped session.
 - (:issue:`806`) Login no longer, by default, check for email deliverability.
+- (:issue:`791`) Token authentication is accepted on endpoints which only allow
+  'session' as authentication-method. (N247S)
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -152,23 +152,21 @@ def _check_token():
 
 
 def _check_session():
+    user_id = session.get("_user_id", None)
+    if user_id is None:
+        return False
+
     user = None
     if get_request_attr("fs_authn_via") == 'session' and hasattr(g, "_login_user"):
         user = g._login_user
-        if user.is_anonymous:
-            user = None
-    
-    if user is None:
-        user_id = session.get("_user_id")
-        if user_id is None or self._security.login_manager._user_callback is None:
-            return False
-        user = self._security.login_manager._user_callback(user_id)
-    
-    if user and not user.active:
-        return False
 
-    app = current_app._get_current_object()
-    identity_changed.send(app, identity=Identity(user.fs_uniquifier))
+    if user is None:
+        if _security.login_manager._user_callback is None:
+            return False
+        user = _security.login_manager._user_callback(user_id)
+
+    if user is None or not user.active:
+        return False
     return True
 
 

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -150,7 +150,7 @@ def _check_token():
     return False
 
 
-def _check_session(self):
+def _check_session():
     user_id = session.get("_user_id")
     if user_id is None or self._security.login_manager._user_callback is None:
         return False

--- a/mypy.ini
+++ b/mypy.ini
@@ -19,3 +19,7 @@ warn_unreachable = True
 # This false-positives with non-annotated methods (like imported packages)
 warn_return_any = False
 warn_unused_configs = True
+
+[mypy-flask_security.cli]
+# Due to click 8.1.4
+ignore_errors = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,7 +205,7 @@ def app(request: pytest.FixtureRequest) -> "SecurityFixture":
         return render_template("index.html", content="HTTP Authentication")
 
     @app.route("/session")
-    @http_auth_required('session')
+    @auth_required('session')
     def session():
         return "Session Authentication"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,6 +204,11 @@ def app(request: pytest.FixtureRequest) -> "SecurityFixture":
         assert get_request_attr("fs_authn_via") == "basic"
         return render_template("index.html", content="HTTP Authentication")
 
+    @app.route("/session")
+    @http_auth_required('session')
+    def session():
+        return "Session Authentication"
+
     @app.route("/token", methods=["GET", "POST"])
     @auth_token_required
     def token():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,7 +205,7 @@ def app(request: pytest.FixtureRequest) -> "SecurityFixture":
         return render_template("index.html", content="HTTP Authentication")
 
     @app.route("/session")
-    @auth_required('session')
+    @auth_required("session")
     def session():
         return "Session Authentication"
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -527,6 +527,14 @@ def test_token_auth_via_header_invalid_token(client):
     assert response.status_code == 401
 
 
+def test_token_auth_invalid_for_session_auth(client):
+    response = json_authenticate(client)
+    token = response.json["response"]["user"]["authentication_token"]
+    headers = {"Authentication-Token": token}
+    response = client.get("/session", headers=headers)
+    assert response.status_code == 401    
+
+
 def test_http_auth(client):
     # browsers expect 401 response with WWW-Authenticate header - which will prompt
     # them to pop up a login form.

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -17,7 +17,7 @@ from flask import Blueprint, g
 
 from flask_security import uia_email_mapper
 from flask_security.decorators import auth_required
-from flask_principal import identity_loaded, identity_changed
+from flask_principal import identity_loaded
 
 from tests.test_utils import (
     authenticate,
@@ -755,25 +755,25 @@ def test_user_deleted_during_session_reverts_to_anonymous_user(app, client):
 
 
 def test_session_loads_identity(app, client):
-
-    @app.route('/identity_check')
-    @auth_required('session')
+    @app.route("/identity_check")
+    @auth_required("session")
     def id_check():
-        if hasattr(g, 'identity'):
+        if hasattr(g, "identity"):
             identity = g.identity
-            assert hasattr(identity, 'loader_called')
+            assert hasattr(identity, "loader_called")
             assert identity.loader_called
-        return 'Success'
-
+        return "Success"
 
     json_authenticate(client)
 
-    # add identity loader after authentication to only fire it for session-authentication next `get` call
+    # add identity loader after authentication to only fire it for
+    # session-authentication next `get` call
     @identity_loaded.connect_via(app)
     def identity_loaded_check(sender, identity):
         identity.loader_called = True
 
-    client.get("/identity_check")
+    response = client.get("/identity_check")
+    assert b"Success" == response.data
 
 
 def test_remember_token(client):

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -1212,15 +1212,15 @@ def test_user_handle(app, client, get_message):
             .decode("utf-8")
             .replace("=", "")
         )
-        upd_signin_data = copy.deepcopy(SIGNIN_DATA_UH)
-        upd_signin_data["response"]["userHandle"] = b64_user_handle
-        signin_options, response_url, _ = _signin_start_json(client, "matt@lp.com")
-        response = client.post(
-            response_url, json=dict(credential=json.dumps(upd_signin_data))
-        )
-        # verify actually logged in
-        response = client.get("/profile", headers={"accept": "application/json"})
-        assert response.status_code == 200
+    upd_signin_data = copy.deepcopy(SIGNIN_DATA_UH)
+    upd_signin_data["response"]["userHandle"] = b64_user_handle
+    signin_options, response_url, _ = _signin_start_json(client, "matt@lp.com")
+    response = client.post(
+        response_url, json=dict(credential=json.dumps(upd_signin_data))
+    )
+    # verify actually logged in
+    response = client.get("/profile", headers={"accept": "application/json"})
+    assert response.status_code == 200
 
 
 @pytest.mark.settings(webauthn_util_cls=HackWebauthnUtil)


### PR DESCRIPTION
If an endpoint was decorated with "session" only - a properly submitted token would also be accepted.
Fix that by checking as part of the auth_required() decorator and the user is authenticated AND was authenticated using the _user_loader (which is what flask-login calls for session based authenticated).

close #791