### PR TITLE
Two-factor simplification and improvements.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Fixes
 - (:pr:`866`) Improve German translations (sr-verde)
 - (:pr:`889`) Improve method translations for unified signin and two factor. Remove support for Flask-Babelex.
 - (:issue:`884`) Oauth re-used POST_LOGIN_VIEW which caused confusion. See below for implications.
+- (:pr:`xxx`) Improve (and simplify) Two-Factor setup. See below for backwards compatability issues and new functionality.
 
 Notes
 ++++++
@@ -46,8 +47,23 @@ Backwards Compatibility Concerns
 
 - Passing in an AnonymousUser class as part of Security initialization has been removed.
 - The never-public method _get_unauthorized_response has been removed.
-- Oauth - a new configuration variable :py:data:`SECURITY_POST_OAUTH_LOGIN_VIEW` was introduced
+- Social-Oauth - a new configuration variable :py:data:`SECURITY_POST_OAUTH_LOGIN_VIEW` was introduced
   and it replaces :py:data:`SECURITY_POST_LOGIN_VIEW` in the oauthresponse logic.
+- Two-Factor setup. Prior to this release when setting up "SMS" the `/tf-setup` endpoint could
+  be POSTed to w/o a phone number, and then another POST could be made to set the phone number.
+  This has always been confusing and added complexity to the code. Now, if "SMS" is selected, the phone number
+  must be supplied (which has always been supported).
+  Other changes:
+
+    - The default two-factor-setup.html template now has a more generic `"Enter code to complete setup"` message.
+    - Make sure the `"disable"` option first.
+    - Adding any currently configured two-factor method on setup failure.
+    - The two_factor_verify template won't show the rescue form if it isn't set.
+    - A GET on /tf-validate now returns the two-factor-validate-form always - before
+      if the client was validating a new method, it would return the two-factor-setup-form
+    - After successfully disabling two-factor the client is redirected to :py:data:`SECURITY_TWO_FACTOR_POST_SETUP_VIEW`
+      rather than :py:data:`SECURITY_POST_LOGIN_VIEW`.
+
 - Bring unauthenticated handling completely into Flask-Security:
     Prior to this release, Flask-Security's :meth:`.Security.unauthn_handler` - called when
     a request wasn't properly authenticated - handled JSON requests then delegated

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -546,6 +546,10 @@ These are used by the Two-Factor and Unified Signin features.
     Setting this to 0 results in undefined behavior.
     Please see :meth:`flask_security.check_and_update_authn_fresh` for details.
 
+    .. note::
+        This stores freshness information in the session - which must be presented
+        (usually via a Cookie) to the above endpoints.
+
     Default: timedelta(hours=24)
 
     .. versionadded:: 3.4.0

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -959,7 +959,7 @@ paths:
           headers:
             Location:
               description: |
-                On form-success: SECURITY_POST_SETUP_VIEW
+                On form-success: SECURITY_US_POST_SETUP_VIEW
               schema:
                 type: string
         400:
@@ -1032,6 +1032,9 @@ paths:
                     description: Config setting SECURITY_TWO_FACTOR_REQUIRED.
                   tf_primary_method:
                     type: string
+                    description: Current (if any) setup method (deprecated).
+                  tf_method:
+                    type: string
                     description: Current (if any) setup method.
                   tf_available_methods:
                     type: string
@@ -1077,6 +1080,15 @@ paths:
                 description: Invalid form values or verification code sent successfully and should be entered into the form.
                 type: string
                 example: render_template(SECURITY_TWO_FACTOR_SETUP_TEMPLATE) with error values
+        302:
+          description: Successfully disabled two-factor.
+          headers:
+            Location:
+              description: |
+                On form-success: SECURITY_TWO_FACTOR_POST_SETUP_VIEW
+              schema:
+                type:
+                  string
         400:
           description: Errors while validating attributes.
           content:
@@ -1091,7 +1103,7 @@ paths:
                 $ref: "#/components/schemas/DefaultJsonErrorResponse"
   /tf-validate:
     get:
-      summary: GET current two-factor state form
+      summary: GET current two-factor validate code form
       responses:
         200:
           description: Code validation
@@ -1099,8 +1111,7 @@ paths:
             text/html:
               schema:
                 description: >
