### PR TITLE
Fix login and unified signin templates to send CSRF tokens.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,8 +25,9 @@ Fixes
 - (:issue:`281`) Reset password can be exploited and other OWASP improvements.
 - (:pr:`817`) Confirmation can be exploited and other OWASP improvements.
 - (:pr:`819`) Convert to pyproject.toml, build, remove setup.
-- (:pr:`xxx`) the tf_validity feature now ONLY sets a cookie - and the token is no longer
+- (:pr:`823`) the tf_validity feature now ONLY sets a cookie - and the token is no longer
   returned as part of a JSON response.
+- (:pr:`xxx`) Fix login/unified signin templates to properly send CSRF token. Add more tests.
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -251,7 +251,7 @@ Note that we use the header name ``X-CSRF-Token`` as that is one of the default
 headers configured in Flask-WTF (*WTF_CSRF_HEADERS*)
 
 To protect your application's endpoints (that presumably are not using Flask forms),
-you need to enable CSRF as described in the FlaskWTF `documentation <https://flask-wtf.readthedocs.io/en/1.0.x/csrf/>`_: ::
+you need to enable CSRF as described in the FlaskWTF `documentation <https://flask-wtf.readthedocs.io/en/1.1.x/csrf/>`_: ::
 
     flask_wtf.CSRFProtect(app)
 

--- a/flask_security/oauth_glue.py
+++ b/flask_security/oauth_glue.py
@@ -4,7 +4,7 @@
 
     Class and methods to glue our login path with authlib for to support 'social' auth.
 
-    :copyright: (c) 2022-2022 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2022-2023 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 
 """
@@ -23,6 +23,7 @@ except ImportError:  # pragma: no cover
 
 from flask import abort, after_this_request, redirect, request
 
+from .decorators import unauth_csrf
 from .proxies import _security
 from .utils import (
     config_value as cv,
@@ -73,6 +74,7 @@ def google_fetch_identity(
     return "email", profile["email"]
 
 
+@unauth_csrf()
 def oauthstart(name: str) -> "ResponseValue":
     """View to start an oauth authentication.
     Name is a pre-registered oauth provider.

--- a/flask_security/templates/security/login_user.html
+++ b/flask_security/templates/security/login_user.html
@@ -21,7 +21,7 @@
     <hr class="fs-gap">
     <h2>{{ _fsdomain("Use WebAuthn to Sign In") }}</h2>
     <div>
-      <form method="get" id="wan-signin-form" name="wan_signin_form">
+      <form method="get" id="wan_signin_form" name="wan_signin_form">
         <input id="wan_signin" name="wan_signin" type="submit" value="{{ _fsdomain('Sign in with WebAuthn') }}" formaction="{{ url_for_security('wan_signin') }}{{ prop_next() }}">
       </form>
     </div>
@@ -31,8 +31,11 @@
     <h2>{{ _fsdomain("Use Social Oauth to Sign In") }}</h2>
     {% for provider in security.oauthglue.provider_names %}
       <div class="fs-gap">
-        <form method="post" id="{{ provider }}"-form name="{{ provider }}"_form>
+        <form method="post" id="{{ provider }}_form" name="{{ provider }}_form">
           <input id="{{ provider }}" name="{{ provider }}" type="submit" value="{{ _fsdomain('Sign in with ')~provider }}" formaction="{{ url_for_security('oauthstart', name=provider) }}{{ prop_next() }}">
+          {% if csrf_token is defined %}
+            <input id="{{ provider }}_csrf_token" name="{{ provider }}_csrf_token" type="hidden" value="{{ csrf_token() }}">
+          {% endif %}
         </form>
       </div>
     {% endfor %}

--- a/flask_security/templates/security/us_signin.html
+++ b/flask_security/templates/security/us_signin.html
@@ -34,8 +34,11 @@
     <h2>{{ _fsdomain("Use Social Oauth to Sign In") }}</h2>
     {% for provider in security.oauthglue.provider_names %}
       <div class="fs-gap">
-        <form method="post" id="{{ provider }}"-form name="{{ provider }}_form">
+        <form method="post" id="{{ provider }}_form" name="{{ provider }}_form">
           <input id="{{ provider }}" name="{{ provider }}" type="submit" value="{{ _fsdomain('Sign in with ')~provider }}" formaction="{{ url_for_security('oauthstart', name=provider) }}{{ prop_next() }}">
+          {% if csrf_token is defined %}
+            <input id="{{ provider }}_csrf_token" name="{{ provider }}_csrf_token" type="hidden" value="{{ csrf_token() }}">
+          {% endif %}
         </form>
       </div>
     {% endfor %}

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -1,4 +1,4 @@
-# :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
+# :copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
 # :license: MIT, see LICENSE for more details.
 
 """
@@ -27,6 +27,7 @@ import typing as t
 
 from flask import Flask, flash, render_template_string, request, session
 from flask_sqlalchemy import SQLAlchemy
+from flask_wtf import CSRFProtect
 
 from flask_security import (
     MailUtil,
@@ -152,6 +153,7 @@ def create_app():
         ):
             app.config[ev] = _find_bool(os.environ.get(ev))
 
+    CSRFProtect(app)
     # Create database models and hook up.
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     db = SQLAlchemy(app)


### PR DESCRIPTION
Add additional tests.

The oauthstart view needs to be decorated with @unauth_csrf.

Turn on complete CSRF support in view_scaffold since we really don't test CSRF enough.