### PR TITLE
Update Markup import from flask to markupsafe

### DIFF
--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -13,7 +13,8 @@
 import inspect
 import typing as t
 
-from flask import Markup, current_app, request
+from flask import current_app, request
+from markupsafe import Markup
 from flask_login import current_user
 from flask_wtf import FlaskForm as BaseForm
 from wtforms import (


### PR DESCRIPTION
This is required as Flask 3.0.0 does not provide anymore imports of Markup from flask