-                  If this is a normal, already setup method, then render_template(SECURITY_TWO_FACTOR_VERIFY_CODE_TEMPLATE) is returned;
-                  if this is validating a new method then render_template(SECURITY_TWO_FACTOR_SETUP_TEMPLATE) is returned.
+                  If this is a normal, already setup method, then render_template(SECURITY_TWO_FACTOR_VERIFY_CODE_TEMPLATE) is returned.
                 type: string
     post:
       summary: Send two-factor code.
@@ -1133,19 +1144,23 @@ paths:
               schema:
                 allOf:
                   - description: >
-                      The code was correct, the caller is now signed in.
+                      The code was correct. If this part of user authentication, the caller is now signed in.
+                      If this was part of changing a two-factor method, that was successful.
                   - $ref: "#/components/schemas/JsonResponseWithToken"
             text/html:
               schema:
-                description:
+                description: >
                   Unsuccessfully processed code. As above, which form is
                   rendered depends on the state of the user's two factor configuration.
                 type: string
         302:
-          description: User successfully sent code when using form based request. The caller is not logged in.
+          description: User successfully sent code when using form based request.
           headers:
             Location:
-              description: Redirect to either ``next`` or ``SECURITY_POST_LOGIN_VIEW``
+              description: >
+                On form-success for two-factor authentication: SECURITY_POST_LOGIN_VIEW
+
+                On form-success for two-factor change method: SECURITY_TWO_FACTOR_SETUP_VIEW
               schema:
                 type: string
         400:
@@ -2162,6 +2177,10 @@ components:
                     indicating the caller needs to call '/tf-validate' with the correct code.
                   example: validating_profile
                 tf_primary_method:
+                  type: string
+                  description: Current method being configured (deprecated).
+                  example: sms
+                tf_method:
                   type: string
                   description: Current method being configured.
                   example: sms

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -102,17 +102,17 @@ as a query param OR in the POSTed form) which it will use when completing an ope
 which results in a redirection. If a malicious user/
 application can inject an arbitrary ``next`` parameter which redirects to an external
 location, this results in a security vulnerability called an `open redirect`.
-The following endpoints accept a ``next`` parameter::
+The following endpoints accept a ``next`` parameter:
 
-- .login ("/login")
-- .logout ("/logout")
-- .register ("/register")
-- .verify ("/verify")
-- .two_factor_token_validation ("/tf-validate")
-- .wan_verify_response ("/wan-verify")
-- .wan_signin_response ("/wan-signin")
-- .us_signin ("/us-signin")
-- .us_verify ("/us-verify")
+    - .login ("/login")
+    - .logout ("/logout")
+    - .register ("/register")
+    - .verify ("/verify")
+    - .two_factor_token_validation ("/tf-validate")
+    - .wan_verify_response ("/wan-verify")
+    - .wan_signin_response ("/wan-signin")
+    - .us_signin ("/us-signin")
+    - .us_verify ("/us-verify")
 
 
 Flask-Security attempts to verify that redirects are always relative.
@@ -152,7 +152,7 @@ mechanisms can be specified.
 Password Validation and Complexity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 There is a large body of references (and endless discussions) around how to get users to create
-good passwords. The `OWASP Authenication cheatsheet <https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html>`_
+good passwords. The `OWASP Authentication cheatsheet <https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html>`_
 is a useful place to start. Flask-Security has a default password validator that:
 
  * Checks for minimum and maximum length (minimum is configurable via :py:data:`SECURITY_PASSWORD_LENGTH_MIN`).
@@ -393,10 +393,10 @@ request and instead defer that decision to later decorators/code. Flask-Security
 :func:`.auth_token_required`, and :func:`.http_auth_required` all support calling csrf protection based on configuration::
 
     # Disable pre-request CSRF
-    app.config[WTF_CSRF_CHECK_DEFAULT] = False
+    app.config["WTF_CSRF_CHECK_DEFAULT"] = False
 
     # Check csrf for session and http auth (but not token)
-    app.config[SECURITY_CSRF_PROTECT_MECHANISMS] = ["session", "basic"]
+    app.config["SECURITY_CSRF_PROTECT_MECHANISMS"] = ["session", "basic"]
 
     # Enable CSRF protection
     flask_wtf.CSRFProtect(app)

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -6,7 +6,7 @@
 
     :copyright: (c) 2012 by Matt Wright.
     :copyright: (c) 2017 by CERN.
