### PR TITLE
Fix (again) possible open redirect vulnerability.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ Fixes
 +++++
 
 - (:issue:`845`) us-signin magic link should use fs_uniquifier (not email)
+- (:issue:`893`) Once again work on open-redirect vulnerability - this time due to newer Werkzeug
 - (:pr:`873`) Update Spanish and Italian translations (gissimo)
 - (:pr:`877`) Make AnonymousUser optional and deprecated
 - (:issue:`875`) user_datastore.create_user has side effects on mutable inputs (NoRePercussions)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -279,38 +279,19 @@ These configuration keys are used globally across all features.
 
 .. py:data:: SECURITY_REDIRECT_VALIDATE_MODE
 
-    These 2 configuration options attempt to solve a open-redirect vulnerability
-    that can be exploited if an application sets the Werkzeug response option
-    ``autocorrect_location_header = False`` (it is ``True`` by default).
-    For numerous views (e.g. /login) Flask-Security allows callers to specify
-    a redirect upon successful completion (via the ?next parameter). So it is
-    possible for a user to be tricked into logging in to a legitimate site
-    and then redirected to a malicious site. Flask-Security attempts to
-    verify that redirects are always relative to overcome this security concern.
-    FS uses the standard Python library urlsplit() to parse the URL and verify
-    that the ``netloc`` hasn't been altered.
-    However, many browsers actually accept URLs that should be considered
-    relative and perform various stripping and conversion that can cause them
-    to be interpreted as absolute. A trivial example of this is:
+    Defines how Flask-Security will attempt to mitigate an open redirect
+    vulnerability w.r.t. client supplied `next` parameters.
+    Please see :ref:`redirect_topic` for a complete discussion.
 
-    .. line-block::
-        /login?next=%20///github.com
+    Current options include `"absolute"` and `"regex"`. A list is allowed.
 
-    This will pass the urlsplit() test that it is relative - but many browsers
-    will simply strip off the space and interpret it as an absolute URL!
-    With the default configuration of Werkzeug this isn't an issue since it by
-    default modifies the Location Header to with the request ``netloc``. However
-    if the application sets the Werkzeug response option
-    ``autocorrect_location_header = False`` this will allow a redirect outside of
-    the application.
 
-    Setting this to ``"regex"`` will force the URL to be matched using the
-    pattern specified below. If a match occurs the URL is considered 'absolute'
-    and will be rejected.
-
-    Default: ``None``
+    Default: ``["absolute"]``
 
     .. versionadded:: 4.0.2
+
+    .. versionchanged:: 5.4.0
+        Default is now `"absolute"` and now takes a list.
 
 .. py:data:: SECURITY_REDIRECT_VALIDATE_RE
 
@@ -318,7 +299,7 @@ These configuration keys are used globally across all features.
     don't allow control characters or white-space followed by slashes (or
     back slashes).
 
