### PR TITLE
TWO_FACTOR_VALIDITY changes.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,8 @@ Version 5.3.0
 
 Released TBD
 
-This is a minor version bump due to the (possible) incompatibility w.r.t.
-WebAuthn, and changes to /reset.
+This is a minor version bump due to some small backwards incompatible changes to
+WebAuthn, recoverability (/reset), confirmation (/confirm) and the two factor validity feature.
 
 Fixes
 ++++++
@@ -18,13 +18,15 @@ Fixes
 - (:pr:`809`) Fix MongoDB support by eliminating dependency on flask-mongoengine.
   Improve MongoDB quickstart.
 - (:issue:`801`) Fix Quickstart for SQLAlchemy with scoped session.
-- (:issue:`806`) Login no longer, by default, check for email deliverability.
-- (:issue:`791`) Token authentication is accepted on endpoints which only allow
+- (:issue:`806`) Login no longer, by default, checks for email deliverability.
+- (:issue:`791`) Token authentication is no longer accepted on endpoints which only allow
   'session' as authentication-method. (N247S)
 - (:issue:`814`) /reset and /confirm and GENERIC_RESPONSES and additional form args don't mix.
 - (:issue:`281`) Reset password can be exploited and other OWASP improvements.
 - (:pr:`817`) Confirmation can be exploited and other OWASP improvements.
 - (:pr:`819`) Convert to pyproject.toml, build, remove setup.
+- (:pr:`xxx`) the tf_validity feature now ONLY sets a cookie - and the token is no longer
+  returned as part of a JSON response.
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
@@ -32,7 +34,10 @@ Backwards Compatibility Concerns
 - To align with the W3C WebAuthn Level2 and 3 spec - transports are now part of the registration response.
   This has been changed BOTH in the server code (using py_webauth data structures) as well as the sample
   javascript code. If an application has their own javascript front end code - it might need to be changed.
-- Reset password was changed to improve adhere to OWASP recommendations and reduce possible exploitation:
+- The tf_validity feature :py:data`SECURITY_TWO_FACTOR_ALWAYS_VALIDATE` used to set a cookie if the request was
+  form based, and return the token as part of a JSON response. Now, this feature is ONLY cookie based and the token
+  is no longer returned as part of any response.
+- Reset password was changed to adhere to OWASP recommendations and reduce possible exploitation:
 
     - A new email (with new token) is no longer sent upon expired token. Users must restart
       the reset password process.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1818,9 +1818,6 @@ components:
           type: boolean
           description: >
             If true, will remember userid as part of cookie. There is a configuration variable DEFAULT_REMEMBER_ME that can be set. This field will override that.
-        tf_validity_token:
-          type: string
-          description: Code verifying the user has successfully verified 2FA in the past. If verified, the user is able to skip validation of the second factor. Only used when SECURITY_TWO_FACTOR_ALWAYS_VALIDATE is False.
     LoginJsonResponse:
       type: object
       description: >
@@ -2037,9 +2034,6 @@ components:
           description: password or code
         remember:
           type: boolean
-        tf_validity_token:
-          type: string
-          description: Code verifying the user has successfully verified 2FA in the past. If verified, the user is able to skip validation of the second factor. Only used when SECURITY_TWO_FACTOR_ALWAYS_VALIDATE is False.
     UsSigninJsonResponse:
       allOf:
         - $ref: '#/components/schemas/BaseJsonResponse'
@@ -2199,10 +2193,6 @@ components:
         csrf_token:
           type: string
           description: Session CSRF token
-        tf_validity_token:
-          type: string
-          description: A timed token that verifies that the user has successfully completed 2FA. Only sent if SECURITY_TWO_FACTOR_ALWAYS_VALIDATE is False and remember_me (from /login POST) is True
-
     WanRegister:
       type: object
       required: [ name, usage ]

