### PR TITLE
Improve /confirm w.r.t. OWASP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Fixes
   'session' as authentication-method. (N247S)
 - (:issue:`814`) /reset and /confirm and GENERIC_RESPONSES and additional form args don't mix.
 - (:issue:`281`) Reset password can be exploited and other OWASP improvements.
+- (:pr:`xxx`) Confirmation can be exploited and other OWASP improvements.
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
@@ -30,7 +31,7 @@ Backwards Compatibility Concerns
 - To align with the W3C WebAuthn Level2 and 3 spec - transports are now part of the registration response.
   This has been changed BOTH in the server code (using py_webauth data structures) as well as the sample
   javascript code. If an application has their own javascript front end code - it might need to be changed.
-- Reset password was changed to improve OWASP compliance and reduce possible exploitation:
+- Reset password was changed to improve adhere to OWASP recommendations and reduce possible exploitation:
 
     - A new email (with new token) is no longer sent upon expired token. Users must restart
       the reset password process.
@@ -41,6 +42,15 @@ Backwards Compatibility Concerns
       query params.
     - The SECURITY_MSG_PASSWORD_RESET_EXPIRED message no longer contains the user's identity/email.
     - The default for :py:data:`SECURITY_RESET_PASSWORD_WITHIN` has been changed from `5 days` to `1 days`.
+    - The response to GET /reset/<token> sets the HTTP header `Referrer-Policy` to `no-referrer` as suggested
+      by OWASP.
+- Confirm email was changed to adhere to OWASP recommendations and reduce possible exploitation:
+
+    - A new email (with new token) is no longer sent upon expired token. Users must restart
+      the confirmation process.
+    - Identity information (identity, email) is no longer sent as part of the URL redirect
+      query params.
+    - The SECURITY_MSG_CONFIRMATION_EXPIRED message no longer contains the user's identity/email.
     - The response to GET /reset/<token> sets the HTTP header `Referrer-Policy` to `no-referrer` as suggested
       by OWASP.
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -596,7 +596,7 @@ paths:
               description: |
                 On spa-success: SECURITY_POST_CONFIRM_VIEW?identity={identity}&email={email}&{level}={msg}
 
-                On spa-error-expired: SECURITY_CONFIRM_ERROR_VIEW?error={msg}&identity={identity}&email={email}
+                On spa-error-expired: SECURITY_CONFIRM_ERROR_VIEW?error={msg}
 
                 On spa-error-invalid-token: SECURITY_CONFIRM_ERROR_VIEW?error={msg}
 
@@ -604,7 +604,7 @@ paths:
                                  SECURITY_POST_LOGIN_VIEW
 
                 On form-success (no auto-login): SECURITY_POST_CONFIRM_VIEW or
-                                 SECURITY_LOGIN_URL
+                                 ".login"
 
                 On form-error-expired: SECURITY_CONFIRM_ERROR_VIEW or
                                        SECURITY_CONFIRM_URL

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -441,11 +441,7 @@ _default_messages = {
         "info",
     ),
     "CONFIRMATION_EXPIRED": (
-        _(
-            "You did not confirm your email within %(within)s. "
-            "New instructions to confirm your email have been sent "
-            "to %(email)s."
-        ),
+        _("You did not confirm your email within %(within)s. "),
         "error",
     ),
     "LOGIN_EXPIRED": (


### PR DESCRIPTION
- no longer send a new token upon receiving an expired token
- no longer send identity/email information as part of query params in unauthenticated requests
- add Referrer-Policy="no-referrer" as suggested by OWASP

Minor improvements to API doc.