### PR TITLE
Improve support for 2FA and unified signin method localizations.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 23.12.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,9 @@ Fixes
 - (:issue:`875`) user_datastore.create_user has side effects on mutable inputs (NoRePercussions)
 - (:pr:`878`) The long deprecated _unauthorized_callback/handler has been removed.
 - (:pr:`881`) No longer rely on Flask-Login.unauthorized callback. See below for implications.
+- (:pr:`855`) Improve translations for two-factor method selection (gissimo)
+- (:pr:`866`) Improve German translations (sr-verde)
+- (:pr:`xxx`) Improve method translations for unified signin and two factor. Remove support for Flask-Babelex.
 
 Notes
 ++++++
@@ -60,6 +63,7 @@ Backwards Compatibility Concerns
 
 - Flask-Security no longer configures anything related to Flask-Login's `fresh_login` logic.
   This shouldn't be used - instead use Flask-Security's :meth:`flask_security.auth_required` decorator.
+- Support for Flask-Babelex has been removed. Please convert to Flask-Babel.
 
 
 Version 5.3.2

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -290,8 +290,7 @@ appropriate input attributes can be set)::
 Localization
 ------------
 All messages, form labels, and form strings are localizable. Flask-Security uses
-`Flask-Babel <https://pypi.org/project/Flask-Babel/>`_ or
-`Flask-BabelEx <https://pythonhosted.org/Flask-BabelEx/>`_ to manage its messages.
+`Flask-Babel <https://pypi.org/project/Flask-Babel/>`_ to manage its messages.
 
 .. tip::
     Be sure to explicitly initialize your babel extension::
@@ -349,9 +348,6 @@ Then compile it with::
 Finally add your translations directory to your configuration::
 
     app.config["SECURITY_I18N_DIRNAME"] = ["builtin", "translations"]
-
-.. note::
-    This only works when using Flask-Babel since Flask-BabelEx doesn't support a list of translation directories.
 
 .. _emails_topic:
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -3,6 +3,9 @@
 Models
 ======
 
+Basics
+------
+
 Flask-Security assumes you'll be using libraries such as SQLAlchemy,
 MongoEngine, Peewee or PonyORM to define a `User`
 and `Role` data model. The fields on your models must follow a particular convention

--- a/flask_security/babel.py
+++ b/flask_security/babel.py
@@ -8,9 +8,7 @@
     :license: MIT, see LICENSE for more details.
 
     As of Flask-Babel 2.0.0 - it supports the Flask-BabelEx Domain extension - and it