--- a/flask_security/tf_plugin.py
+++ b/flask_security/tf_plugin.py
@@ -282,11 +282,7 @@ def tf_verify_validity_token(fs_uniquifier: str) -> bool:
 
     :param fs_uniquifier: The ``fs_uniquifier`` of the submitting user.
     """
-    if request.is_json and request.content_length:
-        token = request.get_json().get("tf_validity_token", None)  # type: ignore
-    else:
-        token = request.cookies.get("tf_validity", default=None)
-
+    token = request.cookies.get("tf_validity", default=None)
     if token is None:
         return False
 
@@ -307,7 +303,9 @@ def tf_set_validity_token_cookie(response: "Response", token: str) -> "Response"
     cookie_kwargs = cv("TWO_FACTOR_VALIDITY_COOKIE")
     max_age = int(get_within_delta("TWO_FACTOR_LOGIN_VALIDITY").total_seconds())
     response.set_cookie("tf_validity", value=token, max_age=max_age, **cookie_kwargs)
-
+    # This is likely overkill since so far we only return this on a POST which is
+    # unlikely to be cached.
+    response.vary.add("Cookie")
     return response
 
 

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -972,10 +972,10 @@ def two_factor_token_validation():
         )
 
         after_this_request(view_commit)
+        if token:
+            after_this_request(partial(tf_set_validity_token_cookie, token=token))
 
         if not _security._want_json(request):
-            if token:
-                after_this_request(partial(tf_set_validity_token_cookie, token=token))
             do_flash(*get_message(completion_message))
             if changing:
                 return redirect(get_url(cv("TWO_FACTOR_POST_SETUP_VIEW")))
@@ -983,10 +983,7 @@ def two_factor_token_validation():
                 return redirect(get_post_login_redirect())
 
         else:
-            json_payload = {}
-            if token:
-                json_payload["tf_validity_token"] = token
-            return base_render_json(form, additional=json_payload)
+            return base_render_json(form)
 
     # GET or not successful POST
 

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -686,7 +686,6 @@ def webauthn_signin_response(token: str) -> "ResponseValue":
         if is_secondary:
             tf_token = _security.two_factor_plugins.tf_complete(form.user, True)
             if tf_token:
-                json_payload["tf_validity_token"] = tf_token
                 after_this_request(
                     partial(tf_set_validity_token_cookie, token=tf_token)
                 )

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -462,6 +462,22 @@ def test_spa_get_bad_token(app, client, get_message):
 
 
 @pytest.mark.filterwarnings("ignore")
+@pytest.mark.registerable()
+@pytest.mark.settings(auto_login_after_confirm=True, post_login_view="/postlogin")
+def test_auto_login(app, client, get_message):
+    with capture_registrations() as registrations:
+        data = dict(email="mary@lp.com", password="password", next="")
+        client.post("/register", data=data, follow_redirects=True)
+
+    assert not is_authenticated(client, get_message)
+
+    token = registrations[0]["confirm_token"]
+    response = client.get("/confirm/" + token, follow_redirects=False)
+    assert "/postlogin" == response.location
+    assert is_authenticated(client, get_message)
+
+
+@pytest.mark.filterwarnings("ignore")
 @pytest.mark.two_factor()
 @pytest.mark.registerable()
 @pytest.mark.settings(two_factor_required=True, auto_login_after_confirm=True)

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -900,7 +900,8 @@ def test_tf_validity_window(app, client, get_message):
 )
 def test_tf_validity_window_json(app, client, get_message):
     # Test with a two-factor validity setting - we don't get re-prompted.
-    response = json_authenticate(client)
+    # This also relies on the tf_validity_cookie
+    json_authenticate(client)
     register_options, response_url = _register_start_json(client)
     client.post(response_url, json=dict(credential=json.dumps(REG_DATA1)))
     logout(client)
@@ -914,11 +915,7 @@ def test_tf_validity_window_json(app, client, get_message):
     signin_options, response_url = _signin_start(client, "matt@lp.com")
     response = client.post(response_url, json=dict(credential=json.dumps(SIGNIN_DATA1)))
     assert response.status_code == 200
-    tf_token = response.json["response"]["tf_validity_token"]
     logout(client)
-
-    # make sure the cookie doesn't affect the JSON request
-    client.delete_cookie("tf_validity")
 
     # Sign in again - shouldn't require 2FA
     response = client.post(
@@ -927,7 +924,6 @@ def test_tf_validity_window_json(app, client, get_message):
             email="matt@lp.com",
             password="password",
             remember=True,
-            tf_validity_token=tf_token,
         ),
     )
     assert response.status_code == 200


### PR DESCRIPTION
Now only a cookie is set - for both forms and JSON, and the tf_validity token is never returned as part of a JSON response. Probably overkill, but in the response containing the tf_validity cookie - we add the Vary: Cookie header.