### PR TITLE
Fix (again) possible open redirect vulnerability.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/psf/black
-    rev: 23.10.0
+    rev: 23.12.1
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
@@ -30,7 +30,7 @@ repos:
           - flake8-bugbear
           - flake8-implicit-str-concat
 -   repo: https://github.com/Riverside-Healthcare/djLint
-    rev: v1.34.0
+    rev: v1.34.1
     hooks:
       - id: djlint-jinja
         files: "\\.html"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,16 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 5.3.3
+-------------
+
+Released December 29, 2023
+
+Fixes
++++++
+- (:issue:`893`) Once again work on open-redirect vulnerability - this time due to newer Werkzeug.
+  Addresses: CVE-2023-49438
+
 Version 5.3.2
 -------------
 

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -279,38 +279,19 @@ These configuration keys are used globally across all features.
 
 .. py:data:: SECURITY_REDIRECT_VALIDATE_MODE
 
-    These 2 configuration options attempt to solve a open-redirect vulnerability
-    that can be exploited if an application sets the Werkzeug response option
-    ``autocorrect_location_header = False`` (it is ``True`` by default).
-    For numerous views (e.g. /login) Flask-Security allows callers to specify
-    a redirect upon successful completion (via the ?next parameter). So it is
-    possible for a user to be tricked into logging in to a legitimate site
-    and then redirected to a malicious site. Flask-Security attempts to
-    verify that redirects are always relative to overcome this security concern.
-    FS uses the standard Python library urlsplit() to parse the URL and verify
-    that the ``netloc`` hasn't been altered.
-    However, many browsers actually accept URLs that should be considered
-    relative and perform various stripping and conversion that can cause them
-    to be interpreted as absolute. A trivial example of this is:
+    Defines how Flask-Security will attempt to mitigate an open redirect
+    vulnerability w.r.t. client supplied `next` parameters.
+    Please see :ref:`redirect_topic` for a complete discussion.
 
-    .. line-block::
-        /login?next=%20///github.com
+    Current options include `"absolute"` and `"regex"`. A list is allowed.
 
-    This will pass the urlsplit() test that it is relative - but many browsers
-    will simply strip off the space and interpret it as an absolute URL!
-    With the default configuration of Werkzeug this isn't an issue since it by
-    default modifies the Location Header to with the request ``netloc``. However
-    if the application sets the Werkzeug response option
-    ``autocorrect_location_header = False`` this will allow a redirect outside of
-    the application.
 
-    Setting this to ``"regex"`` will force the URL to be matched using the
-    pattern specified below. If a match occurs the URL is considered 'absolute'
-    and will be rejected.
-
-    Default: ``None``
+    Default: ``["absolute"]``
 
     .. versionadded:: 4.0.2
+
+    .. versionchanged:: 5.3.3
+        Default is now `"absolute"` and now takes a list.
 
 .. py:data:: SECURITY_REDIRECT_VALIDATE_RE
 
@@ -318,7 +299,7 @@ These configuration keys are used globally across all features.
     don't allow control characters or white-space followed by slashes (or
     back slashes).
 
-    Default: ``r"^/{4,}|\\{3,}|[\s\000-\037][/\\]{2,}"``
+    Default: ``r"^/{4,}|\\{3,}|[\s\000-\037][/\\]{2,}(?![/\\])|[/\\]([^/\\]|/[^/\\])*[/\\].*"``
 
     .. versionadded:: 4.0.2
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -134,4 +134,4 @@ from .webauthn import (
 )
 from .webauthn_util import WebauthnUtil
 