-    is maintained. (Flask-BabelEx is no longer maintained). So we start with that,
-    then fall back to Flask-BabelEx, then fall back to a Null Domain
-    (just as Flask-Admin).
+    is maintained.  If that isn't installed fall back to a Null Domain
 """
 
 # flake8: noqa: F811
@@ -19,8 +17,6 @@ from collections.abc import Iterable
 import atexit
 from contextlib import ExitStack
 from importlib_resources import files, as_file
-
-import typing as t
 
 from flask import current_app
 from .utils import config_value as cv
@@ -31,91 +27,88 @@ def has_babel_ext():
     return current_app and "babel" in current_app.extensions
 
 
-_domain_cls = None
-
-
 try:
-    from flask_babel import Domain
-    import babel.support
+    from flask_babel import Domain, get_locale
+    from babel.support import LazyProxy
+    from babel.lists import format_list
 
-    _domain_cls = Domain
-    _dir_keyword = "translation_directories"
-except ImportError:  # pragma: no cover
-    try:
-        from flask_babelex import Domain
-        import babel.support
+    class FsDomain(Domain):
+        def __init__(self, app):
+            # By default, we use our packaged translations. However, we have to allow
+            # for app to add translation directories or completely override ours.
+            # Grabbing the packaged translations is a bit complex - so we use
+            # the keyword 'builtin' to mean ours.
+            cfdir = cv("I18N_DIRNAME", app=app)
+            if cfdir == "builtin" or (
+                isinstance(cfdir, Iterable) and "builtin" in cfdir
+            ):
+                fm = ExitStack()
+                atexit.register(fm.close)
+                ref = files("flask_security") / "translations"
+                path = fm.enter_context(as_file(ref))
+                if cfdir == "builtin":
+                    dirs = [str(path)]
+                else:
+                    dirs = [d if d != "builtin" else str(path) for d in cfdir]
+            else:
+                dirs = cfdir
+            super().__init__(
+                **{
+                    "domain": cv("I18N_DOMAIN", app=app),
+                    "translation_directories": dirs,
+                }
+            )
 
-        _domain_cls = Domain
-        _dir_keyword = "dirname"
-    except ImportError:
-        # Fake up just enough
-        class FsDomain:
-            def __init__(self, app):
-                pass
-
-            @staticmethod
-            def gettext(string, **variables):
+        def gettext(self, string, **variables):
+            if not has_babel_ext():
                 return string if not variables else string % variables
+            return super().gettext(string, **variables)
 
-            @staticmethod
-            def ngettext(singular, plural, num, **variables):
+        def ngettext(self, singular, plural, num, **variables):  # pragma: no cover
+            if not has_babel_ext():
                 variables.setdefault("num", num)
                 return (singular if num == 1 else plural) % variables
+            return super().ngettext(singular, plural, num, **variables)
 
-        def is_lazy_string(obj):
-            return False
+        @staticmethod
+        def format_list(lst, **kwargs):
+            # This is a Babel method
+            if not has_babel_ext():
+                return ", ".join(lst)
+            ll = get_locale()
+            return format_list(lst, locale=get_locale(), **kwargs)
 
-        def make_lazy_string(__func, msg):
-            return msg
+    def is_lazy_string(obj):
+        """Checks if the given object is a lazy string."""
+        return isinstance(obj, LazyProxy)
 
+    def make_lazy_string(__func, msg):
+        """Creates a lazy string by invoking func with args."""
+        return LazyProxy(__func, msg, enable_cache=False)
 
-if not t.TYPE_CHECKING:
-    # mypy doesn't understand all this
-    if _domain_cls:
-        from babel.support import LazyProxy
+except ImportError:  # pragma: no cover
+    # Fake up just enough
+    class FsDomain:  # type: ignore[no-redef]
+        def __init__(self, app):
+            pass
 
-        class FsDomain(_domain_cls):
-            def __init__(self, app):
-                # By default, we use our packaged translations. However, we have to allow
-                # for app to add translation directories or completely override ours.
-                # Grabbing the packaged translations is a bit complex - so we use
-                # the keyword 'builtin' to mean ours.
-                cfdir = cv("I18N_DIRNAME", app=app)
-                if cfdir == "builtin" or (
-                    isinstance(cfdir, Iterable) and "builtin" in cfdir
-                ):
-                    fm = ExitStack()
-                    atexit.register(fm.close)
-                    ref = files("flask_security") / "translations"
-                    path = fm.enter_context(as_file(ref))
-                    if cfdir == "builtin":
-                        dirs = [str(path)]
-                    else:
-                        dirs = [d if d != "builtin" else str(path) for d in cfdir]
-                else:
-                    dirs = cfdir
-                super().__init__(
-                    **{
-                        "domain": cv("I18N_DOMAIN", app=app),
-                        _dir_keyword: dirs,
-                    }
-                )
+        @staticmethod
+        def gettext(string, **variables):
+            return string if not variables else string % variables
 
-            def gettext(self, string, **variables):
-                if not has_babel_ext():
-                    return string if not variables else string % variables
-                return super().gettext(string, **variables)
+        @staticmethod
+        def ngettext(singular, plural, num, **variables):
+            variables.setdefault("num", num)
+            return (singular if num == 1 else plural) % variables
 
-            def ngettext(self, singular, plural, num, **variables):  # pragma: no cover
-                if not has_babel_ext():
-                    variables.setdefault("num", num)
-                    return (singular if num == 1 else plural) % variables
-                return super().ngettext(singular, plural, num, **variables)
+        @staticmethod
+        def format_list(lst, **kwargs):
+            # This is a Babel method
+            if not has_babel_ext():
+                return ", ".join(lst)
 
-        def is_lazy_string(obj):
-            """Checks if the given object is a lazy string."""
-            return isinstance(obj, LazyProxy)
+    def is_lazy_string(obj):
+        return False
 
-        def make_lazy_string(__func, msg):
-            """Creates a lazy string by invoking func with args."""
-            return LazyProxy(__func, msg, enable_cache=False)
+    def make_lazy_string(__func, msg):
+        return msg

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -521,6 +521,10 @@ _default_messages = {
         _("You successfully disabled two factor authorization."),
         "success",
     ),
+    "US_CURRENT_METHODS": (
+        _("Currently active sign in options: %(method_list)s."),
+        "info",
+    ),
     "US_METHOD_NOT_AVAILABLE": (_("Requested method is not valid"), "error"),
     "US_SETUP_EXPIRED": (
         _("Setup must be completed within %(within)s. Please start over."),

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -88,13 +88,15 @@ _default_field_labels = {
     "sms_method": _("Set up using SMS"),
 }
 
-_tf_methods_xlate = {
+# translated methods for two-factor and us-signin. keyed by form 'choices'
+_setup_methods_xlate = {
     "google_authenticator": _("Google Authenticator"),
-    "authenticator": _("Authenticator app"),
-    "email": _("Email"),
-    "mail": _("Email"),
+    "authenticator": _("authenticator"),
+    "email": _("email"),
+    "mail": _("email"),
     "sms": _("SMS"),
-    None: _("None"),
+    "password": _("password"),
+    None: _("none"),
 }
 
 

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -3,11 +3,13 @@
   On GET:
     available_methods: Value of SECURITY_US_ENABLED_METHODS
     active_methods: Which methods user has already set up
+    current_methods_msg: a translated string of already set up methods
     setup_methods: Which methods require a setup (e.g. password doesn't require any setup)
 
   On successful POST:
     available_methods: Value of SECURITY_US_ENABLED_METHODS
     active_methods: Which methods user has already set up
+    current_methods_msg: a translated string of already set up methods
     setup_methods: Which methods require a setup (e.g. password doesn't require any setup)
     chosen_method: which identity method was chosen (e.g. sms, authenticator)
     code_sent: Was a code sent?
@@ -31,14 +33,7 @@
     {{ render_form_errors(us_setup_form) }}
     {% if setup_methods %}
       <div class="fs-div">
-        {{ _fsdomain("Currently active sign in options:") }}
-        <em>
-          {% if active_methods %}
-            {{ ", ".join(active_methods) }}
-          {% else %}
-            None.
-          {% endif %}
-        </em>
+        {{ current_methods_msg }}
       </div>
       <h3>{{ us_setup_form.chosen_method.label }}</h3>
       <div class="fs-div">

--- a/flask_security/translations/af_ZA/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/af_ZA/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security-Too 4.0.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Michael Bosch <michael@lonelyviking.com>\n"
 "Language: af_ZA\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -330,103 +330,108 @@ msgstr "Gemerkde metode is nie geldig nie"
 msgid "You successfully disabled two factor authorization."
 msgstr "Jy het met sukses twee-faktoor verifikasie afgeskakel"
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr "Versoekte metode is nie geldig nie"
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr "Opstel moet voltooi wees binne %(within)s. Begin asseblief oor."
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr "Jy moet 'n valiede identiteit spesifiseer om in te teken"
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Gebruik hierdie kode om in te teken: %(code)s."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
-msgid "Nickname for new credential is required."
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -547,39 +552,43 @@ msgstr "Stel op deur midde van verifikasie toep (bv. google, lastpass, authy)"
 msgid "Set up using SMS"
 msgstr "Stel op deur midde van SMS"
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr "Beskikbare Metodes"
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -611,23 +620,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr "Kode of Wagwoord"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr "Via e-pos"
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "Via SMS"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -775,7 +784,7 @@ msgstr ""
 "e-pos adres gestuur is"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -794,13 +803,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -831,23 +840,19 @@ msgstr "Die kode vir verifikasie is gestuur na jou e-pos adres"
 msgid "A mail was sent to us in order to reset your application account"
 msgstr "'n E-pos is gestuur na ons om jou rekening te herstel"
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr "Wagwoordlose QRKode"
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1112,3 +1117,15 @@ msgstr ""
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
 #~ msgstr "Jy is nie geverifieer nie. Verskaf asseblief die korrekte getuigskrifte"
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
+#~ msgstr ""

--- a/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 3.1.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2019-06-16 00:12+0200\n"
 "Last-Translator: Orestes Sanchez <miceno.atreides@gmail.com>\n"
 "Language: ca_ES\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -332,103 +332,108 @@ msgstr ""
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
-msgid "Nickname for new credential is required."
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -549,39 +554,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr ""
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -613,23 +622,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -775,7 +784,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -794,13 +803,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -831,23 +840,19 @@ msgstr ""
 msgid "A mail was sent to us in order to reset your application account"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1117,4 +1122,16 @@ msgstr ""
 #~ "enviat noves instruccions a %(email)s."
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
+#~ msgstr ""
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
 #~ msgstr ""

--- a/flask_security/translations/da_DK/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/da_DK/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.1.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2017-03-23 14:04+0100\n"
 "Last-Translator: Leonhard Printz <leonhardprintz@protonmail.ch>\n"
 "Language: da_DK\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -330,103 +330,108 @@ msgstr ""
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
-msgid "Nickname for new credential is required."
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -547,39 +552,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr ""
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -611,23 +620,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -773,7 +782,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -792,13 +801,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -829,23 +838,19 @@ msgstr ""
 msgid "A mail was sent to us in order to reset your application account"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1115,4 +1120,16 @@ msgstr ""
 #~ "blevet sendt til %(email)s."
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
+#~ msgstr ""
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
 #~ msgstr ""

--- a/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.1.3\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2022-04-05 13:50+0200\n"
 "Last-Translator: Pascua Theus <pascua@identeco.de>\n"
 "Language: de_DE\n"
@@ -19,7 +19,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -345,31 +345,36 @@ msgstr "Ausgewählte Methode ist nicht gültig"
 msgid "You successfully disabled two factor authorization."
 msgstr "Zwei-Faktor-Authentisierung wurde deaktiviert"
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr "Angefragte Methode ist ungültig"
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 "Einrichtung muss innerhalb %(within)s abgeschlossen werden. Bitte neu "
 "beginnen."
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr "Single-User-Login erfolgreich eingerichtet"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr "Sie müssen eine gültige Identität auswählen, um sich anzumelden"
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Code zur Anmeldung: %(code)s"
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -378,76 +383,76 @@ msgstr ""
 "Der Benutzername muss mindestens %(min)d und darf nicht länger als "
 "%(max)d Zeichen sein."
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr "Der Benutzername enthält ungültige Zeichen."
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr "Der Benutzername darf nur aus Buchstaben und Ziffern bestehen"
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
 msgstr "Benutzername nicht angegeben"
 
-#: flask_security/core.py:549
+#: flask_security/core.py:553
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s ist bereits mit einem Benutzerkonto verknüpft."
 
-#: flask_security/core.py:553
+#: flask_security/core.py:557
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 "Der WebAuthn-Vorgang muss innerhalb von %(within)s beendet werden. Bitte "
 "erneut versuchen."
 
-#: flask_security/core.py:557
+#: flask_security/core.py:561
 msgid "Nickname for new credential is required."
 msgstr "Zum Setzen eines neuen Webauthn-Tokens ist ein Nickname erforderlich."
 
-#: flask_security/core.py:561
+#: flask_security/core.py:565
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s ist bereits mit einem Webauthn-Token verknüpft."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:569
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s ist für den aktuellen Benutzer nicht eingetragen."
 
-#: flask_security/core.py:569
+#: flask_security/core.py:573
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr "Der Token '%(name)s' wurde entfernt."
 
-#: flask_security/core.py:573
+#: flask_security/core.py:577
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr "Der WebAuthn-Token '%(name)s' wurde hinzugefügt."
 
-#: flask_security/core.py:577
+#: flask_security/core.py:581
 msgid "WebAuthn credential id already registered."
 msgstr "WebAuthn-Token-ID wurde bereits eingetragen."
 
-#: flask_security/core.py:581
+#: flask_security/core.py:585
 msgid "Unregistered WebAuthn credential id."
 msgstr "Nicht eingetragene WebAuthn-Token-ID."
 
-#: flask_security/core.py:585
+#: flask_security/core.py:589
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "WebAuthn-Token gehört zu keinem Benutzer."
 
-#: flask_security/core.py:589
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "Konnte WebAuthn-Token nicht verifizieren: %(cause)s."
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr "WebAuthn-Token ist für diese Verwendung nicht eingetragen."
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr "Benutzerhandle des WebAuthn-Token stimmt nicht überein."
 
@@ -568,39 +573,43 @@ msgstr "Einrichtung via Authentisierungs-App"
 msgid "Set up using SMS"
 msgstr "Einrichtung via SMS"
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr "Verfügbare Methoden"
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr "Deaktiviere Zwei-Faktor-Authentisierung"
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr "Probleme beim Zugriff auf Ihr Konto / Smartphone verloren?"
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr "Kontaktiere einen Administrator"
 
@@ -632,23 +641,23 @@ msgstr "Sende code per E-Mail"
 msgid "Use previously downloaded recovery code"
 msgstr "Zuvor heruntergeladenen Wiederherstellungscode verwenden"
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr "Code oder Passwort"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr "Via E-Mail"
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "Via SMS"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr "Richte weitere Single-User-Login-Option ein"
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr "Löschen der aktivierten Anmeldeoption"
 
@@ -800,7 +809,7 @@ msgstr ""
 "Ihre E-Mail-Adresse geschickt haben"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -822,13 +831,13 @@ msgid "WebAuthn"
 msgstr "WebAuthn"
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr "Diese Anwendung unterstützt WebAuthn-Sicherheitsschlüssel."
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Sie können diese hier einrichten."
@@ -863,23 +872,19 @@ msgstr ""
 "Wir haben eine E-Mail von Ihnen erhalten, um Ihnen bei der "
 "Wiederherstellung Ihres Kontos zu unterstützen"
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Single-User-Login einrichten"
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr "Mögliche Anmeldemöglichkeiten:"
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr "Passwortloser QR-Code"
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr "Keine Methode ausgewählt – keine Einrichtung erfolgt"
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr "Geben Sie den Code hier ein, um die Einrichtung abzuschließen"
 
@@ -1178,3 +1183,15 @@ msgstr ""
 #~ msgstr ""
 #~ "Sie sind nicht angemeldet. Bitte geben"
 #~ " Sie die korrekten Zugangsdaten ein."
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
+#~ msgstr "Mögliche Anmeldemöglichkeiten:"

--- a/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 5.4.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2023-11-27 10:01+0100\n"
 "Last-Translator: Giorgio Stampa <giorgio.stampa@sanofi.com>\n"
 "Language: es_ES\n"
@@ -19,7 +19,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -341,31 +341,36 @@ msgstr "El método marcado no es válido"
 msgid "You successfully disabled two factor authorization."
 msgstr "Has deshabilitado la autorización de dos factores."
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr "El método solicitado no es válido"
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 "La configuración debe completarse dentro de %(within)s. Por favor vuelve "
 "a empezar."
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr "El inicio de sesión unificado se ha configurado correctamente"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr "Debes especificar una identidad válida para iniciar sesión"
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Utiliza este código para iniciar sesión: %(code)s."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -374,76 +379,76 @@ msgstr ""
 "El nombre de usuario debe tener al menos %(min)d caracteres y menos de "
 "%(max)d caracteres"
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr "El nombre de usuario contiene caracteres no admitidos"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr "El nombre de usuario solo puede contener letras y números"
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
 msgstr "Nombre de usuario no proporcionado"
 
-#: flask_security/core.py:549
+#: flask_security/core.py:553
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s ya está asociado a una cuenta."
 
-#: flask_security/core.py:553
+#: flask_security/core.py:557
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 "La operación de WebAuthn debe completarse dentro de %(within)s. Por favor"
 " vuelve a empezar."
 
-#: flask_security/core.py:557
+#: flask_security/core.py:561
 msgid "Nickname for new credential is required."
 msgstr "Se requiere un nombre para la nueva credencial."
 
-#: flask_security/core.py:561
+#: flask_security/core.py:565
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s ya está asociado a una credencial."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:569
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s no registrado con el usuario actual."
 
-#: flask_security/core.py:569
+#: flask_security/core.py:573
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr "Se ha eliminado la credencial WebAuthn con nombre: %(name)s"
 
-#: flask_security/core.py:573
+#: flask_security/core.py:577
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr "Se ha añadido la credencial WebAuthn con nombre: %(name)s"
 
-#: flask_security/core.py:577
+#: flask_security/core.py:581
 msgid "WebAuthn credential id already registered."
 msgstr "Identificador de credencial de WebAuthn ya registrado."
 
-#: flask_security/core.py:581
+#: flask_security/core.py:585
 msgid "Unregistered WebAuthn credential id."
 msgstr "Identificador de credencial de WebAuthn no registrado."
 
-#: flask_security/core.py:585
+#: flask_security/core.py:589
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "La credencial WebAuthn no pertenece a ningún usuario."
 
-#: flask_security/core.py:589
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "No se pudo verificar la credencial WebAuthn: %(cause)s."
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr "Credencial no registrada para este uso (primaria o secundaria)"
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr "La credencial de usuario no coincide"
 
@@ -566,39 +571,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr "Configurar con SMS"
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr "Google Authenticator"
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
-msgstr "Aplicación de autenticación"
+#: flask_security/forms.py:94
+msgid "authenticator"
+msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr "Correo electrónico"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
+msgstr ""
 
-#: flask_security/forms.py:96
+#: flask_security/forms.py:97
 msgid "SMS"
 msgstr "SMS"
 
-#: flask_security/forms.py:97
-msgid "None"
-msgstr "Ninguno"
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr "Métodos disponibles"
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr "Deshabilitar la autenticación de dos factores"
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr "¿Problemas para acceder a tu cuenta/has perdido tu dispositivo móvil?"
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr "Contactar con el administrador"
 
@@ -630,23 +639,23 @@ msgstr "Enviar el código por correo electrónico"
 msgid "Use previously downloaded recovery code"
 msgstr "Usar código de recuperación descargado anteriormente"
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr "Código o contraseña"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr "Vía correo electrónico"
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "Vía SMS"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr "Configurar una opción de inicio de sesión adicional"
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr "Eliminar la opción de inicio de sesión activa"
 
@@ -798,7 +807,7 @@ msgstr ""
 "correo electrónico"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -820,13 +829,13 @@ msgid "WebAuthn"
 msgstr "WebAuthn"
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr "Esta aplicación es compatible con las claves de seguridad de WebAuthn."
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Se pueden configurar aquí."
@@ -859,23 +868,19 @@ msgstr ""
 "Se nos envió un correo electrónico para restablecer tu cuenta de "
 "aplicación"
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Configurar el inicio de sesión unificado"
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr "Opciones de inicio de sesión activas actualmente:"
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr "Código QR sin contraseña"
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr "No se ha habilitado ningún método, no hay nada que configurar"
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr "Introduce el código aquí para completar la configuración"
 
@@ -1085,3 +1090,15 @@ msgstr ""
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
 #~ msgstr "No estás autenticado. Proporciona las credenciales correctas."
+
+#~ msgid "Authenticator app"
+#~ msgstr "Aplicación de autenticación"
+
+#~ msgid "Email"
+#~ msgstr "Correo electrónico"
+
+#~ msgid "None"
+#~ msgstr "Ninguno"
+
+#~ msgid "Currently active sign in options:"
+#~ msgstr "Opciones de inicio de sesión activas actualmente:"

--- a/flask_security/translations/eu_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/eu_ES/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2020-11-28 13:41+0100\n"
 "Last-Translator: Martin Mozos <martinmozos@gmail.com>\n"
 "Language: eu_ES\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -328,29 +328,34 @@ msgstr "Markatutako metodoak ez du balio"
 msgid "You successfully disabled two factor authorization."
 msgstr "Bi faktoreren baimena behar bezala desgaitu duzu."
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr "Eskatutako metodoak ez du balio"
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr "Konfigurazioa %(within)s barruan osatu behar da. Mesedez, berriro hasi."
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr "Bateratutako saio hasierarako konfigurazioa ongi egin da"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr "Saioa hasteko identitate baliagarria zehaztu behar duzu"
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Erabili kode hau saioa hasteko: %(code)s."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -359,74 +364,74 @@ msgstr ""
 "Erabiltzaile izenak gutxienez %(min)d karaktere eta %(max)d karaktere "
 "baino gutxiago izan behar ditu"
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr "Erabiltzaile izenak legez kanpoko karaktereak ditu"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr "Erabiltzaile izenak letrak eta zenbakiak soilik izan ditzake"
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
 msgstr "Erabiltzaile izena ez da eman"
 
-#: flask_security/core.py:549
+#: flask_security/core.py:553
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s dagoeneko kontu batekin lotuta dago."
 
-#: flask_security/core.py:553
+#: flask_security/core.py:557
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:557
-msgid "Nickname for new credential is required."
-msgstr ""
-
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -549,39 +554,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr "Konfiguratu SMS bidez"
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr "Eskuragarri dauden metodoak"
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -613,23 +622,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr "Kodea edo pasahitza"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr "Posta elektronikoaren bidez"
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "SMS bidez"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -777,7 +786,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr "Saioa hasten bukatzeko, idatzi zure posta elektronikora bidalitako kodea"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -798,13 +807,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -835,23 +844,19 @@ msgstr "Autentifikaziorako kodea zure helbide elektronikora bidali da"
 msgid "A mail was sent to us in order to reset your application account"
 msgstr "Zure eskaera kontua berrezartzeko mezu elektroniko bat bidali ziguten"
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr "Pasahitzik gabeko QR kodea"
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr "Ez da metodorik gaitu, ez dago ezer konfiguratzeko"
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1115,3 +1120,15 @@ msgstr ""
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
 #~ msgstr "Ez zaude autentifikatuta. Mesedez, eman egiaztagiri zuzenak."
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
+#~ msgstr ""

--- a/flask_security/translations/flask_security.pot
+++ b/flask_security/translations/flask_security.pot
@@ -9,14 +9,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 5.4.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -323,103 +323,108 @@ msgstr ""
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
-msgid "Nickname for new credential is required."
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -540,39 +545,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr ""
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -604,23 +613,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -766,7 +775,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -785,13 +794,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -822,23 +831,19 @@ msgstr ""
 msgid "A mail was sent to us in order to reset your application account"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 

--- a/flask_security/translations/fr_FR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/fr_FR/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2017-06-08 10:13+0200\n"
 "Last-Translator: Alexandre Bulté <alexandre@bulte.net>\n"
 "Language: fr_FR\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -330,103 +330,108 @@ msgstr ""
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr "Options de connexion actuellement actives : %(method_list)s."
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr "Configuration de la connexion unifiée réussie"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr "Vous devez spécifier une identité valide pour vous connecter"
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgstr ""
+
+#: flask_security/core.py:561
 msgid "Nickname for new credential is required."
 msgstr "Le surnom du nouvel identifiant est requis."
 
-#: flask_security/core.py:561
+#: flask_security/core.py:565
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:569
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:573
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:577
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:581
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:585
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:589
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr "Identifiant non enregistré pour cet usage (premier ou secondaire)"
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -549,39 +554,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr "Configurer par SMS"
 
-#: flask_security/forms.py:92
-msgid "Google Authenticator"
-msgstr ""
-
 #: flask_security/forms.py:93
-msgid "Authenticator app"
-msgstr ""
+msgid "Google Authenticator"
+msgstr "Authentificateur Google"
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
+#: flask_security/forms.py:94
+msgid "authenticator"
+msgstr "authentificateur"
 
-#: flask_security/forms.py:96
-msgid "SMS"
-msgstr ""
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
+msgstr "e-mail"
 
 #: flask_security/forms.py:97
-msgid "None"
-msgstr ""
+msgid "SMS"
+msgstr "SMS"
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr "mot de passe"
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr "aucune"
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr "Méthodes disponibles"
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr "Désactiver l'authentification à deux facteurs"
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -613,23 +622,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr "Code ou mot de passe"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "Par SMS"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr "Configurer une option de connexion supplémentaire"
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -772,7 +781,7 @@ msgstr ""
 #: flask_security/templates/security/two_factor_setup.html:28
 #, python-format
 msgid "Currently setup two-factor method: %(method)s"
-msgstr ""
+msgstr "Méthode à deux facteurs actuellement configurée : %(method)s"
 
 #: flask_security/templates/security/two_factor_setup.html:36
 msgid "To complete logging in, please enter the code sent to your mail"
@@ -781,7 +790,7 @@ msgstr ""
 "messagerie"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -800,13 +809,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr "Cette application prend en charge les clés de sécurité WebAuthn."
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Vous pouvez les paramétrer ici."
@@ -818,16 +827,16 @@ msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
 msgid "Two-factor Authentication"
-msgstr ""
+msgstr "Authentification à deux facteurs"
 
 #: flask_security/templates/security/two_factor_verify_code.html:7
 #, python-format
 msgid "Please enter your authentication code generated via: %(method)s"
-msgstr ""
+msgstr "Veuillez saisir votre code d'authentification généré via: %(method)s"
 
 #: flask_security/templates/security/two_factor_verify_code.html:10
 msgid "enter code"
-msgstr ""
+msgstr "entrez le code"
 
 #: flask_security/templates/security/two_factor_verify_code.html:18
 msgid "The code for authentication was sent to your email address"
@@ -837,23 +846,19 @@ msgstr ""
 msgid "A mail was sent to us in order to reset your application account"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Configurer la connexion unifiée"
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1047,12 +1052,6 @@ msgstr ""
 #~ msgid "No password is set for this user"
 #~ msgstr "Cet utilisateur n'a pas de mot de passe"
 
-#~ msgid "Invalid Token"
-#~ msgstr ""
-
-#~ msgid "Your token has been confirmed"
-#~ msgstr ""
-
 #~ msgid ""
 #~ "Open an authenticator app on your "
 #~ "device and scan the following QRcode "
@@ -1086,6 +1085,3 @@ msgstr ""
 #~ " email dans l'intervalle requis "
 #~ "(%(within)s)De nouvelles instructions ont été"
 #~ " envoyées à %(email)s."
-
-#~ msgid "You are not authenticated. Please supply the correct credentials."
-#~ msgstr ""

--- a/flask_security/translations/hu_HU/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/hu_HU/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: hu_HU\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -336,29 +336,34 @@ msgstr "A megjelölt metódus nem érvényes"
 msgid "You successfully disabled two factor authorization."
 msgstr "Sikeresen letiltotta a kétfaktoros hitelesítést."
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr "A kért metódus nem érvényes"
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr "A telepítést %(within)s időn belül be kell fejezni. Kezdje újra."
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr "Az egységes bejelentkezés beállítása sikeres"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr "A bejelentkezéshez érvényes azonositót kell megadnia"
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Használja ezt a kódot a bejelentkezéshez: %(code)s."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -367,80 +372,80 @@ msgstr ""
 "A felhasználónévnek legalább %(min)d karakterből és kevesebb mint %(max)d"
 " karakterből kell állnia"
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr "A felhasználónév illegális karaktereket tartalmaz"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr "A felhasználónév csak betűket és számokat tartalmazhat"
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
 msgstr "A felhasználónév nincs megadva"
 
-#: flask_security/core.py:549
+#: flask_security/core.py:553
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s már hozzá van rendelve egy fiókhoz."
 
-#: flask_security/core.py:553
+#: flask_security/core.py:557
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr "A WebAuthn műveletet %(within)s időn belül be kell fejezni. Kezdje újra."
 
-#: flask_security/core.py:557
+#: flask_security/core.py:561
 msgid "Nickname for new credential is required."
 msgstr "Az új hitelesítő adatokhoz becenév szükséges."
 
-#: flask_security/core.py:561
+#: flask_security/core.py:565
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s már hozzá van rendelve egy hitelesítő adathoz."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:569
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s nincs regisztrálva az aktuális felhasználónál."
 
-#: flask_security/core.py:569
+#: flask_security/core.py:573
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 "A WebAuthn hitelesítő adatok sikeresen törölve a következő névvel: "
 "%(name)s"
 
-#: flask_security/core.py:573
+#: flask_security/core.py:577
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 "Sikeresen hozzáadva a WebAuthn hitelesítő adatot a következő névvel: "
 "%(name)s"
 
-#: flask_security/core.py:577
+#: flask_security/core.py:581
 msgid "WebAuthn credential id already registered."
 msgstr "A WebAuthn hitelesítő adatazonosítója már regisztrálva."
 
-#: flask_security/core.py:581
+#: flask_security/core.py:585
 msgid "Unregistered WebAuthn credential id."
 msgstr "Nem regisztrált WebAuthn hitelesítő adat azonosítója."
 
-#: flask_security/core.py:585
+#: flask_security/core.py:589
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "A WebAuthn hitelesítő adatok nem tartoznak egyetlen felhasználóhoz sem."
 
-#: flask_security/core.py:589
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "Nem sikerült ellenőrizni a WebAuthn hitelesítő adatait: %(cause)s."
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 "A hitelesítő adat nincs regisztrálva ehhez a felhasználáshoz (első vagy "
 "másodlagos)"
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -561,39 +566,43 @@ msgstr "Beállítás hitelesítő alkalmazás segítségével (pl. google, lastp
 msgid "Set up using SMS"
 msgstr "Beállítás SMS-sel"
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr "Elérhető módszerek"
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr "Kétfaktoros hitelesítés letiltása"
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -625,23 +634,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr "Kód vagy jelszó"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr "E-mailben"
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "SMS-ben"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr "Kiegészítő bejelentkezési lehetőség beállítása"
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr "Az aktív bejelentkezési opció törlése"
 
@@ -789,7 +798,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr "A bejelentkezés befejezéséhez adja meg az e-mail címére küldött kódot"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -811,13 +820,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr "Ez az alkalmazás támogatja a WebAuthn biztonsági kulcsokat."
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Itt állíthatja be."
@@ -850,23 +859,19 @@ msgstr "A hitelesítési kódot elküldtük az Ön e-mail címére"
 msgid "A mail was sent to us in order to reset your application account"
 msgstr "E-mailt küldtünk nekünk az alkalmazás fiókjának visszaállítása érdekében"
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Egységes bejelentkezés beállítása"
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr "Jelszó nélküli QRCode"
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr "Nincs engedélyezve metódus – nincs mit beállítani"
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr "A beállítás befejezéséhez írja be ide a kódot"
 
@@ -1088,3 +1093,15 @@ msgstr ""
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
 #~ msgstr "Ön nincs hitelesítve. Kérjük, adja meg a megfelelő hitelesítő adatokat."
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
+#~ msgstr ""

--- a/flask_security/translations/hy_AM/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/hy_AM/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2020-12-01 11:47+0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: hy_AM\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -334,103 +334,108 @@ msgstr "Նշված տարբերակը վավեր չէ"
 msgid "You successfully disabled two factor authorization."
 msgstr "Դուք հաջողությամբ անջատել եք երկու գործոնի թույլտվությունը"
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr "Հայցվող մեթոդը վավեր չէ"
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr "Կարգավորումը պետք է ավարտվի %(within)s ընթացքում։ Խնդրում ենք նորից սկսել։"
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr "Միասնական մուտքի տեղադրումը հաջող է"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr "Մուտք գործելու համար պետք է նշեք վավեր ինքնություն"
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Մուտքի համար օգտագործեք այս ծածկագիրը․ %(code)s։"
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr "Օգտանունը պետք է լինի առնվազն %(min)d նիշ և %(max)d նիշից պակաս"
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr "Օգտանունը պարունակում է անօրինական նիշեր"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr "Օգտանունը կարող է պարունակել միայն տառեր և թվեր"
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
 msgstr "Օգտանուն չի տրամադրվել"
 
-#: flask_security/core.py:549
+#: flask_security/core.py:553
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s արդեն կապված է օգտահաշվի հետ:"
 
-#: flask_security/core.py:553
+#: flask_security/core.py:557
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr "WebAuthn գործողությունը պետք է ավարտվի %(within)s։ Խնդրում եմ սկսել նորից:"
 
-#: flask_security/core.py:557
+#: flask_security/core.py:561
 msgid "Nickname for new credential is required."
 msgstr "Նոր հավատարմագրի մականունը պարտադիր է:"
 
-#: flask_security/core.py:561
+#: flask_security/core.py:565
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s-ն արդեն կապված է հավատարմագրի հետ:"
 
-#: flask_security/core.py:565
+#: flask_security/core.py:569
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s գրանցված չէ ընթացիկ օգտատիրոջ մոտ:"
 
-#: flask_security/core.py:569
+#: flask_security/core.py:573
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr "%(name)s անունով WebAuthn հավատարմագիրը հաջողությամբ ջնջվեց"
 
-#: flask_security/core.py:573
+#: flask_security/core.py:577
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr "%(name)s անունով WebAuthn հավատարմագիրը հաջողությամբ ավելացվեց"
 
-#: flask_security/core.py:577
+#: flask_security/core.py:581
 msgid "WebAuthn credential id already registered."
 msgstr "WebAuthn հավատարմագրի ID-ն արդեն գրանցված է"
 
-#: flask_security/core.py:581
+#: flask_security/core.py:585
 msgid "Unregistered WebAuthn credential id."
 msgstr "Չգրանցված WebAuthn հավատարմագրի ID:"
 
-#: flask_security/core.py:585
+#: flask_security/core.py:589
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "WebAuthn հավատարմագիրը չի պատկանում որևէ օգտվողի:"
 
-#: flask_security/core.py:589
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "Չհաջողվեց հաստատել WebAuthn հավատարմագիրը՝ %(cause)s:"
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr "Հավատարմագրերը գրանցված չեն այս օգտագործման համար (առաջին կամ երկրորդական)"
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr "Հավատարմագրերի օգտատիրոջ կապը չի համընկնում"
 
@@ -553,39 +558,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr "Կարգավորեք օգտագործելով SMS"
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr "Առկա տարբերակներ"
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr "Անջատել երկու գործոնով նույնականացումը"
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -617,23 +626,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr "Ծածկագիր կամ Գաղտնաբառ"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr "Էլ․ Փոստով"
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "SMS հաղորդագրությամբ"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr "Կարգավորեք մուտքի լրացուցիչ տարբերակ"
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr "Ջնջել ակտիվ մուտքի տարբերակը"
 
@@ -785,7 +794,7 @@ msgstr ""
 "ծածկագիրը"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -806,13 +815,13 @@ msgid "WebAuthn"
 msgstr "WebAuthn"
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr "Այս հավելվածն օժանդակում է WebAuthn անվտանգության բանալիներին:"
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Դուք կարող եք դրանք կարգավորել այստեղ:"
@@ -845,23 +854,19 @@ msgstr "Նույնականացման ծածկագիրն ուղարկվել է Ձ
 msgid "A mail was sent to us in order to reset your application account"
 msgstr "Ձեր օգտահաշվի կիրառումը վերականգնելու համար մեզ նամակ է ուղարկվել"
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Կարգավորեք միասնական մուտքը"
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr "Ներկայում ակտիվ մուտքի տարբերակներ."
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr "Առանց գաղտնաբառի QRcode"
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr "Ոչ մի տարբերակի հնարավորություն տրված չէ ֊ կարգաբերելու կարիք չկա"
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr "Մուտքագրեք ծածկագիրն այստեղ՝ կարգավորումն ավարտելու համար"
 
@@ -1061,3 +1066,15 @@ msgstr "Խնդրում ենք վերսկսել գրանցման գործընթա
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
 #~ msgstr "Դուք նույնականացված չեք: Խնդրում ենք մուտքագրել ճիշտ տվյալներ։"
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
+#~ msgstr "Ներկայում ակտիվ մուտքի տարբերակներ."

--- a/flask_security/translations/is_IS/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/is_IS/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2022-04-23 17:04+0000\n"
 "Last-Translator: \n"
 "Language: is_IS\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -330,29 +330,34 @@ msgstr ""
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -361,74 +366,74 @@ msgstr ""
 "Notendanafnið verður að vera að minnsta kosti %(min)d stafir að lengd og "
 "styttra en %(max)d stafir"
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr "Notendanafnið inniheldur óleyfileg tákn"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr "Notendanafnið má eingöngu innihalda bókstafi og tölustafi"
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
 msgstr "Notendanafn var ekki gefið upp"
 
-#: flask_security/core.py:549
+#: flask_security/core.py:553
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:557
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:557
-msgid "Nickname for new credential is required."
-msgstr ""
-
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -549,39 +554,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr ""
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -613,23 +622,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr "Kóði eða lykilorð"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr "Með tölvupósti"
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "Með SMS skilaboði"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -775,7 +784,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -794,13 +803,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -831,23 +840,19 @@ msgstr ""
 msgid "A mail was sent to us in order to reset your application account"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1074,4 +1079,16 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
+#~ msgstr ""
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
 #~ msgstr ""

--- a/flask_security/translations/it_IT/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/it_IT/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 5.4.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2023-11-27 10:01+0100\n"
 "Last-Translator: Giorgio Stampa <giorgio.stampa@sanofi.com>\n"
 "Language: it_IT\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -338,31 +338,36 @@ msgstr "Il metodo selezionato non è valido"
 msgid "You successfully disabled two factor authorization."
 msgstr "Hai disabilitato l'autorizzazione a due fattori."
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr "Il metodo richiesto non è valido"
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 "La configurazione deve essere completata entro %(within)s. Per favore "
 "ricomincia da capo."
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr "Configurazione dell'accesso unificato riuscita"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr "Devi specificare un'identità valida per accedere"
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Utilizza questo codice per accedere: %(code)s."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -371,76 +376,76 @@ msgstr ""
 "Il nome utente deve essere composto da almeno %(min)d caratteri e meno di"
 " %(max)d caratteri"
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr "Il nome utente contiene caratteri non ammessi"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr "Il nome utente può contenere solo lettere e numeri"
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
 msgstr "Nome utente non fornito"
 
-#: flask_security/core.py:549
+#: flask_security/core.py:553
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s è già associato ad un account."
 
-#: flask_security/core.py:553
+#: flask_security/core.py:557
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 "L'operazione WebAuthn deve essere completata entro %(within)s. Per favore"
 " ricomincia da capo."
 
-#: flask_security/core.py:557
+#: flask_security/core.py:561
 msgid "Nickname for new credential is required."
 msgstr "Il nome per la nuova credenziale è obbligatorio."
 
-#: flask_security/core.py:561
+#: flask_security/core.py:565
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s è già associato ad una credenziale."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:569
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s non registrato con l'utente attuale."
 
-#: flask_security/core.py:569
+#: flask_security/core.py:573
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr "Credenziale WebAuthn con nome: %(name)s eliminata"
 
-#: flask_security/core.py:573
+#: flask_security/core.py:577
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr "Credenziale WebAuthn con nome: %(name)s aggiunta"
 
-#: flask_security/core.py:577
+#: flask_security/core.py:581
 msgid "WebAuthn credential id already registered."
 msgstr "Identificativo di credenziale WebAuthn già registrato."
 
-#: flask_security/core.py:581
+#: flask_security/core.py:585
 msgid "Unregistered WebAuthn credential id."
 msgstr "Identificativo di credenziale WebAuthn non registrato."
 
-#: flask_security/core.py:585
+#: flask_security/core.py:589
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "La credenziale WebAuthn non appartiene a nessun utente."
 
-#: flask_security/core.py:589
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "Impossibile verificare la credenziale WebAuthn: %(cause)s."
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr "Credenziale non registrata per questo uso (primaria o secondaria)"
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr "La credenziale dell'utente non corrisponde"
 
@@ -563,39 +568,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr "Configurazione tramite SMS"
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr "Google Authenticator"
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
-msgstr "App di autenticazione"
+#: flask_security/forms.py:94
+msgid "authenticator"
+msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr "Email"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
+msgstr ""
 
-#: flask_security/forms.py:96
+#: flask_security/forms.py:97
 msgid "SMS"
 msgstr "SMS"
 
-#: flask_security/forms.py:97
-msgid "None"
-msgstr "Nessuno"
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr "Metodi disponibili"
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr "Disabilitare l'autenticazione a due fattori"
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr "Problemi di accesso al tuo account?/Dispositivo mobile smarrito?"
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr "Contatta l'amministratore"
 
@@ -627,23 +636,23 @@ msgstr "Invia codice tramite email"
 msgid "Use previously downloaded recovery code"
 msgstr "Utilizza codice di ripristino scaricato in precedenza"
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr "Codice o password"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr "Tramite email"
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "Tramite SMS"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr "Imposta opzione di accesso aggiuntiva"
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr "Elimina l'opzione di accesso attiva"
 
@@ -793,7 +802,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr "Per completare l'accesso, inserisci il codice inviato alla tua email"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -815,13 +824,13 @@ msgid "WebAuthn"
 msgstr "WebAuthn"
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr "Questa applicazione supporta le chiavi di sicurezza WebAuthn."
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Si possono impostare qui."
@@ -852,23 +861,19 @@ msgstr "Il codice per l'autenticazione è stato inviato al tuo indirizzo email"
 msgid "A mail was sent to us in order to reset your application account"
 msgstr "Ci è stata inviata un'email per reimpostare l'account dell'applicazione"
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Configurazione dell'accesso unificato"
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr "Opzioni di accesso attualmente attive:"
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr "Codice QR senza password"
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr "Nessun metodo è stato abilitato - niente da impostare"
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr "Inserisci qui il codice per completare la configurazione"
 
@@ -1073,3 +1078,15 @@ msgstr ""
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
 #~ msgstr "Non sei autenticato. Fornisci le credenziali corrette."
+
+#~ msgid "Authenticator app"
+#~ msgstr "App di autenticazione"
+
+#~ msgid "Email"
+#~ msgstr "Email"
+
+#~ msgid "None"
+#~ msgstr "Nessuno"
+
+#~ msgid "Currently active sign in options:"
+#~ msgstr "Opzioni di accesso attualmente attive:"

--- a/flask_security/translations/ja_JP/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ja_JP/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2018-01-25 14:12+0900\n"
 "Last-Translator: \n"
 "Language: ja\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -325,103 +325,108 @@ msgstr ""
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
-msgid "Nickname for new credential is required."
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -542,39 +547,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr ""
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -606,23 +615,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -768,7 +777,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -787,13 +796,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -824,23 +833,19 @@ msgstr ""
 msgid "A mail was sent to us in order to reset your application account"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1104,4 +1109,16 @@ msgstr ""
 #~ msgstr "%(within)s以内にメール アドレスが検証されませんでした。新しい検証手順を %(email)s に送信しました。"
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
+#~ msgstr ""
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
 #~ msgstr ""

--- a/flask_security/translations/nl_NL/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/nl_NL/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2017-05-01 17:52+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: nl_NL\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -331,104 +331,109 @@ msgstr "De gemarkeerde methode is niet valide"
 msgid "You successfully disabled two factor authorization."
 msgstr "U heeft succesvol Dubbele Authenticatie uitgeschakeld."
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 #, fuzzy
 msgid "Requested method is not valid"
 msgstr "De gemarkeerde methode is niet valide"
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
-msgid "Nickname for new credential is required."
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -550,39 +555,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr ""
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -614,23 +623,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -780,7 +789,7 @@ msgstr ""
 "gezonden invoeren"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -799,13 +808,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -836,23 +845,19 @@ msgstr "The code voor authenticatie is naar uw e-mail adres verzonden"
 msgid "A mail was sent to us in order to reset your application account"
 msgstr "Een bericht is naar uw e-mail adres verzonden om uw account te herstellen"
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1131,3 +1136,15 @@ msgstr ""
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
 #~ msgstr "U bent niet aangemeld. Voer alstublieft de juiste gegevens in."
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
+#~ msgstr ""

--- a/flask_security/translations/pl_PL/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/pl_PL/LC_MESSAGES/flask_security.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2020-11-28 10:19+0100\n"
 "Last-Translator: Kamil Daniewski <kamil.daniewski@gmail.com>\n"
 "Language: pl_PL\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -332,105 +332,110 @@ msgstr "Wybrana metoda jest niewłaściwa"
 msgid "You successfully disabled two factor authorization."
 msgstr "Pomyślnie wyłączyłeś logowanie dwuskładnikowe."
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr "Żądana metoda jest niewłaściwa"
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 "Ustawienie musi zostać ukończone w ciągu %(within)s. Prosimy zacząć "
 "ponownie."
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr "Ujednolicone logowanie przebiegło pomyślnie"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr "Musisz ustawić prawidłowy identyfikator, aby się zalogować"
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Użyj tego kodu, aby się zalogować: %(code)s."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
-msgid "Nickname for new credential is required."
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -553,39 +558,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr "Ustaw przy pomocy wiadomości SMS"
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr "Dostępne metody"
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -617,23 +626,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr "Kod lub hasło"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr "Poprzez adres e-mail"
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "Poprzez wiadomość SMS"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -783,7 +792,7 @@ msgstr ""
 "wysłany na Twój adres e-mail"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -802,13 +811,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -841,23 +850,19 @@ msgstr ""
 "Wiadomość e-mail została do nas wysłana w celu zresetowania Twojego konta"
 " aplikacji"
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr "Bezhasłowy kod QR"
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr "Żadna z metod nie została włączona"
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1132,3 +1137,15 @@ msgstr ""
 #~ msgstr ""
 #~ "Nie jesteś zalogowany. Prosimy o "
 #~ "przesłanie prawidłowych danych uwierzytelniania."
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
+#~ msgstr ""

--- a/flask_security/translations/pt_BR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/pt_BR/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2017-09-27 23:39-0300\n"
 "Last-Translator: José Neto <josenetodino@gmail.com>\n"
 "Language: pt_BR\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -328,103 +328,108 @@ msgstr ""
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
-msgid "Nickname for new credential is required."
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -545,39 +550,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr ""
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -609,23 +618,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -771,7 +780,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -790,13 +799,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -827,23 +836,19 @@ msgstr ""
 msgid "A mail was sent to us in order to reset your application account"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1113,4 +1118,16 @@ msgstr ""
 #~ "enviadas para %(email)s."
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
+#~ msgstr ""
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
 #~ msgstr ""

--- a/flask_security/translations/pt_PT/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/pt_PT/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2018-04-27 14:00+0100\n"
 "Last-Translator: Micael Grilo <micael.grilo@outlook.com>\n"
 "Language: pt_PT\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -331,103 +331,108 @@ msgstr ""
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
-msgid "Nickname for new credential is required."
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -548,39 +553,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr ""
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -612,23 +621,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -774,7 +783,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -793,13 +802,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -830,23 +839,19 @@ msgstr ""
 msgid "A mail was sent to us in order to reset your application account"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1116,4 +1121,16 @@ msgstr ""
 #~ "enviadas para %(email)s."
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
+#~ msgstr ""
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
 #~ msgstr ""

--- a/flask_security/translations/ru_RU/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ru_RU/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2023-01-25 04:14+0530\n"
 "Last-Translator: Ivan Fedorov <inbox@titaniumhocker.ru>\n"
 "Language: ru_RU\n"
@@ -18,7 +18,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -335,31 +335,36 @@ msgstr "Отмеченный метод недействителен"
 msgid "You successfully disabled two factor authorization."
 msgstr "Вы успешно отключили двухфакторную авторизацию."
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr "Запрошенный метод недействителен"
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 "Настройка должна быть завершена в течение %(within)s. Пожалуйста, начните"
 " заново."
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr "Настройка единого способа входа прошла успешно"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr "Вы должны указать действительный идентификатор для входа"
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Используйте данный код для входа: %(code)s."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -368,78 +373,78 @@ msgstr ""
 "Имя пользователя должно содержать не менее %(min)d и не более %(max)d "
 "символов"
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr "Имя пользователя содержит недопустимые символы"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr "Имя пользователя может содержать только буквы и цифры"
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
 msgstr "Имя пользователя не указано"
 
-#: flask_security/core.py:549
+#: flask_security/core.py:553
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "Имя пользователя %(username)s уже связано с учётной записью."
 
-#: flask_security/core.py:553
+#: flask_security/core.py:557
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 "Операция WebAuthn должна быть завершена в течение %(within)s. Пожалуйста,"
 " начните сначала."
 
-#: flask_security/core.py:557
+#: flask_security/core.py:561
 msgid "Nickname for new credential is required."
 msgstr "Требуется псевдоним для новых учётных данных."
 
-#: flask_security/core.py:561
+#: flask_security/core.py:565
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s уже связан с учётными данными."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:569
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s не зарегистрирован с текущим пользователем."
 
-#: flask_security/core.py:569
+#: flask_security/core.py:573
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr "Учётные данные WebAuthn с именем %(name)s успешно удалены"
 
-#: flask_security/core.py:573
+#: flask_security/core.py:577
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr "Учётные данные WebAuthn с именем %(name)s успешно добавлены"
 
-#: flask_security/core.py:577
+#: flask_security/core.py:581
 msgid "WebAuthn credential id already registered."
 msgstr "Учётные данные WebAuthn уже зарегистрированы."
 
-#: flask_security/core.py:581
+#: flask_security/core.py:585
 msgid "Unregistered WebAuthn credential id."
 msgstr "Незарегистрированный идентификатор учетных данных WebAuthn."
 
-#: flask_security/core.py:585
+#: flask_security/core.py:589
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "Учётные данные WebAuthn не принадлежат ни одному пользователю."
 
-#: flask_security/core.py:589
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "Не удалось проверить учётные данные WebAuthn: %(cause)s."
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 "Учётные данные не зарегистрированы для этого использования (первичное или"
 " вторичное)"
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr "Несовпадение учётных данных пользователя"
 
@@ -562,39 +567,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr "Настроить с помощью СМС"
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr "Доступные методы"
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr "Отключить двухфакторную аутентификацию"
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -626,23 +635,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr "Код или пароль"
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr "По электронной почте"
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "По СМС"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr "Настроить дополнительный метод входа"
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr "Удаление активной опции входа"
 
@@ -792,7 +801,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr "Для завершения входа введите код, отправленный на вашу электронную почту"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -814,13 +823,13 @@ msgid "WebAuthn"
 msgstr "WebAuthn"
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr "Это приложение поддерживает ключи безопасности WebAuthn."
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Вы можете настроить их здесь."
@@ -851,23 +860,19 @@ msgstr "Код аутентификации был отправлен вам н�
 msgid "A mail was sent to us in order to reset your application account"
 msgstr "Нам было отправлено письмо для сброса вашей учетной записи"
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr "Настроить единый вход"
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr "Активные на данный момент варианты входа в систему:"
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr "Беспарольный QR код"
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr "Никакие методы не были включены — нечего настраивать"
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr "Введите код, чтобы завершить настройку"
 
@@ -1159,3 +1164,15 @@ msgstr "Пожалуйста, повторите процесс регистра
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
 #~ msgstr "Вы не аутентифицированы. Пожалуйста, укажите корректные учётные данные."
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
+#~ msgstr "Активные на данный момент варианты входа в систему:"

--- a/flask_security/translations/tr_TR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/tr_TR/LC_MESSAGES/flask_security.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2018-12-20 18:48+0300\n"
 "Last-Translator: Ecmel B. Canlıer <me@ecmelberk.com>\n"
 "Language: tr_TR\n"
@@ -16,7 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -326,103 +326,108 @@ msgstr ""
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
-msgid "Nickname for new credential is required."
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -543,39 +548,43 @@ msgstr ""
 msgid "Set up using SMS"
 msgstr ""
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -607,23 +616,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -769,7 +778,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -788,13 +797,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -825,23 +834,19 @@ msgstr ""
 msgid "A mail was sent to us in order to reset your application account"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1111,4 +1116,16 @@ msgstr ""
 #~ "%(email)s adresine gönderilmiştir."
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
+#~ msgstr ""
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
 #~ msgstr ""

--- a/flask_security/translations/zh_Hans_CN/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/zh_Hans_CN/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-06 12:04+0100\n"
+"POT-Creation-Date: 2023-12-17 20:22-0800\n"
 "PO-Revision-Date: 2018-08-02 19:55+0800\n"
 "Last-Translator: SteinKuo <guoming054@gmail.com>\n"
 "Language: zh_CN\n"
@@ -17,7 +17,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.13.1\n"
+"Generated-By: Babel 2.14.0\n"
 
 #: flask_security/core.py:267
 msgid "Login Required"
@@ -326,103 +326,108 @@ msgstr "选择的方法无效"
 msgid "You successfully disabled two factor authorization."
 msgstr "你成功地禁用了双因素授权。"
 
-#: flask_security/core.py:524
+#: flask_security/core.py:525
+#, python-format
+msgid "Currently active sign in options: %(method_list)s."
+msgstr ""
+
+#: flask_security/core.py:528
 msgid "Requested method is not valid"
 msgstr "非法的请求方法"
 
-#: flask_security/core.py:526
+#: flask_security/core.py:530
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr "必须在%(within)s内完成设置。请重新开始。"
 
-#: flask_security/core.py:529
+#: flask_security/core.py:533
 msgid "Unified sign in setup successful"
 msgstr "统一登录设置成功"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:534
 msgid "You must specify a valid identity to sign in"
 msgstr "您必须指定一个有效的身份才能登录"
 
-#: flask_security/core.py:531
+#: flask_security/core.py:535
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "使用此代码登录：%(code)s"
 
-#: flask_security/core.py:533
+#: flask_security/core.py:537
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:540
+#: flask_security/core.py:544
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:548
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:547
+#: flask_security/core.py:551
 msgid "Username not provided"
-msgstr ""
-
-#: flask_security/core.py:549
-#, python-format
-msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:553
 #, python-format
-msgid "WebAuthn operation must be completed within %(within)s. Please start over."
+msgid "%(username)s is already associated with an account."
 msgstr ""
 
 #: flask_security/core.py:557
-msgid "Nickname for new credential is required."
+#, python-format
+msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
 #: flask_security/core.py:561
-#, python-format
-msgid "%(name)s is already associated with a credential."
+msgid "Nickname for new credential is required."
 msgstr ""
 
 #: flask_security/core.py:565
 #, python-format
-msgid "%(name)s not registered with current user."
+msgid "%(name)s is already associated with a credential."
 msgstr ""
 
 #: flask_security/core.py:569
 #, python-format
-msgid "Successfully deleted WebAuthn credential with name: %(name)s"
+msgid "%(name)s not registered with current user."
 msgstr ""
 
 #: flask_security/core.py:573
 #, python-format
-msgid "Successfully added WebAuthn credential with name: %(name)s"
+msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:577
-msgid "WebAuthn credential id already registered."
+#, python-format
+msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
 #: flask_security/core.py:581
-msgid "Unregistered WebAuthn credential id."
+msgid "WebAuthn credential id already registered."
 msgstr ""
 
 #: flask_security/core.py:585
-msgid "WebAuthn credential doesn't belong to any user."
+msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
 #: flask_security/core.py:589
+msgid "WebAuthn credential doesn't belong to any user."
+msgstr ""
+
+#: flask_security/core.py:593
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:597
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:601
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -543,39 +548,43 @@ msgstr "设置一个认证的app（例如：google、lastpass、authy）"
 msgid "Set up using SMS"
 msgstr "用SMS进行设置\""
 
-#: flask_security/forms.py:92
+#: flask_security/forms.py:93
 msgid "Google Authenticator"
 msgstr ""
 
-#: flask_security/forms.py:93
-msgid "Authenticator app"
+#: flask_security/forms.py:94
+msgid "authenticator"
 msgstr ""
 
-#: flask_security/forms.py:94 flask_security/forms.py:95
-msgid "Email"
-msgstr ""
-
-#: flask_security/forms.py:96
-msgid "SMS"
+#: flask_security/forms.py:95 flask_security/forms.py:96
+msgid "email"
 msgstr ""
 
 #: flask_security/forms.py:97
-msgid "None"
+msgid "SMS"
 msgstr ""
 
-#: flask_security/forms.py:772 flask_security/unified_signin.py:162
+#: flask_security/forms.py:98
+msgid "password"
+msgstr ""
+
+#: flask_security/forms.py:99
+msgid "none"
+msgstr ""
+
+#: flask_security/forms.py:774 flask_security/unified_signin.py:164
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:780
+#: flask_security/forms.py:782
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:862
+#: flask_security/forms.py:864
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:866
 msgid "Contact Administrator"
 msgstr ""
 
@@ -607,23 +616,23 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:155
+#: flask_security/unified_signin.py:157
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:164
+#: flask_security/unified_signin.py:166
 msgid "Via email"
 msgstr "通过邮件"
 
-#: flask_security/unified_signin.py:165
+#: flask_security/unified_signin.py:167
 msgid "Via SMS"
 msgstr "通过SMS"
 
-#: flask_security/unified_signin.py:293
+#: flask_security/unified_signin.py:295
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:306
+#: flask_security/unified_signin.py:308
 msgid "Delete active sign in option"
 msgstr ""
 
@@ -769,7 +778,7 @@ msgid "To complete logging in, please enter the code sent to your mail"
 msgstr "要完成登录，请输入发送到您邮箱的代码"
 
 #: flask_security/templates/security/two_factor_setup.html:42
-#: flask_security/templates/security/us_setup.html:66
+#: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
@@ -788,13 +797,13 @@ msgid "WebAuthn"
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:93
+#: flask_security/templates/security/us_setup.html:88
 msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:62
 #: flask_security/templates/security/two_factor_setup.html:78
-#: flask_security/templates/security/us_setup.html:94
+#: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
@@ -825,23 +834,19 @@ msgstr "认证代码已发送至您的电子邮件地址。"
 msgid "A mail was sent to us in order to reset your application account"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:28
+#: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:34
-msgid "Currently active sign in options:"
-msgstr ""
-
-#: flask_security/templates/security/us_setup.html:69
+#: flask_security/templates/security/us_setup.html:64
 msgid "Passwordless QRCode"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:76
+#: flask_security/templates/security/us_setup.html:71
 msgid "No methods have been enabled - nothing to setup"
 msgstr ""
 
-#: flask_security/templates/security/us_setup.html:82
+#: flask_security/templates/security/us_setup.html:77
 msgid "Enter code here to complete setup"
 msgstr ""
 
@@ -1106,3 +1111,15 @@ msgstr ""
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
 #~ msgstr "你还没有通过认证。请提供正确的凭证。"
+
+#~ msgid "Authenticator app"
+#~ msgstr ""
+
+#~ msgid "Email"
+#~ msgstr ""
+
+#~ msgid "None"
+#~ msgstr ""
+
+#~ msgid "Currently active sign in options:"
+#~ msgstr ""

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -49,7 +49,7 @@ from .confirmable import (
 )
 from .decorators import anonymous_user_required, auth_required, unauth_csrf
 from .forms import (
-    _tf_methods_xlate,
+    _setup_methods_xlate,
     DummyForm,
     ForgotPasswordForm,
     LoginForm,
@@ -108,6 +108,7 @@ from .utils import (
     hash_password,
     is_user_authenticated,
     json_error_response,
+    localize_callback,
     login_user,
     logout_user,
     propagate_next,
@@ -881,9 +882,9 @@ def two_factor_setup():
         two_factor_verify_code_form=code_form,
         choices=choices,
         chosen_method=form.setup.data,
-        primary_method=_tf_methods_xlate[
-            getattr(user, "tf_primary_method", None)
-        ],  # translated
+        primary_method=localize_callback(
+            _setup_methods_xlate[getattr(user, "tf_primary_method", None)]
+        ),
         two_factor_required=cv("TWO_FACTOR_REQUIRED"),
         **_ctx("tf_setup"),
     )
@@ -1000,7 +1001,7 @@ def two_factor_token_validation():
             cv("TWO_FACTOR_VERIFY_CODE_TEMPLATE"),
             two_factor_rescue_form=rescue_form,
             two_factor_verify_code_form=form,
-            chosen_method=_tf_methods_xlate[pm],  # translated
+            chosen_method=localize_callback(_setup_methods_xlate[pm]),
             problem=None,
             **_ctx("tf_token_validation"),
         )
@@ -1068,7 +1069,9 @@ def two_factor_rescue():
         cv("TWO_FACTOR_VERIFY_CODE_TEMPLATE"),
         two_factor_verify_code_form=code_form,
         two_factor_rescue_form=form,
-        chosen_method=_tf_methods_xlate[form.user.tf_primary_method],  # translated
+        chosen_method=localize_callback(
+            _setup_methods_xlate[form.user.tf_primary_method]
+        ),
         rescue_mail=cv("TWO_FACTOR_RESCUE_MAIL"),
         problem=rproblem,
         **_ctx("tf_token_validation"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,10 +51,7 @@ NO_BABEL = False
 try:
     from flask_babel import Babel
 except ImportError:
-    try:
-        from flask_babelex import Babel
-    except ImportError:
-        NO_BABEL = True
+    NO_BABEL = True
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from flask.testing import FlaskClient

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -117,13 +117,6 @@ def test_cli_createuser_errors(script_info):
 @pytest.mark.babel()
 @pytest.mark.app_settings(babel_default_locale="fr_FR")
 def test_cli_locale(script_info):
-    # Flask_BabelEx required a request context - and click just has an app context.
-    try:
-        import flask_babelex  # noqa: F401
-
-        pytest.skip("Flask-BabelEx doesn't support app context")
-    except ImportError:
-        pass
     runner = CliRunner()
     result = runner.invoke(
         users_create, ["--password", "battery staple"], obj=script_info

--- a/tox.ini
+++ b/tox.ini
@@ -86,16 +86,6 @@ commands =
     tox -e compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}
 
-# manual test to verify we still work with Flask-BabelEx
-[testenv:babelex]
-deps =
-    -r requirements/tests.txt
-    flask_babelex
-commands =
-    pip uninstall -y flask_babel
-    tox -e compile_catalog
-    pytest --basetemp={envtmpdir} {posargs:tests}
-
 [testenv:style]
 deps = pre-commit
 skip_install = true


### PR DESCRIPTION
Improve on recent PR that adds support for 2FA method translations - it didn't actually call a localize_callback to translate the data.

Add tests to verify actual xlation is occurring.

Remove support for Flask-BabelEx.

Use Babel.format_lists to construct the list of existing setup unified signup methods - moving this from the template to the view.

Fix view_scaffold localization configuration.

@gissimo When I wrote some tests - I (re) learned that in Flask-Security '_' is just a marker for strings to translate - it doesn't actually do any translation - so minor change to fix that.

unified signin has very similar 'methods' - so combined that with what you did. Minor wording changes - let me know of any concerns.