### PR TITLE
Replace save with update

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,6 +26,7 @@ Christophe Simonis
 David Ignacio
 Eric Butler
 Eskil Heyn Olsen
+Ido Shraga
 Iuri de Silvio
 Jay Goel
 Jiri Kuncar

--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -94,6 +94,6 @@ def confirm_user(user):
     if user.confirmed_at is not None:
         return False
     user.confirmed_at = _security.datetime_factory()
-    _datastore.put(user)
+    _datastore.update(user, confirmed_at=user.confirmed_at)
     user_confirmed.send(app._get_current_object(), user=user)
     return True

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -104,7 +104,7 @@ class MongoEngineDatastore(Datastore):
         model.delete()
 
     def update(self, model, **update_ops):
-        return model.modify(**update_ops, upsert=False)
+        model.update(**update_ops, upsert=False)
 
 
 class PeeweeDatastore(Datastore):
@@ -117,7 +117,6 @@ class PeeweeDatastore(Datastore):
 
     def update(self, model, **update_ops):
         model.save(force_insert=False, only=list(update_ops.keys()))
-        return model
 
 
 def with_pony_session(f):

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -107,6 +107,6 @@ def update_password(user, password):
     user.password = hash_password(password)
     # Change uniquifier - this will cause ALL sessions to be invalidated.
     _datastore.set_uniquifier(user)
-    _datastore.put(user)
+    _datastore.update(user, password=user.password)
     send_password_reset_notice(user)
     password_reset.send(app._get_current_object(), user=user)

--- a/flask_security/totp.py
+++ b/flask_security/totp.py
@@ -12,7 +12,7 @@ import io
 import typing as t
 
 from passlib.totp import TOTP, TokenError, TotpMatch
-from passlib.pwd import genword
+
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from .datastore import User
@@ -164,6 +164,8 @@ class Totp:
 
         .. versionadded:: 5.0.0
         """
+        from passlib.pwd import genword
+
         pwds = genword(length=12, charset="hex", returns=number)
         # make this a bit easier to type - 3 sets of 4 characters
         spwds = []

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -160,7 +160,14 @@ def login_user(
         user.current_login_ip = new_current_ip
         user.login_count = user.login_count + 1 if user.login_count else 1
 
-        _datastore.put(user)
+        _datastore.update(
+            user,
+            last_login_at=user.last_login_at,
+            current_login_at=user.current_login_at,
+            last_login_ip=user.last_login_ip,
+            current_login_ip=user.current_login_ip,
+            login_count=user.login_count,
+        )
 
     session["fs_cc"] = "set"  # CSRF cookie
     session["fs_paa"] = time.time()  # Primary authentication at - timestamp
@@ -343,7 +350,7 @@ def verify_and_update_password(password: SB, user: "User") -> bool:
 
     if verified and _pwd_context.needs_update(user.password):
         user.password = hash_password(password)
-        _datastore.put(user)
+        _datastore.update(user, password=user.password)
     return verified
 
 

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -822,7 +822,7 @@ def two_factor_setup():
         )
         if new_phone:
             user.tf_phone_number = new_phone
-            _datastore.put(user)
+            _datastore.update(user, tf_phone_number=user.tf_phone_number)
             after_this_request(view_commit)
 
         # This form is sort of bizarre - for SMS and authenticator

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -32,6 +32,9 @@ class MockDatastore(UserDatastore):
     def delete(self, model):
         pass
 
+    def update(self, model, **update_ops):
+        pass
+
 
 def test_unimplemented_datastore_methods():
     datastore = Datastore(None)


### PR DESCRIPTION
In mongoDB it is critical from my experience (I pretty sure the sql will act the same)
and in scale of multiple operation on same account it could override other operation because save will save the current state of document instead of justupdate
