### PR TITLE
Invert unauthenticated handling.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/psf/black
-    rev: 23.10.1
+    rev: 23.11.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -25,8 +25,6 @@ Protecting Views
 
 .. autofunction:: flask_security.auth_required
 
-.. autofunction:: flask_security.login_required
-
 .. autofunction:: flask_security.roles_required
 
 .. autofunction:: flask_security.roles_accepted
@@ -256,6 +254,13 @@ sends the following signals.
 
     .. versionadded:: 3.4.0
 
+.. data:: user_unauthenticated
+
+   Sent when a user fails to authenticate. It is sent from the `default_unauthn_handler`.
+   It is passed the app (which is the sender).
+
+    .. versionadded:: 5.4.0
+
 .. data:: user_registered
 
    Sent when a user registers on the site. In addition to the app (which is the
@@ -369,4 +374,4 @@ sends the following signals.
 
     .. versionadded:: 5.0.0
 
-.. _Flask documentation on signals: https://flask.palletsprojects.com/en/2.0.x/signals/
+.. _Flask documentation on signals: https://flask.palletsprojects.com/en/2.3.x/signals/

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -537,9 +537,9 @@ tandem with Flask-Login, behaves as follows:
 
     * If authentication fails as the result of a `@login_required`, `@auth_required("session", "token")`,
       or `@token_auth_required` then if the request 'wants' a JSON
-      response, :meth:`.Security.render_json` is called with a 401 status code. If not
-      then flask_login.LoginManager.unauthorized() is called. By default THAT will redirect to
-      a login view.
+      response, :meth:`.Security.render_json` is called with a 401 status code.
+      If not then the `SECURITY_MSG_UNAUTHENTICATED` message is flashed and the request is
+      redirected to the `login` view.
 
     * If authentication fails as the result of a `@http_auth_required` or `@auth_required("basic")`
       then a 401 is returned along with the http header ``WWW-Authenticate`` set to
@@ -575,12 +575,12 @@ any `next` query param and in fact, an existing `?next=/xx` will override most o
 As a complex example consider an unauthenticated user accessing a `@auth_required` endpoint, and the user has
 two-factor authentication set up.:
 
-    * GET("/protected") - The `default_unauthn_handler` via Flask-Login will redirect to ``/login?next=/protected``
+    * GET("/protected") - The `default_unauthn_handler` will redirect to ``/login?next=/protected``
     * The login form/template will pick any `?next=/xx` argument off the request URL and append it to form action.
     * When the form is submitted if will do a POST("/login?next=/protected")
     * Assuming correct authentication, the system will send out a 2-factor code and redirect to ``/tf-verify?next=/protected``
     * The two_factor_validation_form/template also pulls any `?next=/xx` and appends to the form action.
     * When the `tf-validate` form is submitted it will do a POST("/tf-validate?next=/protected").
     * Assuming a correct code, the user is authenticated and is redirected. That redirection first
-      looks for a 'next' in the request.args then in request.form and finally will use the value of `SECURITY_POST_LOGIN_VIEW`.
+      looks for a 'next' in the request.args then in request.form and finally will use the value of :py:data:`SECURITY_POST_LOGIN_VIEW`.
       In this example it will find the ``next=/protected`` in the request.args and redirect to ``/protected``.

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -78,6 +78,7 @@ from .signals import (
     tf_security_token_sent,
     tf_disabled,
     user_authenticated,
+    user_unauthenticated,
     user_confirmed,
     user_registered,
     user_not_registered,

--- a/flask_security/signals.py
+++ b/flask_security/signals.py
@@ -15,6 +15,8 @@ signals = blinker.Namespace()
 
 user_authenticated = signals.signal("user-authenticated")
 
+user_unauthenticated = signals.signal("user-unauthenticated")
+
 user_registered = signals.signal("user-registered")
 
 # For cases of RETURN_GENERIC_RESPONSES with existing email/username

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -632,6 +632,26 @@ def propagate_next(
     raise ValueError("No valid redirect URL found - configuration error")
 
 
+def simplify_url(base_url: str, redirect_url: str) -> str:
+    """
+    Reduces the scheme and host from the redirect_url so it can be passed
+    as a relative URL in a query (e.g. next) param.
+    For this method we aren't worrying about a valid url (e.g. if it points
+    externally) - that will be handled by later requests.
+
+    :param base_url: The URL to simplify 'against'.
+    :param redirect_url: The URL to reduce.
+    """
+    b_url = urlsplit(base_url)
+    r_url = urlsplit(redirect_url)
+
+    if (not r_url.scheme or r_url.scheme == b_url.scheme) and (
+        not r_url.netloc or r_url.netloc == b_url.netloc
+    ):
+        return urlunsplit(("", "", r_url.path, r_url.query, r_url.fragment))
+    return redirect_url
+
+
 def get_config(app: "Flask") -> t.Dict[str, t.Any]:
     """Conveniently get the security configuration for the specified
     application without the annoying 'SECURITY_' prefix.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,6 @@ from flask_security import (
     auth_token_required,
     http_auth_required,
     get_request_attr,
-    login_required,
     roles_accepted,
     roles_required,
     permissions_accepted,
@@ -188,7 +187,7 @@ def app(request: pytest.FixtureRequest) -> "SecurityFixture":
         return render_template("index.html", content="Profile Page")
 
     @app.route("/post_login")
-    @login_required
+    @auth_required()
     def post_login():
         return render_template("index.html", content="Post Login")
 

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -203,7 +203,7 @@ def test_change_invalidates_session(app, client):
     # try to access protected endpoint - shouldn't work
     response = client.get("/profile")
     assert response.status_code == 302
-    assert "/login?next=%2Fprofile" in response.location
+    assert response.location == "/login?next=/profile"
 
 
 def test_change_updates_remember(app, client):
@@ -253,7 +253,7 @@ def test_change_invalidates_auth_token(app, client):
     # authtoken should now be invalid
     response = client.get("/token", headers=headers)
     assert response.status_code == 302
-    assert "/login?next=%2Ftoken" in response.location
+    assert response.location == "/login?next=/token"
 
 
 def test_auth_uniquifier(app):
@@ -432,7 +432,7 @@ def test_basic_change(app, client_nc, get_message):
         new_password_confirm="new strong password",
     )
     response = client_nc.post("/change", data=data)
-    assert b"You are not authenticated" in response.data
+    assert get_message("UNAUTHENTICATED") in response.data
     assert "WWW-Authenticate" in response.headers
 
     response = client_nc.post(

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -18,7 +18,7 @@ from tests.test_utils import authenticate, logout
     post_logout_view="/post_logout",
     default_http_auth_realm="Custom Realm",
 )
-def test_view_configuration(client):
+def test_view_configuration(client, get_message):
     response = client.get("/custom_login")
     assert b"<h1>Login</h1>" in response.data
 
@@ -35,7 +35,7 @@ def test_view_configuration(client):
         headers={"Authorization": "Basic %s" % base64.b64encode(b"joe@lp.com:bogus")},
     )
     assert response.status_code == 401
-    assert b"You are not authenticated" in response.data
+    assert get_message("UNAUTHENTICATED") in response.data
     assert "WWW-Authenticate" in response.headers
     assert 'Basic realm="Custom Realm"' == response.headers["WWW-Authenticate"]
 

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -280,7 +280,7 @@ def test_recover_invalidates_session(app, client):
     # try to access protected endpoint with old session - shouldn't work
     response = other_client.get("/profile")
     assert response.status_code == 302
-    assert "/login?next=%2Fprofile" in response.location
+    assert response.location == "/login?next=/profile"
 
 
 def test_login_form_description(sqlalchemy_app):

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -269,7 +269,7 @@ def test_two_factor(app, client):
     # make sure not logged in
     response = client.get("/profile")
     assert response.status_code == 302
-    assert "/login?next=%2Fprofile" in response.location
+    assert response.location == "/login?next=/profile"
 
 
 @pytest.mark.two_factor()

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -52,7 +52,7 @@ def test_default_unauthn(app, client):
 
     response = client.get("/profile")
     assert response.status_code == 302
-    assert "/login?next=%2Fprofile" in response.location
+    assert response.location == "/login?next=/profile"
 
     response = client.get("/profile", headers={"Accept": "application/json"})
     assert response.status_code == 401
@@ -68,7 +68,7 @@ def test_default_unauthn_bp(app, client):
 
     response = client.get("/profile")
     assert response.status_code == 302
-    assert "/myprefix/mylogin?next=%2Fprofile" in response.location
+    assert response.location == "/myprefix/mylogin?next=/profile"
 
 
 def test_default_unauthn_myjson(app, client):

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -931,7 +931,7 @@ def test_admin_setup_reset(app, client, get_message):
     # we shouldn't be logged in
     response = client.get("/profile", follow_redirects=False)
     assert response.status_code == 302
-    assert "/login?next=%2Fprofile" in response.location
+    assert response.location == "/login?next=/profile"
 
     # Use admin to setup gene's SMS/phone.
     with app.app_context():
@@ -1291,7 +1291,7 @@ def test_verify(app, client, get_message):
     # Test setup when re-authenticate required
     authenticate(client)
     response = client.get("tf-setup", follow_redirects=False)
-    assert "/verify?next=http://localhost/tf-setup" in response.location
+    assert response.location == "/verify?next=/tf-setup"
     logout(client)
 
     # Now try again - follow redirects to get to verify form
@@ -1318,7 +1318,7 @@ def test_verify(app, client, get_message):
             follow_redirects=False,
         )
         assert response.status_code == 302
-        assert response.location == "http://localhost/tf-setup"
+        assert response.location == "/tf-setup"
     assert get_message("REAUTHENTICATION_SUCCESSFUL") == flashes[0]["message"].encode(
         "utf-8"
     )

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -987,7 +987,7 @@ def test_verify(app, client, get_message):
     us_authenticate(client)
     response = client.get("us-setup", follow_redirects=False)
     verify_url = response.location
-    assert "/us-verify?next=http://localhost/us-setup" in verify_url
+    assert verify_url == "/us-verify?next=/us-setup"
     logout(client)
     us_authenticate(client)
 
@@ -1018,7 +1018,7 @@ def test_verify(app, client, get_message):
 
     code = sms_sender.messages[0].split()[-1].strip(".")
     response = client.post(verify_url, data=dict(passcode=code), follow_redirects=False)
-    assert response.location == "http://localhost/us-setup"
+    assert response.location == "/us-setup"
 
 
 def test_verify_json(app, client, get_message):

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -1292,7 +1292,7 @@ def test_verify(app, client, get_message):
 
     old_paa = reset_fresh(client, app.config["SECURITY_FRESHNESS"])
     response = client.get("fresh")
-    assert "/verify?next=http://localhost/fresh" in response.location
+    assert response.location == "/verify?next=/fresh"
     signin_options, response_url = _signin_start(
         client, endpoint="wan-verify?next=/fresh"
     )

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -35,7 +35,6 @@ from flask_security import (
     WebauthnUtil,
     auth_required,
     current_user,
-    login_required,
     SQLAlchemyUserDatastore,
 )
 from flask_security.models import fsqla_v3 as fsqla
@@ -256,7 +255,7 @@ def create_app():
 
     # Views
     @app.route("/")
-    @login_required
+    @auth_required()
     def home():
         return render_template_string(
             """


### PR DESCRIPTION
Flask-Security used to Flask-Login's unauthorized handler - now all that logic is in Flask-Security and Flask-Login will call our _unauthn_handler as part of @login_required.

Added new signal 'user-unauthenticated' to replace Flask-Login user-unauthorized signal.

The CHANGES.rst lists all the minor backwards compatibility concerns.

Many of the test changes resulted from Flask-Login using urlencode for 'next' query parameters - whereas Werkzeug uses quote which doesn't escape '/'s.

Also - now that our minimum Flask is higher - we can once again do assert 'equals' for response.location