### PR TITLE
Remove create_user side effects by copying roles list

### DIFF
--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -12,6 +12,7 @@ import datetime
 import json
 import typing as t
 import uuid
+from copy import copy
 
 from .utils import config_value as cv
 
@@ -207,7 +208,7 @@ class UserDatastore:
 
     def _prepare_create_user_args(self, **kwargs):
         kwargs.setdefault("active", True)
-        roles = kwargs.get("roles", [])
+        roles = copy(kwargs.get("roles", []))
         for i, role in enumerate(roles):
             rn = role.name if isinstance(role, self.role_model) else role
             # see if the role exists

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -164,6 +164,21 @@ def test_create_user_with_roles(app, datastore):
         assert current_nqueries is None or end_nqueries == (current_nqueries + 1)
 
 
+def test_create_user_no_side_effects(app, datastore):
+    init_app_with_options(app, datastore)
+
+    with app.app_context():
+        datastore.find_role("admin")
+        roles = ["admin"]
+        datastore.commit()
+
+        datastore.create_user(
+            email="dude@lp.com", username="dude", password="password", roles=roles
+        )
+
+        assert all(isinstance(role, str) for role in roles)
+
+
 def test_delete_user(app, datastore):
     init_app_with_options(app, datastore)
 


### PR DESCRIPTION
Resolves #875 by making a copy of the roles list in `UserDatastore._prepare_create_user_args` to prevent it from mutating inputs:

https://github.com/NoRePercussions/flask-security/blob/f7562bd60d6f06494b0b001a993f4fb5b3564a8e/flask_security/datastore.py#L211-L215