### PR TITLE
Fix form.next for newer authentication mechanisms - including two-fac…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ Fixes
 - (:issue:`826`) Fix error in quickstart (codycollier)
 - (:pr:`835`) Update Armenian translations (amkrtchyan-tmp)
 - (:pr:`831`) Update German translations. (sr-verde)
+- (:issue:`853`) Fix 'next' propagation when passed as form.next (thanks cariaso)
 
 Version 5.3.0
 -------------

--- a/flask_security/oauth_glue.py
+++ b/flask_security/oauth_glue.py
@@ -115,7 +115,7 @@ def oauthresponse(name: str) -> "ResponseValue":
     if user:
         after_this_request(view_commit)
         response = _security.two_factor_plugins.tf_enter(
-            user, False, "oauth", next_loc=propagate_next(request.url)
+            user, False, "oauth", next_loc=propagate_next(request.url, None)
         )
         if response:
             return response

--- a/flask_security/tf_plugin.py
+++ b/flask_security/tf_plugin.py
@@ -4,7 +4,7 @@
 
     Flask-Security Two-Factor Plugin Module
 
-    :copyright: (c) 2022-2022 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2022-2023 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 
     TODO:
@@ -58,7 +58,9 @@ class TwoFactorSelectForm(Form):
 def tf_select() -> "ResponseValue":
     # Ask user which MFA method they want to use.
     # This is used when a user has setup more than one type of 2FA.
-    form = build_form_from_request("two_factor_select_form")
+    form = t.cast(
+        TwoFactorSelectForm, build_form_from_request("two_factor_select_form")
+    )
 
     # This endpoint is unauthenticated - make sure we're in a valid state
     if not all(k in session for k in ["tf_user_id", "tf_select"]):
@@ -81,7 +83,7 @@ def tf_select() -> "ResponseValue":
         if tf_impl:
             json_payload = {"tf_required": True}
             response = tf_impl.tf_login(
-                user, json_payload, next_loc=propagate_next(request.url)
+                user, json_payload, next_loc=propagate_next(request.url, None)
             )
         if not response:  # pragma no cover
             # This really can't happen unless between the time the started logging in

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -183,7 +183,10 @@ def login() -> "ResponseValue":
         assert form.user is not None
         remember_me = form.remember.data if "remember" in form else None
         response = _security.two_factor_plugins.tf_enter(
-            form.user, remember_me, "password", next_loc=propagate_next(request.url)
+            form.user,
+            remember_me,
+            "password",
+            next_loc=propagate_next(request.url, form),
         )
         if response:
             return response
@@ -305,7 +308,7 @@ def register() -> "ResponseValue":
         # signin - we adhere to historic behavior.
         if not _security.confirmable or cv("LOGIN_WITHOUT_CONFIRMATION"):
             response = _security.two_factor_plugins.tf_enter(
-                form.user, False, "register", next_loc=propagate_next(request.url)
+                form.user, False, "register", next_loc=propagate_next(request.url, form)
             )
             if response:
                 return response
@@ -490,7 +493,7 @@ def confirm_email(token):
             # get the email.
             # Note also this goes against OWASP recommendations.
             response = _security.two_factor_plugins.tf_enter(
-                user, False, "confirm", next_loc=propagate_next(request.url)
+                user, False, "confirm", next_loc=propagate_next(request.url, None)
             )
             if response:
                 do_flash(m, c)
@@ -639,7 +642,7 @@ def reset_password(token):
         if cv("AUTO_LOGIN_AFTER_RESET"):
             # backwards compat - really shouldn't do this according to OWASP
             response = _security.two_factor_plugins.tf_enter(
-                form.user, False, "reset", next_loc=propagate_next(request.url)
+                form.user, False, "reset", next_loc=propagate_next(request.url, None)
             )
             if response:
                 return response

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -1246,6 +1246,18 @@ def test_propagate_next(app, client):
             verify_url, data=dict(code=codes[0]["login_token"]), follow_redirects=False
         )
         assert "/im-in" in response.location
+        logout(client)
+
+        # do it with next in the form
+        data = dict(email="gal@lp.com", password="password", next="/im-in")
+        response = client.post("/login", data=data, follow_redirects=True)
+        assert "?next=/im-in" in response.request.url
+        # grab URL from form to show that our template propagates ?next
+        verify_url = get_form_action(response)
+        response = client.post(
+            verify_url, data=dict(code=codes[1]["login_token"]), follow_redirects=False
+        )
+        assert "/im-in" in response.location
 
 
 @pytest.mark.settings(freshness=timedelta(minutes=0))

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -26,6 +26,7 @@ from tests.test_utils import (
     capture_flashes,
     get_existing_session,
     get_form_action,
+    get_form_input,
     json_authenticate,
     logout,
     reset_fresh,
@@ -1654,3 +1655,20 @@ def test_login_next(app, client, get_message):
     )
     assert response.status_code == 200
     assert b"Profile Page" in response.data
+
+    # Try form.next
+    logout(client, endpoint="/auth/logout")
+    reset_signcount(app, "matt@lp.com", "testr3")
+
+    response = client.post(
+        "/auth/wan-signin", data=dict(identity="matt@lp.com", next="/im-in")
+    )
+    response_url = get_form_action(response)
+
+    next_loc = get_form_input(response, "next")
+    response = client.post(
+        response_url,
+        data=dict(credential=json.dumps(SIGNIN_DATA1), next=next_loc),
+        follow_redirects=False,
+    )
+    assert "/im-in" in response.location


### PR DESCRIPTION
…tor.

Propagating 'next' when part of the request query string was working - but FS also supported 'next' as a hidden field in some endpoints such as /login and /register. form.next wasn't being propagated with 2FA. Also - newer authentication endpoints - /us-signin /wan-signin didn't have the 'next' hidden field.

Also - there were NO tests for form.next.

Fixed all that, added tests, combined all 'next' calculations in a single utility.

closes #853