### PR TITLE
Add support for not using on AnonymousUser.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,25 @@ Fixes
 +++++
 
 - (:issue:`845`) us-signin magic link should use fs_uniquifier (not email)
+- (:pr:`873`) Update Spanish and Italian translations (gissimo)
+- (:pr:`xxx`) Make AnonymousUser optional and deprecated
+- (:issue:`875`) user_datastore.create_user has side effects on mutable inputs (NoRePercussions)
+
+Notes
+++++++
+- Prior to this release, the **current_user** proxy always pointed to a user object.
+  If the user wasn't authenticated, it pointed to an AnonymousUser object. With this release,
+  setting :py:data:`SECURITY_ANONYMOUS_USER_DISABLED` to `True` will force **current_user** to be set
+  to `None` if the requesting user isn't authenticated. It should be noted that this is in support
+  of a proposal by the Pallets team to remove AnonymousUser from Flask-Login - as well as deprecating
+  the `is_authenticated` property. The default behavior (`False`) should be the same as prior releases.
+  A new function `_fs_is_user_authenticated` is now part of the render_template context that
+  templates can use instead of `current_user.is_authenticated`.
+
+Backwards Compatibility Concerns
++++++++++++++++++++++++++++++++++
+
+- Passing in an AnonymousUser class as part of Security initialization has been removed.
 
 
 Version 5.3.2
@@ -36,8 +55,6 @@ Released October 14, 2023
 
 - If your application uses webauthn you must use pydantic < 2.0
   until the issue with user_handle is resolved.
-- If you want to use the latest Flask (3.0.0) you need to have Flask-Login changes -
-  those aren't currently released - use the 'main' branch.
 
 Fixes
 ++++++

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,9 +50,6 @@ User Object Helpers
 .. autoclass:: flask_security.WebAuthnMixin
    :members:
 
-.. autoclass:: flask_security.AnonymousUser
-   :members:
-
 
 Datastores
 ----------

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -469,24 +469,6 @@ These configuration keys are used globally across all features.
 
     .. versionadded:: 5.0.0
 
