### PR TITLE
Deprecate passing in anonymous_user class.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ Fixes
 - (:issue:`859`) Update Quickstart to show how to properly handle SQLAlchemy connections.
 - (:issue:`861`) Auth Token not returned from /tf-validate. (thanks lilz-egoto)
 - (:pr:`864`) Fix for latest email_validator deprecation - bump minimum to 2.0.0
+- (:pr:`xxx`) Deprecate passing in the anonymous_user class (sent to Flask-Login).
 
 Version 5.3.1
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,16 +15,6 @@ Core
 
    A proxy for the current user.
 
-.. function:: flask_security.Security.unauthorized_handler
-
-    If an endpoint fails authentication or authorization from one of the decorators
-    described below
-    (except ``login_required``), a method annotated with this decorator will be called.
-    For ``login_required`` (which is implemented in Flask-Login) use
-    **flask_security.login_manager.unauthorized_handler**
-
-    .. deprecated:: 3.3.0
-
 Protecting Views
 ----------------
 .. autofunction:: flask_security.anonymous_user_required
@@ -146,8 +136,6 @@ Utils
 .. autofunction:: flask_security.url_for_security
 
 .. autofunction:: flask_security.send_mail
-
-.. autofunction:: flask_security.get_token_status
 
 .. autofunction:: flask_security.check_and_get_token_status
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -134,4 +134,4 @@ from .webauthn import (
 )
 from .webauthn_util import WebauthnUtil
 
-__version__ = "5.3.1"
+__version__ = "5.3.2"

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1108,11 +1108,12 @@ class Security:
         ``send_mail`` and ``send_mail_task``. Replaced with ``mail_util_cls``.
         ``two_factor_verify_password_form`` removed.
         ``password_validator`` removed in favor of the new ``password_util_cls``.
-
     .. deprecated:: 5.0.0
         Passing in a LoginManager instance. Removed in 5.1.0
     .. deprecated:: 5.0.0
         json_encoder_cls is no longer honored since Flask 2.2 has deprecated it.
+    .. deprecated:: 5.3.1
+        Passing in an anonymous_user class.
     """
 
     def __init__(
@@ -1172,7 +1173,7 @@ class Security:
             warnings.warn(
                 "kwargs passed to the constructor are now ignored",
                 DeprecationWarning,
-                stacklevel=4,
+                stacklevel=2,
             )
         self.app = app
         self._datastore = datastore
@@ -1220,7 +1221,7 @@ class Security:
 
         # Attributes not settable from init.
         self._unauthn_handler: t.Callable[
-            [t.List[str], t.Optional[t.Dict[str, str]]], "ResponseValue"
+            ..., "ResponseValue"
         ] = default_unauthn_handler
         self._reauthn_handler: t.Callable[
             [timedelta, timedelta], "ResponseValue"
@@ -1389,6 +1390,14 @@ class Security:
         for attr in attr_names:
             if kwargs.get(attr, None):
                 setattr(self, attr, kwargs.get(attr))
+
+        if self.anonymous_user:
+            warnings.warn(
+                "Passing in an anonymous_user class for use with Flask-Login"
+                "was deprecated in 5.3.2 and will be removed in 5.4",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # set all (SECURITY) config items as attributes (minus the SECURITY_ prefix)
         for key, value in get_config(app).items():
@@ -1871,7 +1880,7 @@ class Security:
     def unauthorized_handler(self, cb: t.Callable[[], "ResponseValue"]) -> None:
         warnings.warn(
             "'unauthorized_handler' has been replaced with"
-            " 'unauthz_handler' and 'unauthn_handler'",
+            " 'unauthz_handler' and 'unauthn_handler' and will be removed in 5.4",
             DeprecationWarning,
             stacklevel=2,
         )

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -248,7 +248,7 @@ def http_auth_required(realm: t.Any) -> DecoratedView:
             else:
                 r = _security.default_http_auth_realm if callable(realm) else realm
                 h = {"WWW-Authenticate": f'Basic realm="{r}"'}
-                return _security._unauthn_handler(["basic"], h)
+                return _security._unauthn_handler(["basic"], headers=h)
 
         return wrapper
 


### PR DESCRIPTION
This continues deprecating Flask-Login exposed attributes and features.

Clean up some API docs.