-    Default: ``r"^/{4,}|\\{3,}|[\s\000-\037][/\\]{2,}"``
+    Default: ``r"^/{4,}|\\{3,}|[\s\000-\037][/\\]{2,}(?![/\\])|[/\\]([^/\\]|/[^/\\])*[/\\].*"``
 
     .. versionadded:: 4.0.2
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -197,8 +197,8 @@ _default_config: t.Dict[str, t.Any] = {
     "REDIRECT_HOST": None,
     "REDIRECT_BEHAVIOR": None,
     "REDIRECT_ALLOW_SUBDOMAINS": False,
-    "REDIRECT_VALIDATE_MODE": None,
-    "REDIRECT_VALIDATE_RE": r"^/{4,}|\\{3,}|[\s\000-\037][/\\]{2,}",
+    "REDIRECT_VALIDATE_MODE": ["absolute"],
+    "REDIRECT_VALIDATE_RE": r"^/{4,}|\\{3,}|[\s\000-\037][/\\]{2,}(?![/\\])|[/\\]([^/\\]|/[^/\\])*[/\\].*",  # noqa: E501
     "FORGOT_PASSWORD_TEMPLATE": "security/forgot_password.html",
     "LOGIN_USER_TEMPLATE": "security/login_user.html",
     "REGISTER_USER_TEMPLATE": "security/register_user.html",
@@ -1432,10 +1432,6 @@ class Security:
         self._username_util = self.username_util_cls(app)
         self._webauthn_util = self.webauthn_util_cls(app)
         self._mf_recovery_codes_util = self.mf_recovery_codes_util_cls(app)
-        rvre = cv("REDIRECT_VALIDATE_RE", app=app)
-        if rvre:
-            self._redirect_validate_re = re.compile(rvre)
-
         self.remember_token_serializer = _get_serializer(app, "remember")
         self.login_serializer = _get_serializer(app, "login")
         self.reset_serializer = _get_serializer(app, "reset")
@@ -1531,10 +1527,32 @@ class Security:
         if cv("OAUTH_ENABLE", app=app):
             self.oauthglue = OAuthGlue(app, self._oauth)
 
+        redirect_validate_mode = cv("REDIRECT_VALIDATE_MODE", app=app) or []
+        if redirect_validate_mode:
+            # should be "regex" or "absolute" or a list of those
+            if not isinstance(redirect_validate_mode, list):
+                redirect_validate_mode = [redirect_validate_mode]
+            if all([m in ["regex", "absolute"] for m in redirect_validate_mode]):
+                if "regex" in redirect_validate_mode:
+                    rvre = cv("REDIRECT_VALIDATE_RE", app=app)
+                    if rvre:
+                        self._redirect_validate_re = re.compile(rvre)
+                    else:
+                        raise ValueError("Must specify REDIRECT_VALIDATE_RE")
+            else:
+                raise ValueError("Invalid value(s) for REDIRECT_VALIDATE_MODE")
+
+        def autocorrect(r):
+            # By setting this (Werkzeug) avoids any open-redirect issues.
+            r.autocorrect_location_header = True
+            return r
+
         # register our blueprint/endpoints
         bp = None
         if self.register_blueprint:
             bp = create_blueprint(app, self, __name__)
+            if "absolute" in redirect_validate_mode:
+                bp.after_request(autocorrect)
             self.two_factor_plugins.create_blueprint(app, bp, self)
             if self.oauthglue:
                 self.oauthglue._create_blueprint(app, bp)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -22,6 +22,7 @@ from flask_principal import identity_loaded
 from tests.test_utils import (
     authenticate,
     capture_flashes,
+    check_location,
     get_auth_token_version_3x,
     get_form_action,
     get_num_queries,
@@ -224,13 +225,13 @@ def test_login_form_username(client):
 
 
 @pytest.mark.settings(username_enable=True, username_required=True)
-def test_login_form_username_required(client):
+def test_login_form_username_required(app, client):
     # If username required - we should still be able to login with email alone
     # given default user_identity_attributes
     response = client.post(
         "/login", data=dict(email="matt@lp.com", password="password")
     )
-    assert response.location == "/"
+    assert check_location(app, response.location, "/")
 
 
 @pytest.mark.confirmable()

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -22,6 +22,7 @@ from tests.test_utils import (
     authenticate,
     capture_flashes,
     capture_registrations,
+    check_location,
     is_authenticated,
     logout,
     populate_data,
@@ -469,7 +470,7 @@ def test_auto_login(app, client, get_message):
 
     token = registrations[0]["confirm_token"]
     response = client.get("/confirm/" + token, follow_redirects=False)
-    assert "/postlogin" == response.location
+    assert check_location(app, response.location, "/postlogin")
     assert is_authenticated(client, get_message)
 
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -25,6 +25,7 @@ from tests.test_utils import (
     authenticate,
     capture_flashes,
     capture_reset_password_requests,
+    check_location,
     check_xlation,
     get_csrf_token,
     init_app_with_options,
@@ -1117,7 +1118,7 @@ def test_verify_fresh(app, client, get_message):
     response = client.post(
         verify_url, data=dict(password="password"), follow_redirects=False
     )
-    assert response.location == "/fresh"
+    assert check_location(app, response.location, "/fresh")
 
     # should be fine now
     response = client.get("/fresh", follow_redirects=True)
@@ -1301,6 +1302,27 @@ def test_post_security_with_application_root_and_views(app, sqlalchemy_datastore
     assert "/post_logout" in response.location
 
 
+def test_invalid_redirect_config(app, sqlalchemy_datastore, get_message):
+    with pytest.raises(ValueError):
+        init_app_with_options(
+            app,
+            sqlalchemy_datastore,
+            **{"SECURITY_REDIRECT_VALIDATE_MODE": ["regex", "bogus"]},
+        )
+
+
+def test_invalid_redirect_re(app, sqlalchemy_datastore, get_message):
+    with pytest.raises(ValueError):
+        init_app_with_options(
+            app,
+            sqlalchemy_datastore,
+            **{
+                "SECURITY_REDIRECT_VALIDATE_MODE": ["regex"],
+                "SECURITY_REDIRECT_VALIDATE_RE": None,
+            },
+        )
+
+
 @pytest.mark.settings(redirect_validate_mode="regex")
 def test_validate_redirect(app, sqlalchemy_datastore):
     """
@@ -1314,7 +1336,22 @@ def test_validate_redirect(app, sqlalchemy_datastore):
         assert not validate_redirect_url("\\\\\\github.com")
         assert not validate_redirect_url(" //github.com")
         assert not validate_redirect_url("\t//github.com")
+        assert not validate_redirect_url(r"/\github.com")
+        assert not validate_redirect_url(r"\/github.com")
         assert not validate_redirect_url("//github.com")  # this is normal urlsplit
+
+
+@pytest.mark.settings(post_login_view="\\\\\\github.com")
+def test_validate_redirect_default(app, client):
+    """
+    Test various possible URLs that urlsplit() shows as relative but
+    many browsers will interpret as absolute - and thus have a
+    open-redirect vulnerability. This tests the default configuration for
+    Flask-Security, Flask, Werkzeug
+    """
+    authenticate(client)
+    response = client.get("/login", follow_redirects=False)
+    assert response.location.startswith("http://localhost")
 
 
 def test_kwargs():

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -27,6 +27,7 @@ from tests.test_utils import (
     authenticate,
     capture_flashes,
     capture_send_code_requests,
+    check_location,
     check_xlation,
     get_form_action,
     get_session,
@@ -813,7 +814,7 @@ def test_opt_in(app, client, get_message):
     # Validate token - this should complete 2FA setup
     response = client.post("/tf-validate", data=dict(code=code), follow_redirects=True)
     assert b"You successfully changed" in response.data
-    assert response.history[0].location == "/tf-setup"
+    assert check_location(app, response.history[0].location, "/tf-setup")
 
     # Upon completion, session cookie shouldnt have any two factor stuff in it.
     session = get_session(response)
@@ -1293,7 +1294,7 @@ def test_verify(app, client, get_message):
     # Test setup when re-authenticate required
     authenticate(client)
     response = client.get("tf-setup", follow_redirects=False)
-    assert response.location == "/verify?next=/tf-setup"
+    assert check_location(app, response.location, "/verify?next=/tf-setup")
     logout(client)
 
     # Now try again - follow redirects to get to verify form
@@ -1320,7 +1321,8 @@ def test_verify(app, client, get_message):
             follow_redirects=False,
         )
         assert response.status_code == 302
-        assert response.location == "/tf-setup"
+        assert check_location(app, response.location, "/tf-setup")
+
     assert get_message("REAUTHENTICATION_SUCCESSFUL") == flashes[0]["message"].encode(
         "utf-8"
     )
@@ -1445,7 +1447,7 @@ def test_post_setup_redirect(app, client):
 
     # Validate token - this should complete 2FA setup
     response = client.post("/tf-validate", data=dict(code=code), follow_redirects=False)
-    assert response.location == "/post_setup_view"
+    assert check_location(app, response.location, "/post_setup_view")
 
 
 @pytest.mark.app_settings(babel_default_locale="fr_FR")

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -26,6 +26,7 @@ from tests.test_utils import (
     authenticate,
     capture_flashes,
     capture_reset_password_requests,
+    check_location,
     check_xlation,
     get_form_action,
     is_authenticated,
@@ -457,7 +458,7 @@ def test_us_passwordless_confirm_json(app, client, get_message):
     matcher = re.findall(r"\w+:.*", outbox[0].body, re.IGNORECASE)
     link = matcher[0].split(":", 1)[1]
     response = client.get(link, headers=headers, follow_redirects=False)
-    assert response.location == "/login"
+    assert check_location(app, response.location, "/login")
 
     # should be able to authenticate now.
     response = client.post(
@@ -989,7 +990,7 @@ def test_verify(app, client, get_message):
     us_authenticate(client)
     response = client.get("us-setup", follow_redirects=False)
     verify_url = response.location
-    assert verify_url == "/us-verify?next=/us-setup"
+    assert check_location(app, response.location, "/us-verify?next=/us-setup")
     logout(client)
     us_authenticate(client)
 
@@ -1020,7 +1021,7 @@ def test_verify(app, client, get_message):
 
     code = sms_sender.messages[0].split()[-1].strip(".")
     response = client.post(verify_url, data=dict(passcode=code), follow_redirects=False)
-    assert response.location == "/us-setup"
+    assert check_location(app, response.location, "/us-setup")
 
 
 def test_verify_json(app, client, get_message):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,7 @@ from flask_security.signals import (
     us_security_token_sent,
 )
 from flask_security.utils import hash_data, hash_password
+from flask_security.utils import config_value as cv
 
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from werkzeug.http import parse_cookie
@@ -61,6 +62,16 @@ def is_authenticated(client, get_message):
     ) == get_message("UNAUTHENTICATED"):
         return False
     raise ValueError("Failed to figure out if authenticated")
+
+
+def check_location(app, location, expected_base):
+    # verify response location. This can be absolute or relative based
+    # on configuration
+    redirect_validate_mode = cv("REDIRECT_VALIDATE_MODE", app=app) or []
+    if "absolute" in redirect_validate_mode:
+        return location == f"http://localhost{expected_base}"
+    else:
+        return location == expected_base
 
 
 def verify_token(client_nc, token, status=None):


### PR DESCRIPTION
Improve the regex (thanks Brandon Elliot) to catch more crafted relative paths that browsers convert to absolute.

Add the "absolute" option to SECURITY_REDIRECT_VALIDATE_MODE which restores Werkzeug prior behavior of converting all Location header values into absolute paths rather than relative (autocorrect_location_header=True).

closes #893