-.. py:data:: SECURITY_BACKWARDS_COMPAT_UNAUTHN
-
-    If set to ``True`` then the default behavior for authentication
-    failures from one of Flask-Security's decorators will be restored to
-    be compatible with releases prior to 3.3.0 (return 401 and some static html).
-
-    Default: ``False``.
-
-.. py:data:: SECURITY_BACKWARDS_COMPAT_AUTH_TOKEN
-
-    If set to ``True`` then an Authentication-Token will be returned
-    on every successful call to login, reset-password, change-password
-    as part of the JSON response. This was the default prior to release 3.3.0
-    - however sending Authentication-Tokens (which by default don't expire)
-    to session based UIs is a bad security practice.
-
-    Default: ``False``.
-
 Core - Multi-factor
 -------------------
 These are used by the Two-Factor and Unified Signin features.
@@ -591,6 +573,37 @@ These are used by the Two-Factor and Unified Signin features.
 
     .. versionadded:: 3.4.0
 
+Core - Compatibility
+---------------------
+These are flags that change various backwards compatability functionality.
+
+.. py:data:: SECURITY_ANONYMOUS_USER_DISABLED
+
+    If set to `True` then :data:`flask_security.current_user` will be `None` for unauthenticated
+    users instead of pointing to an AnonymousUser object. Note that Flask-Login intends
+    to deprecate the entire AnonymousUser concept.
+
+    Default: ``False``.
+
+    .. versionadded:: 5.4.0
+
+.. py:data:: SECURITY_BACKWARDS_COMPAT_UNAUTHN
+
+    If set to ``True`` then the default behavior for authentication
+    failures from one of Flask-Security's decorators will be restored to
+    be compatible with releases prior to 3.3.0 (return 401 and some static html).
+
+    Default: ``False``.
+
+.. py:data:: SECURITY_BACKWARDS_COMPAT_AUTH_TOKEN
+
+    If set to ``True`` then an Authentication-Token will be returned
+    on every successful call to login, reset-password, change-password
+    as part of the JSON response. This was the default prior to release 3.3.0
+    - however sending Authentication-Tokens (which by default don't expire)
+    to session based UIs is a bad security practice.
+
+    Default: ``False``.
 
 Core - rarely need changing
 ----------------------------

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -45,8 +45,12 @@ Each template is passed a template context object that includes the following,
 including the objects/values that are passed to the template by the main
 Flask application context processor:
 
-* ``<template_name>_form``: A form object for the view
-* ``security``: The Flask-Security extension object
+* ``<template_name>_form``: A form object for the view.
+* ``security``: The Flask-Security extension object.
+* ``url_for_security``: A function that returns the configured URL for the passed Security endpoint.
+* ``_fsdomain``: A function used to `tag` strings for extraction and localization.
+* ``_fs_is_user_authenticated``: Returns True if argument (user) is authenticated.
+  Usually the `current_user` proxy is the appropriate argument.
 
 To add more values to the template context, you can specify a context processor
 for all views or a specific view. For example::
@@ -529,7 +533,7 @@ it on `app.json_provider_cls`.
 401, 403, Oh My
 +++++++++++++++
 For a very long read and discussion; look at `this`_. Out of the box, Flask-Security in
-tandem with Flask-Login, behave as follows:
+tandem with Flask-Login, behaves as follows:
 
     * If authentication fails as the result of a `@login_required`, `@auth_required("session", "token")`,
       or `@token_auth_required` then if the request 'wants' a JSON

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -17,7 +17,6 @@ from .core import (
     RoleMixin,
     UserMixin,
     WebAuthnMixin,
-    AnonymousUser,
     FormInfo,
     current_user,
 )
@@ -134,4 +133,4 @@ from .webauthn import (
 )
 from .webauthn_util import WebauthnUtil
 
-__version__ = "5.3.2"
+__version__ = "5.4.0"

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -344,6 +344,7 @@ def users_change_password(user, password):
 
     kwargs = {"password": password, "password_confirm": password}
     form = build_form("reset_password_form", meta={"csrf": False}, **kwargs)
+    form.user = user_obj
 
     if form.validate():
         # validation will normalize password

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -687,6 +687,9 @@ class RegisterForm(ConfirmRegisterForm, NextFormMixin):
 class ResetPasswordForm(Form, NewPasswordFormMixin, PasswordConfirmFormMixin):
     """The default reset password form"""
 
+    # filled in by caller
+    user: "User"
+
     submit = SubmitField(get_form_field_label("reset_password"))
 
     def validate(self, **kwargs: t.Any) -> bool:
@@ -694,7 +697,7 @@ class ResetPasswordForm(Form, NewPasswordFormMixin, PasswordConfirmFormMixin):
             return False
 
         pbad, self.password.data = _security._password_util.validate(
-            self.password.data, False, user=current_user
+            self.password.data, False, user=self.user
         )
         if pbad:
             self.password.errors.extend(pbad)

--- a/flask_security/templates/security/_menu.html
+++ b/flask_security/templates/security/_menu.html
@@ -2,7 +2,7 @@
   <hr>
   <h2>{{ _fsdomain('Menu') }}</h2>
   <ul>
-    {% if current_user and current_user.is_authenticated %}
+    {% if _fs_is_user_authenticated(current_user) %}
       {# already authenticated user #}
       <li>
         <a href="{{ url_for_security('logout') }}">{{ _fsdomain("Sign out") }}</a>

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -76,6 +76,7 @@ from .utils import (
     get_message,
     get_url,
     get_within_delta,
+    is_user_authenticated,
     json_error_response,
     login_user,
     lookup_identity,
@@ -540,7 +541,7 @@ def us_signin() -> "ResponseValue":
     For POST - redirects to POST_LOGIN_VIEW (forms) or returns 400 (json).
     """
 
-    if current_user.is_authenticated and request.method == "POST":
+    if is_user_authenticated(current_user) and request.method == "POST":
         # Just redirect current_user to POST_LOGIN_VIEW (or next).
         # While its tempting to try to logout the current user and login the
         # new requested user - that simply doesn't work with CSRF.
@@ -598,7 +599,7 @@ def us_signin() -> "ResponseValue":
         }
         return base_render_json(form, include_user=False, additional=payload)
 
-    if current_user.is_authenticated:
+    if is_user_authenticated(current_user):
         # Basically a no-op if authenticated - just perform the same
         # post-login redirect as if user just logged in.
         return redirect(get_post_login_redirect())

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -105,6 +105,7 @@ from .utils import (
     get_request_attr,
     get_url,
     hash_password,
+    is_user_authenticated,
     json_error_response,
     login_user,
     logout_user,
@@ -159,7 +160,7 @@ def login() -> "ResponseValue":
     """
     form = t.cast(LoginForm, build_form_from_request("login_form"))
 
-    if current_user.is_authenticated:
+    if is_user_authenticated(current_user):
         # Just redirect current_user to POST_LOGIN_VIEW.
         # While its tempting to try to logout the current user and login the
         # new requested user - that simply doesn't work with CSRF.
@@ -272,7 +273,7 @@ def logout():
     """View function which handles a logout request."""
     tf_clean_session()
 
-    if current_user.is_authenticated:
+    if is_user_authenticated(current_user):
         logout_user()
 
     # No body is required - so if a POST and json - return OK
@@ -743,7 +744,7 @@ def two_factor_setup():
     """
     form = t.cast(TwoFactorSetupForm, build_form_from_request("two_factor_setup_form"))
 
-    if not current_user.is_authenticated:
+    if not is_user_authenticated(current_user):
         # This is the initial login case
         # We can also get here from setup if they want to change TODO: how?
         if not all(k in session for k in ["tf_user_id", "tf_state"]) or session[
@@ -900,7 +901,7 @@ def two_factor_token_validation():
         TwoFactorVerifyCodeForm, build_form_from_request("two_factor_verify_code_form")
     )
 
-    changing = current_user.is_authenticated
+    changing = is_user_authenticated(current_user)
     if not changing:
         # This is the normal login case OR initial setup
         if (

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -2,4 +2,4 @@ Pallets-Sphinx-Themes~=2.1
 Sphinx~=7.2
 sphinx-issues==3.0.1
 packaging
-Flask-Login@git+https://github.com/maxcountryman/flask-login.git@main
+Flask-Login

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,6 +1,6 @@
 Flask-Babel
 Babel
-Flask-Login@git+https://github.com/maxcountryman/flask-login@main
+Flask-Login
 Flask-Mailman
 Flask-Principal
 peewee

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ from flask_security import (
 )
 from flask_security.utils import localize_callback
 
-from tests.test_utils import populate_data
+from tests.test_utils import convert_bool_option, populate_data
 
 NO_BABEL = False
 try:
@@ -158,6 +158,12 @@ def app(request: pytest.FixtureRequest) -> "SecurityFixture":
     if settings is not None:
         for key, value in settings.kwargs.items():
             app.config[key.upper()] = value
+
+    # allow pytest command line to override everything
+    if request.config.option.setting:
+        for s in request.config.option.setting:
+            key, value = s.split("=")
+            app.config["SECURITY_" + key.upper()] = convert_bool_option(value)
 
     app.mail = Mail(app)  # type: ignore
 
@@ -985,6 +991,13 @@ def pytest_addoption(parser):
         default=None,
         help="""Set url for using real mongo database for testing.
         e.g. 'localhost'""",
+    )
+    parser.addoption(
+        "--setting",
+        default=None,
+        action="append",
+        help="""Set one or more SECURITY_ settings from command line.
+        e.g. --setting anonymous_user_enable=False""",
     )
 
 

--- a/tests/templates/_nav.html
+++ b/tests/templates/_nav.html
@@ -1,17 +1,17 @@
-{%- if current_user.is_authenticated -%}
+{%- if _fs_is_user_authenticated(current_user) -%}
   <p>{{ _fsdomain('Welcome') }} {{ current_user.calc_username() }}</p>
 {%- endif %}
 <ul>
   <li><a href="{{ url_for('index') }}">Index</a></li>
   <li><a href="{{ url_for('profile') }}">Profile</a></li>
-  {% if current_user.has_role('admin') -%}
+  {% if current_user and current_user.has_role('admin') -%}
   <li><a href="{{ url_for('admin') }}">Admin</a></li>
   {% endif -%}
-  {% if current_user.has_role('admin') or current_user.has_role('editor') -%}
+  {% if current_user and (current_user.has_role('admin') or current_user.has_role('editor')) -%}
   <li><a href="{{ url_for('admin_or_editor') }}">Admin or Editor</a></li>
   {% endif -%}
   <li>
-    {%- if current_user.is_authenticated -%}
+    {%- if _fs_is_user_authenticated(current_user) -%}
       <a href="{{ url_for('security.logout') }}">Log out</a>
     {%- else -%}
       <a href="{{ url_for('security.login') }}">Log in</a>

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -45,6 +45,14 @@ def test_authenticate(client):
     assert b"Welcome matt@lp.com" in response.data
 
 
+@pytest.mark.settings(anonymous_user_disabled=True)
+def test_authenticate_no_anon(client):
+    response = authenticate(client)
+    assert response.status_code == 302
+    response = authenticate(client, follow_redirects=True)
+    assert b"Welcome matt@lp.com" in response.data
+
+
 def test_authenticate_with_next(client):
     data = dict(email="matt@lp.com", password="password")
     response = client.post("/login?next=/page1", data=data, follow_redirects=True)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -8,8 +8,9 @@ import inspect
 import pytest
 
 from sqlalchemy import Column
-from flask_security import AnonymousUser, RoleMixin, UserMixin
+from flask_security import RoleMixin, UserMixin
 from flask_security.models import fsqla, fsqla_v2
+from flask_security.core import AnonymousUser
 
 
 class Role(RoleMixin):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,7 +51,7 @@ def json_authenticate(client, email="matt@lp.com", password="password", endpoint
 
 def is_authenticated(client, get_message):
     # Return True is 'client' is authenticated.
-    # Return False is not
+    # Return False if not
     # Raise ValueError not certain...
     response = client.get("/profile", headers={"accept": "application/json"})
     if response.status_code == 200:
@@ -417,3 +417,12 @@ class FakeSerializer:
 
     def dumps(self, state):
         return "heres your state"
+
+
+def convert_bool_option(v):
+    # Used for command line options to convert string to bool
+    if str(v).lower() in ["true"]:
+        return True
+    elif str(v).lower() in ["false"]:
+        return False
+    return v

--- a/tox.ini
+++ b/tox.ini
@@ -148,7 +148,7 @@ deps =
     jinja2
 skip_install = true
 commands =
-    pybabel extract --version 5.3.2 --keyword=_fsdomain --project=Flask-Security \
+    pybabel extract --version 5.4.0 --keyword=_fsdomain --project=Flask-Security \
         -o flask_security/translations/flask_security.pot \
         --msgid-bugs-address=jwag956@github.com --mapping-file=babel.ini \
         --add-comments=NOTE flask_security


### PR DESCRIPTION
Flask-Login is proposing doing away with AnonymousUser concept - we now support that as well. There will likely be some small changes required when they decide precisely how they plan on implementing it.

Add a new utility method is_user_authenticated that encapsulates both models. Add a new template context method _fs_is_user_authenticated for use in templates.