-    :copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -773,13 +773,13 @@ class TwoFactorSetupForm(Form):
     setup = RadioField(
         get_form_field_xlate(_("Available Methods")),
         choices=[
+            ("disable", get_form_field_xlate(_("Disable two factor authentication"))),
             ("email", get_form_field_label("email_method")),
             (
                 "authenticator",
                 get_form_field_label("authapp_method"),
             ),
             ("sms", get_form_field_label("sms_method")),
-            ("disable", get_form_field_xlate(_("Disable two factor authentication"))),
         ],
         validate_choice=False,
     )
@@ -801,13 +801,9 @@ class TwoFactorSetupForm(Form):
         if "setup" not in self.data or self.data["setup"] not in choices:
             self.setup.errors.append(get_message("TWO_FACTOR_METHOD_NOT_AVAILABLE")[0])
             return False
-        if self.setup.data == "sms" and self.phone.data and len(self.phone.data) > 0:
-            # Somewhat bizarre - but this isn't required the first time around
-            # when they select "sms". Then they get a field to fill out with
-            # phone number, then Submit again.
+        if self.setup.data == "sms":
             msg = _security._phone_util.validate_phone_number(self.phone.data)
             if msg:
-                self.phone.errors = list()
                 self.phone.errors.append(msg)
                 return False
 

--- a/flask_security/templates/security/mf_recovery.html
+++ b/flask_security/templates/security/mf_recovery.html
@@ -9,4 +9,5 @@
     {{ render_field_with_errors(mf_recovery_form.code) }}
     {{ render_field(mf_recovery_form.submit) }}
   </form>
+  {% include "security/_menu.html" %}
 {% endblock content %}

