### PR TITLE
Allowed the oauth login to work with spa

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/psf/black
-    rev: 23.11.0
+    rev: 23.12.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8

--- a/flask_security/oauth_glue.py
+++ b/flask_security/oauth_glue.py
@@ -181,8 +181,8 @@ class OAuthGlue:
         oauth_provider = self.oauth_provider(name)
         if not oauth_provider:
             return abort(404)
-        start_uri = url_for_security(
-            "oauthresponse", name=name, _external=True, **values
+        start_uri = get_url(
+            url_for_security("oauthresponse", name=name, _external=True, **values)
         )
         redirect_url = oauth_provider.authorize_redirect(start_uri)
         return redirect_url

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -549,7 +549,12 @@ def validate_redirect_url(url: str) -> bool:
     if url is None or url.strip() == "":
         return False
     url_next = urlsplit(url)
-    url_base = urlsplit(request.host_url)
+    security_redirect_host = config_value("REDIRECT_HOST")
+    url_base = (
+        urlsplit(f"http://{security_redirect_host}")
+        if security_redirect_host
+        else urlsplit(request.host_url)
+    )
     if (url_next.netloc or url_next.scheme) and url_next.netloc != url_base.netloc:
         base_domain = current_app.config.get("SERVER_NAME")
         if (

--- a/pytest.ini
+++ b/pytest.ini
@@ -18,6 +18,7 @@ markers =
 
 filterwarnings =
     error
+    ignore::DeprecationWarning:pkg_resources:
     ignore::DeprecationWarning:mongoengine:
     ignore::DeprecationWarning:flask_login:0
     ignore::DeprecationWarning:pydantic_core:0

--- a/tests/test_spa.py
+++ b/tests/test_spa.py
@@ -1,0 +1,19 @@
+import pytest
+
+from flask_security.utils import validate_redirect_url
+from tests.test_utils import init_app_with_options
+
+
+@pytest.mark.settings(redirect_validate_mode="regex")
+def test_validate_redirect_for_spa(app, sqlalchemy_datastore):
+    """
+    Test various possible URLs that urlsplit() shows as relative but
+    many browsers will interpret as absolute - and thus have a
+    open-redirect vulnerability. Note this vulnerability only
+    is viable if the application sets autocorrect_location_header = False
+    """
+    init_app_with_options(
+        app, sqlalchemy_datastore, **{"SECURITY_REDIRECT_HOST": "localhost:4000"}
+    )
+    with app.test_request_context("http://localhost:5001/login"):
+        assert validate_redirect_url("http://localhost:4000/login")


### PR DESCRIPTION
Allowed the oauth login to work with spa and SECURITY_REDIRECT_HOST by re-wirting the redirect URL, and stopping validate_redirect_url from erroring when the URL points to the redirect host.

Ignore the deprecation of pkg_resources in pytest to ensure it runs

Added unit tests for these changes

Fixes https://github.com/Flask-Middleware/flask-security/issues/884