-__version__ = "5.3.2"
+__version__ = "5.3.3"

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -196,8 +196,8 @@ _default_config: t.Dict[str, t.Any] = {
     "REDIRECT_HOST": None,
     "REDIRECT_BEHAVIOR": None,
     "REDIRECT_ALLOW_SUBDOMAINS": False,
-    "REDIRECT_VALIDATE_MODE": None,
-    "REDIRECT_VALIDATE_RE": r"^/{4,}|\\{3,}|[\s\000-\037][/\\]{2,}",
+    "REDIRECT_VALIDATE_MODE": ["absolute"],
+    "REDIRECT_VALIDATE_RE": r"^/{4,}|\\{3,}|[\s\000-\037][/\\]{2,}(?![/\\])|[/\\]([^/\\]|/[^/\\])*[/\\].*",  # noqa: E501
     "FORGOT_PASSWORD_TEMPLATE": "security/forgot_password.html",
     "LOGIN_USER_TEMPLATE": "security/login_user.html",
     "REGISTER_USER_TEMPLATE": "security/register_user.html",
@@ -1432,10 +1432,6 @@ class Security:
         self._username_util = self.username_util_cls(app)
         self._webauthn_util = self.webauthn_util_cls(app)
         self._mf_recovery_codes_util = self.mf_recovery_codes_util_cls(app)
-        rvre = cv("REDIRECT_VALIDATE_RE", app=app)
-        if rvre:
-            self._redirect_validate_re = re.compile(rvre)
-
         self.remember_token_serializer = _get_serializer(app, "remember")
         self.login_serializer = _get_serializer(app, "login")
         self.reset_serializer = _get_serializer(app, "reset")
@@ -1522,10 +1518,32 @@ class Security:
         if cv("OAUTH_ENABLE", app=app):
             self.oauthglue = OAuthGlue(app, self._oauth)
 
+        redirect_validate_mode = cv("REDIRECT_VALIDATE_MODE", app=app) or []
+        if redirect_validate_mode:
+            # should be "regex" or "absolute" or a list of those
+            if not isinstance(redirect_validate_mode, list):
+                redirect_validate_mode = [redirect_validate_mode]
+            if all([m in ["regex", "absolute"] for m in redirect_validate_mode]):
+                if "regex" in redirect_validate_mode:
+                    rvre = cv("REDIRECT_VALIDATE_RE", app=app)
+                    if rvre:
+                        self._redirect_validate_re = re.compile(rvre)
+                    else:
+                        raise ValueError("Must specify REDIRECT_VALIDATE_RE")
+            else:
+                raise ValueError("Invalid value(s) for REDIRECT_VALIDATE_MODE")
+
+        def autocorrect(r):
+            # By setting this (Werkzeug) avoids any open-redirect issues.
+            r.autocorrect_location_header = True
+            return r
+
         # register our blueprint/endpoints
         bp = None
         if self.register_blueprint:
             bp = create_blueprint(app, self, __name__)
+            if "absolute" in redirect_validate_mode:
+                bp.after_request(autocorrect)
             self.two_factor_plugins.create_blueprint(app, bp, self)
             if self.oauthglue:
                 self.oauthglue._create_blueprint(app, bp)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -22,6 +22,7 @@ from flask_principal import identity_loaded
 from tests.test_utils import (
     authenticate,
     capture_flashes,
+    check_location,
     get_auth_token_version_3x,
     get_form_action,
     get_num_queries,
@@ -183,13 +184,13 @@ def test_login_form_username(client):
 
 
 @pytest.mark.settings(username_enable=True, username_required=True)
-def test_login_form_username_required(client):
+def test_login_form_username_required(app, client):
     # If username required - we should still be able to login with email alone
     # given default user_identity_attributes
     response = client.post(
         "/login", data=dict(email="matt@lp.com", password="password")
     )
-    assert response.location == "/"
+    assert check_location(app, response.location, "/")
 
 
 @pytest.mark.confirmable()

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -22,6 +22,7 @@ from tests.test_utils import (
     authenticate,
     capture_flashes,
     capture_registrations,
+    check_location,
     is_authenticated,
     logout,
     populate_data,
@@ -469,7 +470,7 @@ def test_auto_login(app, client, get_message):
 
     token = registrations[0]["confirm_token"]
     response = client.get("/confirm/" + token, follow_redirects=False)
-    assert "/postlogin" == response.location
+    assert check_location(app, response.location, "/postlogin")
     assert is_authenticated(client, get_message)
 
 

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -25,6 +25,7 @@ from tests.test_utils import (
     authenticate,
     capture_flashes,
     capture_reset_password_requests,
+    check_location,
     get_form_action,
     is_authenticated,
     logout,
@@ -455,7 +456,7 @@ def test_us_passwordless_confirm_json(app, client, get_message):
     matcher = re.findall(r"\w+:.*", outbox[0].body, re.IGNORECASE)
     link = matcher[0].split(":", 1)[1]
     response = client.get(link, headers=headers, follow_redirects=False)
-    assert response.location == "/login"
+    assert check_location(app, response.location, "/login")
 
     # should be able to authenticate now.
     response = client.post(
@@ -986,7 +987,9 @@ def test_verify(app, client, get_message):
     us_authenticate(client)
     response = client.get("us-setup", follow_redirects=False)
     verify_url = response.location
-    assert "/us-verify?next=http://localhost/us-setup" in verify_url
+    assert check_location(
+        app, response.location, "/us-verify?next=http://localhost/us-setup"
+    )
     logout(client)
     us_authenticate(client)
 
@@ -1017,7 +1020,7 @@ def test_verify(app, client, get_message):
 
     code = sms_sender.messages[0].split()[-1].strip(".")
     response = client.post(verify_url, data=dict(passcode=code), follow_redirects=False)
-    assert response.location == "http://localhost/us-setup"
+    assert check_location(app, response.location, "/us-setup")
 
 
 def test_verify_json(app, client, get_message):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,7 @@ from flask_security.signals import (
     us_security_token_sent,
 )
 from flask_security.utils import hash_data, hash_password
+from flask_security.utils import config_value as cv
 
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from werkzeug.http import parse_cookie
@@ -61,6 +62,16 @@ def is_authenticated(client, get_message):
     ) == get_message("UNAUTHENTICATED"):
         return False
     raise ValueError("Failed to figure out if authenticated")
+
+
+def check_location(app, location, expected_base):
+    # verify response location. This can be absolute or relative based
+    # on configuration
+    redirect_validate_mode = cv("REDIRECT_VALIDATE_MODE", app=app) or []
+    if "absolute" in redirect_validate_mode:
+        return location == f"http://localhost{expected_base}"
+    else:
+        return location == expected_base
 
 
 def verify_token(client_nc, token, status=None):


### PR DESCRIPTION
Improve the regex (thanks Brandon Elliot) to catch more crafted relative paths that browsers convert to absolute.

Add the "absolute" option to SECURITY_REDIRECT_VALIDATE_MODE which restores Werkzeug prior behavior of converting all Location header values into absolute paths rather than relative (autocorrect_location_header=True).

This is the backport to 5.3