--- a/flask_security/templates/security/two_factor_setup.html
+++ b/flask_security/templates/security/two_factor_setup.html
@@ -1,8 +1,8 @@
 {#
   This template receives different input based on state of tf-setup. In addition
   to form values the following are available:
-  On GET:
-    choices: Value of SECURITY_TWO_FACTOR_ENABLED_METHODS (with possible addition of 'delete'
+  On GET or unsuccessful POST:
+    choices: Value of SECURITY_TWO_FACTOR_ENABLED_METHODS (with possible addition of 'delete')
     two_factor_required: Value of SECURITY_TWO_FACTOR_REQUIRED
     primary_method: the translated name of two-factor method that has already been set up.
   On successful POST:
@@ -30,12 +30,16 @@
     {% for subfield in two_factor_setup_form.setup %}
       {% if subfield.data in choices %}{{ render_field_with_errors(subfield) }}{% endif %}
     {% endfor %}
-    {{ render_field_errors(two_factor_setup_form.setup) }}
-    {{ render_field(two_factor_setup_form.submit) }}
-    {% if chosen_method=="email" and chosen_method in choices %}
-      <div>{{ _fsdomain("To complete logging in, please enter the code sent to your mail") }}</div>
-    {% endif %}
-    {% if chosen_method=="authenticator" and chosen_method in choices %}
+    <div class="fs-div">
+      {% if "sms" in choices %}
+        {{ render_field_with_errors(two_factor_setup_form.phone) }}
+      {% endif %}
+    </div>
+    <div class="fs-gap">
+      {{ render_field_errors(two_factor_setup_form.setup) }}
+      {{ render_field(two_factor_setup_form.submit) }}
+    </div>
+    {% if chosen_method=="authenticator" %}
       <hr>
       <div class="fs-center">
         <div>
@@ -43,40 +47,40 @@
         </div>
         <div>
           <img alt="{{ _fsdomain('Two factor authentication code') }}" id="qrcode" src="{{ authr_qrcode }}">
-          {# TODO: add width and heigth attrs #}
+          {# TODO: add width and height attrs #}
         </div>
         <div>{{ authr_key }}</div>
       </div>
     {% endif %}
-    {% if chosen_method=="sms" and chosen_method in choices %}
-      <p>{{ _fsdomain("To Which Phone Number Should We Send Code To?") }}</p>
-      {{ two_factor_setup_form.hidden_tag() }}
-      {{ render_field_with_errors(two_factor_setup_form.phone) }}
-      {{ render_field(two_factor_setup_form.submit) }}
-    {% endif %}
   </form>
-  {% if security.webauthn and not chosen_method %}
-    <h3>{{ _fsdomain("WebAuthn") }}</h3>
-    <div class="fs-div">
-      {{ _fsdomain("This application supports WebAuthn security keys.") }}
-      <a href="{{ url_for_security('wan_register') }}">{{ _fsdomain("You can set them up here.") }}</a>
-    </div>
-  {% endif %}
   {% if chosen_method %}
     {# Hide this when first setting up #}
-    <hr>
+    {# This is the fill in code part #}
+    <hr class="fs-gap">
+    <div class="fs-important">{{ _fsdomain("Enter code to complete setup") }}</div>
     <form action="{{ url_for_security('two_factor_token_validation') }}" method="post" name="two_factor_verify_code_form">
       {{ two_factor_verify_code_form.hidden_tag() }}
-      {{ render_field_with_errors(two_factor_verify_code_form.code) }}
-      {{ render_field(two_factor_verify_code_form.submit) }}
+      {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder=_fsdomain("enter numeric code")) }}
+      <div class="fs-gap">{{ render_field(two_factor_verify_code_form.submit) }}</div>
     </form>
+  {% else %}
+    {% if security.support_mfa and security.multi_factor_recovery_codes %}
+      <hr class="fs-gap">
+      <h3>{{ _fsdomain("Recovery Codes") }}</h3>
+      <div class="fs-div">
+        {{ _fsdomain("This application supports setting up recovery codes.") }}
+        <a href="{{ url_for_security('mf_recovery_codes') }}">{{ _fsdomain("You can set them up here.") }}</a>
+      </div>
+    {% endif %}
+    {% if security.webauthn %}
+      <hr class="fs-gap">
+      <h3>{{ _fsdomain("WebAuthn") }}</h3>
+      <div class="fs-div">
+        {{ _fsdomain("This application supports WebAuthn security keys.") }}
+        <a href="{{ url_for_security('wan_register') }}">{{ _fsdomain("You can set them up here.") }}</a>
+      </div>
+    {% endif %}
   {% endif %}
-  {% if security.support_mfa and security.multi_factor_recovery_codes %}
-    <h3>{{ _fsdomain("Recovery Codes") }}</h3>
-    <div class="fs-div">
-      {{ _fsdomain("This application supports setting up recovery codes.") }}
-      <a href="{{ url_for_security('mf_recovery_codes') }}">{{ _fsdomain("You can set them up here.") }}</a>
-    </div>
-  {% endif %}
+
   {% include "security/_menu.html" %}
 {% endblock content %}

--- a/flask_security/templates/security/two_factor_verify_code.html
+++ b/flask_security/templates/security/two_factor_verify_code.html
@@ -4,23 +4,25 @@
 {% block content %}
   {% include "security/_messages.html" %}
   <h1>{{ _fsdomain("Two-factor Authentication") }}</h1>
-  <h2>{{ _fsdomain("Please enter your authentication code generated via: %(method)s", method=chosen_method) }}</h2> {# chosen_method is translated string #}
+  <h3>{{ _fsdomain("Please enter your authentication code generated via: %(method)s", method=chosen_method) }}</h3> {# chosen_method is translated string #}
   <form action="{{ url_for_security('two_factor_token_validation') }}{{ prop_next() }}" method="post" name="two_factor_verify_code_form">
     {{ two_factor_verify_code_form.hidden_tag() }}
-    {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder=_fsdomain("enter code")) }}
+    {{ render_field_with_errors(two_factor_verify_code_form.code, placeholder=_fsdomain("enter numeric code")) }}
     {{ render_field(two_factor_verify_code_form.submit) }}
   </form>
-  <hr class="fs-gap">
-  <form action="{{ url_for_security('two_factor_rescue') }}{{ prop_next() }}" method="post" name="two_factor_rescue_form">
-    {{ two_factor_rescue_form.hidden_tag() }}
-    {{ render_field_with_errors(two_factor_rescue_form.help_setup) }}
-    {% if problem=="email" %}
-      <div>{{ _fsdomain("The code for authentication was sent to your email address") }}</div>
-    {% endif %}
-    {% if problem=="help" %}
-      <div>{{ _fsdomain("A mail was sent to us in order to reset your application account") }}</div>
-    {% endif %}
-    {{ render_field(two_factor_rescue_form.submit) }}
-  </form>
+  {% if two_factor_rescue_form %}
+    <hr class="fs-gap">
+    <form action="{{ url_for_security('two_factor_rescue') }}{{ prop_next() }}" method="post" name="two_factor_rescue_form">
+      {{ two_factor_rescue_form.hidden_tag() }}
+      {{ render_field_with_errors(two_factor_rescue_form.help_setup) }}
+      {% if problem=="email" %}
+        <div>{{ _fsdomain("The code for authentication was sent to your email address") }}</div>
+      {% endif %}
+      {% if problem=="help" %}
+        <div>{{ _fsdomain("An email was sent to us in order to reset your application account") }}</div>
+      {% endif %}
+      {{ render_field(two_factor_rescue_form.submit) }}
+    </form>
+  {% endif %}
   {% include "security/_menu.html" %}
 {% endblock content %}

--- a/flask_security/templates/security/us_setup.html
+++ b/flask_security/templates/security/us_setup.html
@@ -62,7 +62,7 @@
           </div>
           <div>
             <img alt="{{ _fsdomain('Passwordless QRCode') }}" id="qrcode" src="{{ authr_qrcode }}">
-            {# TODO: add width and heigth attrs #}%}
+            {# TODO: add width and heigth attrs #}
           </div>
           <div>{{ authr_key }}</div>
         </div>

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -5,7 +5,7 @@
     Flask-Security two_factor module
 
     :copyright: (c) 2016 by Gal Stainfeld, at Emedgene
-    :copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
 """
 
 import typing as t
@@ -231,5 +231,4 @@ class CodeTfPlugin(TfPluginBase):
 
         # JSON response - Fake up a form - doesn't really matter which.
         form = DummyForm(formdata=None)
-        form.user = user
         return base_render_json(form, include_user=False, additional=json_payload)

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -87,6 +87,7 @@ from .utils import (
     url_for_security,
     view_commit,
 )
+from .twofactor import tf_clean_session
 from .webauthn import has_webauthn
 
 if t.TYPE_CHECKING:  # pragma: no cover
@@ -563,6 +564,9 @@ def us_signin() -> "ResponseValue":
     form = t.cast(UnifiedSigninForm, build_form_from_request("us_signin_form"))
     form.submit.data = True
     form.submit_send_code.data = False
+    # Clean out any potential old session info - in case of previous
+    # aborted 2FA attempt.
+    tf_clean_session()
 
     if form.validate_on_submit():
         # Check if multi-factor is required. Some (this is configurable) don't

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -1476,7 +1476,7 @@ def test_tf(app, client, get_message):
     sms_sender = SmsSenderFactory.createSender("test")
     data = dict(setup="sms", phone="+442083661177")
     response = client.post("/tf-setup", data=data, follow_redirects=True)
-    assert b"To Which Phone Number Should We Send Code To" in response.data
+    assert b"Enter code to complete setup" in response.data
     code = sms_sender.messages[0].split()[-1]
 
     response = client.post("/tf-validate", data=dict(code=code), follow_redirects=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,7 @@
 
     Test utils
 
-    :copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 from contextlib import contextmanager
@@ -50,11 +50,14 @@ def json_authenticate(client, email="matt@lp.com", password="password", endpoint
     return client.post(ep, content_type="application/json", json=data)
 
 
-def is_authenticated(client, get_message):
+def is_authenticated(client, get_message, auth_token=None):
     # Return True is 'client' is authenticated.
     # Return False if not
     # Raise ValueError not certain...
-    response = client.get("/profile", headers={"accept": "application/json"})
+    headers = {"accept": "application/json"}
+    if auth_token:
+        headers["Authentication-Token"] = auth_token
+    response = client.get("/profile", headers=headers)
     if response.status_code == 200:
         return True
     if response.status_code == 401 and response.json["response"]["errors"][0].encode(


### PR DESCRIPTION
Two-Factor setup. Prior to this release when setting up "SMS" the `/tf-setup` endpoint could
  be POSTed to w/o a phone number, and then another POST could be made to set the phone number.
  This has always been confusing and added complexity to the code. Now, if "SMS" is selected, the phone number
  must be supplied (which has always been supported).
  Other changes:

    - The default two-factor-setup.html template now has a more generic `"Enter code to complete setup"` message.
    - Make sure the `"disable"` option first. - Adding any currently configured two-factor method on setup failure. - The two_factor_verify template won't show the rescue form if it isn't set. - A GET on /tf-validate now returns the two-factor-validate-form always - before if the client was validating a new method, it would return the two-factor-setup-form - After successfully disabling two-factor the client is redirected to :py:data:`SECURITY_TWO_FACTOR_POST_SETUP_VIEW` rather than :py:data:`SECURITY_POST_LOGIN_VIEW`.

 Also - make /us-setup/<token> a POST only endpoint.
 On /login and /us-signin - on GET reset any two factor session info (from a possible failed/interrupted 2fa setup).