### PR TITLE
Fix us-sign magic link to use fs_uniquifier.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,17 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 5.4.0
+-------------
+
+Released xxx
+
+Fixes
++++++
+
+- (:issue:`845`) us-signin magic link should use fs_uniquifier (not email)
+
+
 Version 5.3.2
 -------------
 


### PR DESCRIPTION
It was using email as a user/account unique ID - it should, like everything else, use fs_uniquifier.

closes #845