### PR TITLE
Updates for python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,12 +29,14 @@ jobs:
           - {python: '3.10', tox: 'py310-low'}
           - {python: '3.11', tox: 'py311-release'}
           - {python: '3.11', tox: 'py311-low'}
+          - { python: '3.12', tox: 'py312-release' }
+          - { python: '3.12', tox: 'py312-low' }
           - {python: 'pypy-3.9', tox: 'pypy39-release'}
           - {python: 'pypy-3.9', tox: 'pypy39-low'}
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: update pip
@@ -54,7 +56,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
-        - uses: actions/setup-python@v4
+        - uses: actions/setup-python@v5
           with:
             python-version: "3.9"
         - name: update pip
@@ -69,7 +71,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
-        - uses: actions/setup-python@v4
+        - uses: actions/setup-python@v5
           with:
             python-version: "3.9"
         - name: update pip
@@ -83,7 +85,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v4
-        - uses: actions/setup-python@v4
+        - uses: actions/setup-python@v5
           with:
             python-version: "3.9"
         - name: update pip
@@ -117,7 +119,7 @@ jobs:
             --health-retries 5
       steps:
         - uses: actions/checkout@v4
-        - uses: actions/setup-python@v4
+        - uses: actions/setup-python@v5
           with:
             python-version: "3.9"
         - name: update pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
         additional_dependencies:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ from Flask-Login and may require some application changes due to backwards incom
 Features
 ++++++++
 - (:issue:`879`) Work with Flask[async]. view decorators and signals support async handlers.
+- (:pr:`900`) CI support for python 3.12
 
 Fixes
 +++++

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (C) 2012-2021 by Matthew Wright
-Copyright (C) 2019-2021 by Chris Wagner
+Copyright (C) 2019-2024 by Chris Wagner
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Quickly add security features to your Flask application.
 
 Notes on this repo
 ------------------
-This is a independently maintained version of Flask-Security based on the 3.0.0
+This is a independently maintained version of Flask-Security forked from the 3.0.0
 version of the `Original <https://github.com/mattupstate/flask-security>`_
 
 Goals

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,7 @@ master_doc = "index"
 
 # General information about the project.
 project = "Flask-Security"
-copyright = "2012-2023"
+copyright = "2012-2024"
 author = "Matt Wright & Chris Wagner"
 
 # The version info for the project you're documenting, acts as replacement for
@@ -248,7 +248,7 @@ texinfo_documents = [
 epub_title = "Flask-Security"
 epub_author = "Matt Wright"
 epub_publisher = "J. Christopher Wagner"
-epub_copyright = "2012-2020"
+epub_copyright = "2012-2024"
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -609,9 +609,10 @@ Core - rarely need changing
 
 .. py:data:: SECURITY_DATETIME_FACTORY
 
-    Specifies the default datetime factory.
+    Specifies the default datetime factory. The default is naive-UTC which
+    corresponds to many DB's DateTime type.
 
-    Default:``datetime.datetime.utcnow``.
+    Default:``flask_security.naive_utcnow``.
 
 .. py:data:: SECURITY_CONFIRM_SALT
 

--- a/examples/unified_signin/server/api.py
+++ b/examples/unified_signin/server/api.py
@@ -1,10 +1,10 @@
 """
-Copyright 2020 by J. Christopher Wagner (jwag). All rights reserved.
+Copyright 2020-2024 by J. Christopher Wagner (jwag). All rights reserved.
 :license: MIT, see LICENSE for more details.
 
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 
 from flask import Blueprint, abort, current_app, jsonify
 from flask_security import auth_required
@@ -17,7 +17,7 @@ api = Blueprint("api", __name__)
 @api.route("/health", methods=["GET"])
 @auth_required("session")
 def health():
-    return jsonify(secret="lush oranges", date=datetime.utcnow())
+    return jsonify(secret="lush oranges", date=datetime.now(timezone.utc))
 
 
 @api.route("/popmail", methods=["GET"])

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -2,11 +2,11 @@
     flask_security
     ~~~~~~~~~~~~~~
 
-    Flask-Security is a Flask extension that aims to add quick and simple
-    security via Flask-Login, Flask-Principal, Flask-WTF, and passlib.
+    Flask-Security is a Flask extension that aims to add comprehensive security
+    to Flask applications.
 
     :copyright: (c) 2012-2019 by Matt Wright.
-    :copyright: (c) 2019-2023 by J. Christopher Wagner.
+    :copyright: (c) 2019-2024 by J. Christopher Wagner.
     :license: MIT, see LICENSE for more details.
 """
 
@@ -111,6 +111,7 @@ from .utils import (
     login_user,
     logout_user,
     lookup_identity,
+    naive_utcnow,
     password_breached_validator,
     password_complexity_validator,
     password_length_validator,

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -7,7 +7,7 @@
     :copyright: (c) 2012 by Matt Wright.
     :copyright: (c) 2017 by CERN.
     :copyright: (c) 2017 by ETH Zurich, Swiss Data Science Center.
-    :copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -96,6 +96,7 @@ from .utils import (
     get_message,
     get_request_attr,
     is_user_authenticated,
+    naive_utcnow,
     set_request_attr,
     uia_email_mapper,
     uia_username_mapper,
@@ -285,7 +286,7 @@ _default_config: t.Dict[str, t.Any] = {
     "API_ENABLED_METHODS": ["session", "token"],
     "HASHING_SCHEMES": ["sha256_crypt", "hex_md5"],
     "DEPRECATED_HASHING_SCHEMES": ["hex_md5"],
-    "DATETIME_FACTORY": datetime.utcnow,
+    "DATETIME_FACTORY": naive_utcnow,
     "TOTP_SECRETS": None,
     "TOTP_ISSUER": None,
     "SMS_SERVICE": "Dummy",
@@ -1265,6 +1266,7 @@ class Security:
         self.register_blueprint: bool
         self.two_factor_plugins: TfPlugin
         self.oauthglue: t.Optional[OAuthGlue] = None
+        self.datetime_factory: t.Callable[[], datetime]
 
         self.login_manager: "flask_login.LoginManager"
         self._mail_util: MailUtil

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -5,10 +5,10 @@
     This module contains an user datastore classes.
 
     :copyright: (c) 2012 by Matt Wright.
-    :copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
-import datetime
+from datetime import datetime
 import json
 import typing as t
 import uuid
@@ -818,6 +818,8 @@ class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
         extensions: t.Optional[str] = None,
         **kwargs: t.Any,
     ) -> None:
+        from .proxies import _security
+
         if not hasattr(self, "webauthn_model") or not self.webauthn_model:
             raise NotImplementedError
 
@@ -831,7 +833,7 @@ class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
             backup_state=backup_state,
             transports=transports,
             extensions=extensions,
-            lastuse_datetime=datetime.datetime.utcnow(),
+            lastuse_datetime=_security.datetime_factory(),
             **kwargs,
         )
         user.webauthn.append(webauthn)
@@ -945,6 +947,8 @@ class MongoEngineUserDatastore(MongoEngineDatastore, UserDatastore):
         extensions: t.Optional[str] = None,
         **kwargs: t.Any,
     ) -> None:
+        from .proxies import _security
+
         if not hasattr(self, "webauthn_model") or not self.webauthn_model:
             raise NotImplementedError
         webauthn = self.webauthn_model(
@@ -958,7 +962,7 @@ class MongoEngineUserDatastore(MongoEngineDatastore, UserDatastore):
             backup_state=backup_state,
             transports=transports,
             extensions=extensions,
-            lastuse_datetime=datetime.datetime.utcnow(),
+            lastuse_datetime=_security.datetime_factory(),
             **kwargs,
         )
         user.webauthn.append(webauthn)
@@ -1080,6 +1084,8 @@ class PeeweeUserDatastore(PeeweeDatastore, UserDatastore):
         extensions: t.Optional[str] = None,
         **kwargs: t.Any,
     ) -> None:
+        from .proxies import _security
+
         if not hasattr(self, "webauthn_model") or not self.webauthn_model:
             raise NotImplementedError
         webauthn = self.webauthn_model(
@@ -1093,7 +1099,7 @@ class PeeweeUserDatastore(PeeweeDatastore, UserDatastore):
             backup_state=backup_state,
             transports=transports,
             extensions=extensions,
-            lastuse_datetime=datetime.datetime.utcnow(),
+            lastuse_datetime=_security.datetime_factory(),
             **kwargs,
         )
         self.put(webauthn)  # type: ignore
@@ -1165,9 +1171,9 @@ if t.TYPE_CHECKING:  # pragma: no cover
         fs_uniquifier: str
         fs_token_uniquifier: str
         fs_webauthn_user_handle: str
-        confirmed_at: t.Optional[datetime.datetime]
-        last_login_at: datetime.datetime
-        current_login_at: datetime.datetime
+        confirmed_at: t.Optional[datetime]
+        last_login_at: datetime
+        current_login_at: datetime
         last_login_ip: t.Optional[str]
         current_login_ip: t.Optional[str]
         login_count: int
@@ -1177,8 +1183,8 @@ if t.TYPE_CHECKING:  # pragma: no cover
         mf_recovery_codes: t.Optional[t.List[str]]
         us_phone_number: t.Optional[str]
         us_totp_secrets: t.Optional[t.Union[str, bytes]]
-        create_datetime: datetime.datetime
-        update_datetime: datetime.datetime
+        create_datetime: datetime
+        update_datetime: datetime
         roles: t.List["Role"]
         webauthn: t.List["WebAuthn"]
 
@@ -1190,7 +1196,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
         name: str
         description: t.Optional[str]
         permissions: t.Optional[t.List[str]]
-        update_datetime: datetime.datetime
+        update_datetime: datetime
 
         def __init__(self, **kwargs):
             ...
@@ -1205,7 +1211,7 @@ if t.TYPE_CHECKING:  # pragma: no cover
         backup_state: bool
         device_type: str
         extensions: t.Optional[str]
-        lastuse_datetime: datetime.datetime
+        lastuse_datetime: datetime
         user_id: int
         usage: str
 

--- a/flask_security/json.py
+++ b/flask_security/json.py
@@ -1,30 +1,11 @@
 """
     Flask-Security JSON extensions.
 
-    :copyright: (c) 2022-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2022-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 
     Pieces of this code liberally copied from flask-mongoengine.
 """
-
-
-def _use_encoder(superclass):  # pragma: no cover
-    """Flask < 2.2"""
-
-    class FsJsonEncoder(superclass):
-        """Flask-Security JSON encoder.
-        Extends Flask's JSONencoder to handle lazy-text.
-        """
-
-        def default(self, obj):
-            from .babel import is_lazy_string
-
-            if is_lazy_string(obj):
-                return str(obj)
-            else:
-                return super().default(obj)
-
-    return FsJsonEncoder
 
 
 def _use_provider(superclass):
@@ -44,19 +25,6 @@ def _use_provider(superclass):
 
 def setup_json(app, bp=None):
     # Called at init_app time.
-    if hasattr(app, "json_provider_class"):
-        # Flask >= 2.2
-        app.json_provider_class = _use_provider(app.json_provider_class)
-        app.json = app.json_provider_class(app)
-        # a bit if a hack - if a package (e.g. flask-mongoengine) hasn't
-        # converted yet - they might use json_encoder. This ONLY applies
-        # to this specific version of Flask that happens to use _json_encoder to
-        # signal if any app/extension has registered an old style encoder.
-        # (app.json_encoder is always set)
-        # (If they do, then Flask 2.2.x won't use json_provider at all)
-        # Of course if they do this AFTER we're initialized all bets are off.
-        if getattr(app, "_json_encoder", None):
-            app.json_encoder = _use_encoder(app.json_encoder)
-
-    elif bp:  # pragma: no cover
-        bp.json_encoder = _use_encoder(app.json_encoder)
+    # Flask >= 2.2
+    app.json_provider_class = _use_provider(app.json_provider_class)
+    app.json = app.json_provider_class(app)

--- a/flask_security/models/fsqla.py
+++ b/flask_security/models/fsqla.py
@@ -1,5 +1,5 @@
 """
-Copyright 2019-2021 by J. Christopher Wagner (jwag). All rights reserved.
+Copyright 2019-2024 by J. Christopher Wagner (jwag). All rights reserved.
 :license: MIT, see LICENSE for more details.
 
 
@@ -11,7 +11,6 @@ BE AWARE: Once any version of this is shipped no changes can be made - instead
 a new version needs to be created.
 """
 
-import datetime
 from typing import cast
 from sqlalchemy import (
     Boolean,
@@ -25,7 +24,7 @@ from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.mutable import MutableList
 from sqlalchemy.sql import func
 
-from flask_security import AsaList, RoleMixin, UserMixin
+from flask_security import AsaList, RoleMixin, UserMixin, naive_utcnow
 
 
 class FsModels:
@@ -77,7 +76,7 @@ class FsRoleMixin(RoleMixin):
         type_=DateTime,
         nullable=False,
         server_default=func.now(),
-        onupdate=datetime.datetime.utcnow,
+        onupdate=naive_utcnow,
     )
 
 
@@ -126,5 +125,5 @@ class FsUserMixin(UserMixin):
         type_=DateTime,
         nullable=False,
         server_default=func.now(),
-        onupdate=datetime.datetime.utcnow,
+        onupdate=naive_utcnow,
     )

--- a/flask_security/password_util.py
+++ b/flask_security/password_util.py
@@ -4,7 +4,7 @@
 
     Utility class providing methods for validating and normalizing passwords.
 
-    :copyright: (c) 2020-2021 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2020-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 
 """

--- a/flask_security/translations/af_ZA/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/af_ZA/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security-Too 4.0.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Michael Bosch <michael@lonelyviking.com>\n"
 "Language: af_ZA\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Intekening Benodig"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,93 +31,93 @@ msgstr "Intekening Benodig"
 msgid "Welcome"
 msgstr "Welkom"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Bevestig asseblief jou e-pos adres"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Intekening instruksies"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Jou wagwoord is teruggestel"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Jou wagwoord is verander"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Wagwoord terugstel instruksies"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "Twee-faktoor Intekening"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr "Twee-faktoor Redding"
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr "Verifikasie Kode"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr "Insette nie geskik vir die versoekte API nie"
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Jy het nie toestemming om hierdie hulpbron te bekyk nie."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Jy moet herverifieer om toegang te kry tot hierdie eindpunt"
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Dankie. Bevestigings instruksies is gestuur na %(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Dankie. Jou e-pos adres is bevestig."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Jou e-pos adres is reeds bevestig."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr ""
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s is reeds geassosieer met 'n rekening."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -126,66 +126,66 @@ msgstr ""
 "Identiteits kenmerk '%(attr)s' met waarde '%(value)s' is reeds "
 "geassosieer met 'n rekening."
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Wagwoord stem nie ooreen nie"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Wagwoorde stem nie ooreen nie"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Herleiding buite die domein is verbied"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "Instruksies om jou wagwoord terug te stel is gestuur na %(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Ongeldige wagwoord terugstellings token."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "E-pos adres benodig bevestiging"
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Bevestigings instruksies is gestuur na %(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -194,77 +194,77 @@ msgstr ""
 "Jy het nie ingeteken binne %(within)s nie. Nuwe instruksies om in te "
 "teken is gestuur na %(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Instruksies om in te teken is gestuur na %(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Ongeldige intekenings token."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Rekening is gestremd."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "E-pos is nie voorsien nie"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Ongeldige e-pos adres"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr "Ongeldige kode"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Wagwoord is nie voorsien nie"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "Wagwoord moet ten minste %(length)s karakters bevat"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr "Wagwoord is te eenvoudig"
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr "Telefoon nommer is ongeldig, bv. afwesige lands kode"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Gespesifieerde verbruiker bestaan nie"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Ongeldige wagwoord"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr "Voorsiende wagwoord of kode is ongeldig"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Jy het met sukses in geteken"
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Wagwoord vergeet?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -272,166 +272,166 @@ msgstr ""
 "Jy het met sukses jou wagwoord teruggestel en jy het automaties in "
 "geteken."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Jou nuwe wagwoord moet verskil van jou vorige wagwoord."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Jy het met sukses jou wagwoord verander."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Teken asseblief in om toegang te kry tot hierdie blad."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Herverifieer asseblief om toegang te kry tot hierdie blad."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr "Herverifikasie suksesvol"
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr "Jy kan slegs hierdie eindpunt bereik wanneer jy nie in geteken is nie."
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr "Mislukking met stuur van kode. Probeer asseblief later weer"
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "Jy het met sukses jou twee-faktoor metode verander."
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr "Jy het tans nie toestemming om hierdie blad te besoek nie"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr "Gemerkde metode is nie geldig nie"
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr "Jy het met sukses twee-faktoor verifikasie afgeskakel"
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr "Versoekte metode is nie geldig nie"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr "Opstel moet voltooi wees binne %(within)s. Begin asseblief oor."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr "Jy moet 'n valiede identiteit spesifiseer om in te teken"
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Gebruik hierdie kode om in te teken: %(code)s."
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -576,19 +576,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr "Beskikbare Metodes"
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -620,47 +620,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr "Kode of Wagwoord"
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr "Via e-pos"
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "Via SMS"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -777,46 +777,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-"Om intekening af te handel, sleutel asseblief die kode in wat na jou "
-"e-pos adres gestuur is"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr "Twee-faktoor verifikasie kode"
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
-msgstr "Na Watter Telefoon Nommer Moet Ons Die Kode Stuur?"
-
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -828,17 +827,13 @@ msgstr "Twee-faktoor Verifikasie"
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr "Die kode vir verifikasie is gestuur na jou e-pos adres"
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
-msgstr "'n E-pos is gestuur na ons om jou rekening te herstel"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
+msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
@@ -1129,3 +1124,18 @@ msgstr ""
 
 #~ msgid "Currently active sign in options:"
 #~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+#~ "Om intekening af te handel, sleutel "
+#~ "asseblief die kode in wat na jou"
+#~ " e-pos adres gestuur is"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr "Na Watter Telefoon Nommer Moet Ons Die Kode Stuur?"
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
+#~ msgstr "'n E-pos is gestuur na ons om jou rekening te herstel"

--- a/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ca_ES/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 3.1.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2019-06-16 00:12+0200\n"
 "Last-Translator: Orestes Sanchez <miceno.atreides@gmail.com>\n"
 "Language: ca_ES\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Per poder veure la pàgina sol·licitada és necessari iniciar la sessió"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,163 +31,163 @@ msgstr "Per poder veure la pàgina sol·licitada és necessari iniciar la sessi�
 msgid "Welcome"
 msgstr "Benvingut"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Si us plau, confirmeu el vostre correu electrònic"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Instruccions d'inici de la sessió"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "S'ha restablit la teva contrasenya"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "S'ha canviat la teva contrasenya"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Instruccions de recuperació de la contrasenya"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr ""
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr ""
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "No tens permís d'accés per a consultar aquest recurs."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr ""
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr ""
 "Moltes gràcies. S'ha enviat un correu electrònic a %(email)s amb "
 "instruccions per confirmar el teu compte."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Moltes gràcies. S'ha confirmat el teu correu electrònic."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "El teu correu electrònic ja s'havia confirmat."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Token de confirmació no vàlid."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s ja es associat amb un compte."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "La contrasenya no coincideix"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Les contrasenyes no coincideixen"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Les redireccions a llocs web externes s'han prohibit"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Les instruccions per restablir la teva contrasenya s'han enviat a "
 "%(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "El token per restablir la contrasenya no és vàlid."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "El correu electrònic requereix d'una confirmació."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Les instruccions de confirmació s'han enviat a %(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -196,77 +196,77 @@ msgstr ""
 "No vas iniciar la sessió abans de %(within)s. S'han enviat noves "
 "instruccions a %(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "S'han enviat instruccions per l'inici de sessió a %(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Token de d'inici de sessió no vàlid."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "el compte està desactivat."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "No s'ha inclòs el correu electrònic"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Adreça de correu electrònic no vàlida"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr ""
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "No s'ha inclòs la contrasenya"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, fuzzy, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "La contrasenya ha de tenir al menys %(length)s caràcters"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr ""
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr ""
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "L'usuari no existeix"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Contrasenya no vàlida"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "La sessió s'ha iniciat amb èxit."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Has oblidat la teva contrasenya?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -274,166 +274,166 @@ msgstr ""
 "Has restablert la teva contrasenya amb èxit i s'ha iniciat la sessió "
 "automàticament."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "La nova contrasenya ha de ser diferent de l'anterior."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "La teva contrasenya s'ha modificat amb èxit."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Has d'iniciar sessió per tal d'accedir a aquesta pàgina."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Has d'iniciar una nova sessió per tal d'accedir a aquesta pàgina."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr ""
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr ""
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -578,19 +578,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -622,47 +622,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -779,44 +779,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -828,16 +829,12 @@ msgstr ""
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
@@ -1134,4 +1131,16 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Currently active sign in options:"
+#~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr ""
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
 #~ msgstr ""

--- a/flask_security/translations/da_DK/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/da_DK/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.1.0\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2017-03-23 14:04+0100\n"
 "Last-Translator: Leonhard Printz <leonhardprintz@protonmail.ch>\n"
 "Language: da_DK\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Login påkræveet"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,161 +31,161 @@ msgstr "Login påkræveet"
 msgid "Welcome"
 msgstr "Velkommen"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Bekræft venligst din email"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Logininstruktioner"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Din adgangskode er blevet nulstillet"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Din adgangskode er blevet ændret"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Instruktioner til nulstilling af adganskode"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr ""
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr ""
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Du har ikke adgang til denne resource."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr ""
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Mange tak. Bekræftelsesinstruktioner er blevet sendt til %(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Mange Tak. Din email er blevet bekræftet."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Din email er allerede blevet bekræftet."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Ugyldig bekræftigelsestoken."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s er allerede brugt af en anden konto."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Adgangskode passer ikke"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Adgangskoderne passer ikke"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Omdirigering udenfor domænet er forbudt"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Instruktioner til nulstilling af din adgangskode er blevet sendt til "
 "%(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Ugyldig nulstillingstoken."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "Email kræver bekræftigelse."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Bekræftigelsesinstruktioner er blevet sendt til %(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -194,77 +194,77 @@ msgstr ""
 "Du har ikke logget in indenfor %(within)s. Nye logininstruktioner er "
 "blevet sendt til %(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Logininstruktioner er blevet sendt til %(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Ugyldig logintoken."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Kontoen er deaktiveret."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Email ikke angivet"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Ugyldig email adresse"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr ""
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Adgangskode ikke angivet"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, fuzzy, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "Adgangskoden skal indeholde mindst %(length)s tegn"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr ""
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr ""
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Denne bruger findes ikke"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Ugyldig adgangskode"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Du er hermed blevet logget ind."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Glemt adgangskode?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -272,166 +272,166 @@ msgstr ""
 "Du har hermed nulstillet din adgangskode og er blevet automatisk logget "
 "ind."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Din nye adgangskode skal være anderledes end din tidligere adgangskode."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Du har hermed ændret din adgangskode."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Log in for at få adgang til denne side."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Bekræft identitet for at få adgang til denne side."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr ""
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr ""
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -576,19 +576,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -620,47 +620,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -777,44 +777,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -826,16 +827,12 @@ msgstr ""
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
@@ -1132,4 +1129,16 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Currently active sign in options:"
+#~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr ""
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
 #~ msgstr ""

--- a/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.1.3\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2022-04-05 13:50+0200\n"
 "Last-Translator: Pascua Theus <pascua@identeco.de>\n"
 "Language: de_DE\n"
@@ -21,11 +21,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Anmeldung erforderlich"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -33,51 +33,51 @@ msgstr "Anmeldung erforderlich"
 msgid "Welcome"
 msgstr "Willkommen"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Bitte E-Mail-Adresse bestätigen"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Anmeldeanleitung"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Das Passwort wurde zurückgesetzt"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Das Passwort wurde geändert"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Anleitung zur Passwortwiederherstellung"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "Zwei-Faktor-Anmeldung"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr "Zwei-Faktor-Wiederherstellung"
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr "Verifizierungscode"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr "Ungültige Eingabe für die angeforderte Ressource"
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 "Authentifizierung fehlgeschlagen – Identität oder Passwort/Passcode "
 "ungültig"
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -85,46 +85,46 @@ msgstr ""
 "Wenn diese E-Mail-Adresse bei uns existiert, erhalten Sie eine E-Mail, in"
 " der beschrieben wird, wie Sie Ihr Passwort zurücksetzen können."
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr "Wenn diese Identität bei uns existiert, wird Ihnen ein Code zugesandt."
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Sie haben keine Berechtigung, um diese Ressource zu sehen."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 #, fuzzy
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Bitte neu authentisieren, um auf diese Seite zuzugreifen."
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Vielen Dank. Bestätigungsanleitung wurde an %(email)s gesendet."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Vielen Dank. Die E-Mail-Adresse wurde bestätigt."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Die E-Mail-Adresse wurde bereits bestätigt."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Ungültiger Bestätigungscode."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s ist bereits mit einem Konto verknüpft."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -133,12 +133,12 @@ msgstr ""
 "Benutzermerkmal '%(attr)s' mit Wert '%(value)s' ist bereits mit einem "
 "anderen Benutzerkonto verknüpft"
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr "Benutzer %(id)s nicht registriert"
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
@@ -146,57 +146,57 @@ msgstr ""
 "Es trat ein Fehler bei der Kommunikation mit dem OAuth-Provider auf. "
 "Bitte versuchen Sie es erneut."
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Das Passwort stimmt nicht überein"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Die Passwörter stimmen nicht überein"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Weiterleitungen außerhalb der Domain sind verboten"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr "Wiederherstellungscode ungültig"
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr "Es wurden noch keine Sicherheitscodes generiert."
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Eine Anleitung, um das Passwort wiederherzustellen wurde an %(email)s "
 "gesendet."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr "Sie haben ihr Passwort nicht innerhalb von %(within)s zurückgesetzt. "
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Ungültiger Passwortwiederherstellungscode."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "Die E-Mail-Adresse muss bestätigt werden."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Bestätigungsanleitung wurde an %(email)s gesendet."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr "Sie haben Ihre E-Mail-Adresse nich innerhalb von $(within)s bestätigt."
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -205,77 +205,77 @@ msgstr ""
 "Die Anmeldung erfolgte nicht in %(within)s. Eine neue Anleitung wurde an "
 "%(email)s gesendet."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Eine Anleitung zur Anmeldung wurde an %(email)s gesendet."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Ungültiger Anmeldecode."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Konto ist deaktiviert."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Keine E-Mail-Adresse angegeben"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Ungültige E-Mail-Adresse"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr "Ungültiger Code"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Kein Passwort angegeben"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, fuzzy, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "Das Passwort muss mindestens %(length)s Zeichen lang sein"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr "Passwort ist nicht komplex genug"
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr "Passwort ist öffentlich bekannt"
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr "Konnte keine Verbindung zum Dienst aufbauen, um Passwörter zu überprüfen."
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr "Telefonnumer ist ungültig, eventuell fehlt die Landesvorwahl"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Der angegebene Benutzer existiert nicht"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Ungültiges Passwort"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr "Übermitteltes Passwort oder Code ist ungültig"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Sie wurden angemeldet."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Passwort vergessen?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -283,7 +283,7 @@ msgstr ""
 "Das Passwort wurde erfolgreich wiederhergestellt und die Anmeldung "
 "erfolgte automatisch."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -291,90 +291,90 @@ msgstr ""
 "Sie haben Ihr Passwort erfolgreich zurückgesetzt. Bitte bestätigen Sie "
 "Ihr neues Passwort."
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Das neue Passwort muss sich vom vorherigen unterscheiden."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Das Passwort wurde erfolgreich geändert."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Bitte melden Sie sich an, um diese Seite zu sehen."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Bitte neu anmelden, um auf diese Seite zuzugreifen."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr "Neuanmeldung erfolgreich"
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr "Dieser Endpunkt ist nur für angemeldete Nutzer erlaubt."
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr "Code wurde gesendet."
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr ""
 "Zusendung des Codes fehlgeschlagen. Bitte versuchen Sie es später noch "
 "einmal."
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr "Ihr Code wurde bestätigt."
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "Sie haben Ihre Zwei-Faktor-Methode erfolgreich geändert."
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr "Sie haben aktuell nicht die nötigen Rechte, um die Seite anzusehen"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr "Ausgewählte Methode ist nicht gültig"
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr "Zwei-Faktor-Authentisierung wurde deaktiviert"
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr "Angefragte Methode ist ungültig"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 "Einrichtung muss innerhalb %(within)s abgeschlossen werden. Bitte neu "
 "beginnen."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr "Single-User-Login erfolgreich eingerichtet"
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr "Sie müssen eine gültige Identität auswählen, um sich anzumelden"
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Code zur Anmeldung: %(code)s"
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -383,76 +383,76 @@ msgstr ""
 "Der Benutzername muss mindestens %(min)d und darf nicht länger als "
 "%(max)d Zeichen sein."
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr "Der Benutzername enthält ungültige Zeichen."
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr "Der Benutzername darf nur aus Buchstaben und Ziffern bestehen"
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr "Benutzername nicht angegeben"
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s ist bereits mit einem Benutzerkonto verknüpft."
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 "Der WebAuthn-Vorgang muss innerhalb von %(within)s beendet werden. Bitte "
 "erneut versuchen."
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr "Zum Setzen eines neuen Webauthn-Tokens ist ein Nickname erforderlich."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s ist bereits mit einem Webauthn-Token verknüpft."
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s ist für den aktuellen Benutzer nicht eingetragen."
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr "Der Token '%(name)s' wurde entfernt."
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr "Der WebAuthn-Token '%(name)s' wurde hinzugefügt."
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr "WebAuthn-Token-ID wurde bereits eingetragen."
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr "Nicht eingetragene WebAuthn-Token-ID."
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "WebAuthn-Token gehört zu keinem Benutzer."
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "Konnte WebAuthn-Token nicht verifizieren: %(cause)s."
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr "WebAuthn-Token ist für diese Verwendung nicht eingetragen."
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr "Benutzerhandle des WebAuthn-Token stimmt nicht überein."
 
@@ -597,19 +597,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr "Verfügbare Methoden"
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr "Deaktiviere Zwei-Faktor-Authentisierung"
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr "Probleme beim Zugriff auf Ihr Konto / Smartphone verloren?"
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr "Kontaktiere einen Administrator"
 
@@ -641,47 +641,47 @@ msgstr "Sende code per E-Mail"
 msgid "Use previously downloaded recovery code"
 msgstr "Zuvor heruntergeladenen Wiederherstellungscode verwenden"
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr "Code oder Passwort"
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr "Via E-Mail"
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "Via SMS"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr "Richte weitere Single-User-Login-Option ein"
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr "Löschen der aktivierten Anmeldeoption"
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr "Nickname"
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr "Benutzung"
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr "Als ersten Faktor benutzen"
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr "Als zweiten Faktor benutzen"
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr "Start"
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr "WebAuthn"
 
@@ -758,7 +758,7 @@ msgid "Enter Recovery Code"
 msgstr "Wiederherstellungscode eingeben"
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr "Wiederherstellungscodes"
@@ -802,13 +802,7 @@ msgstr "Sie müssen zusätzlich zu Benutzername und Passwort einen Code angeben"
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Aktivierte Zwei-Faktor-Methode: %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-"Um die Anmeldung abzuschließen, geben Sie bitte den Code ein, den wir an "
-"Ihre E-Mail-Adresse geschickt haben"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -818,34 +812,39 @@ msgstr ""
 " Sie den folgenden QR-Code (oder geben Sie den unten stehenden Code ein),"
 " um den Empfang von Codes zu beginnen"
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr "Zwei-Faktor-Authentisierungscode"
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
-msgstr "An welche Telefonnummer sollen wir den Code senden?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
-msgstr "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
-msgstr "Diese Anwendung unterstützt WebAuthn-Sicherheitsschlüssel."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr "Diese Anwendung unterstützt die Einrichtung von Wiederherstellungscodes."
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Sie können diese hier einrichten."
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
-msgstr "Diese Anwendung unterstützt die Einrichtung von Wiederherstellungscodes."
+msgid "WebAuthn"
+msgstr "WebAuthn"
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
+msgstr "Diese Anwendung unterstützt WebAuthn-Sicherheitsschlüssel."
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
 msgid "Two-factor Authentication"
@@ -858,19 +857,13 @@ msgstr ""
 "Bitte geben Sie den Authentisierungscode ein, den Sie via %(method)s "
 "erhalten haben."
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr "Der Authentisierungscode wurde an Ihre E-Mail-Adresse gesendet"
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
-"Wir haben eine E-Mail von Ihnen erhalten, um Ihnen bei der "
-"Wiederherstellung Ihres Kontos zu unterstützen"
 
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
@@ -1195,3 +1188,22 @@ msgstr ""
 
 #~ msgid "Currently active sign in options:"
 #~ msgstr "Mögliche Anmeldemöglichkeiten:"
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+#~ "Um die Anmeldung abzuschließen, geben "
+#~ "Sie bitte den Code ein, den wir"
+#~ " an Ihre E-Mail-Adresse geschickt "
+#~ "haben"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr "An welche Telefonnummer sollen wir den Code senden?"
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
+#~ msgstr ""
+#~ "Wir haben eine E-Mail von Ihnen "
+#~ "erhalten, um Ihnen bei der "
+#~ "Wiederherstellung Ihres Kontos zu unterstützen"

--- a/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/es_ES/LC_MESSAGES/flask_security.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 5.4.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2023-12-20 15:33+0100\n"
 "Last-Translator: Giorgio Stampa <giorgio.stampa@sanofi.com>\n"
 "Language: es_ES\n"
@@ -21,11 +21,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Inicio de sesión necesario"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -33,51 +33,51 @@ msgstr "Inicio de sesión necesario"
 msgid "Welcome"
 msgstr "Bienvenido·a"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Confirma tu correo electrónico"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Instrucciones para iniciar sesión"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Tu contraseña ha sido restablecida"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Tu contraseña ha sido cambiada"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Instrucciones de recuperación de contraseña"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "Inicio de sesión de dos factores"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr "Recuperación de sesión de dos factores"
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr "Código de verificación"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr "Entrada no apropiada para la API solicitada"
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 "Fallo de autenticación - identidad o contraseña/código de acceso no "
 "válidos"
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -86,47 +86,47 @@ msgstr ""
 " un correo electrónico con la descripción de como restablecer tu "
 "contraseña."
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr "Si esa identidad está en nuestro sistema, se te envió un código."
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "No tienes permiso para consultar este recurso."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr "Debes autenticarte para acceder a este recurso."
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Debes volver a autenticarte para acceder a este recurso"
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr ""
 "Gracias. Instrucciones sobre cómo confirmar tu cuenta se han enviado a "
 "%(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Gracias. Tu correo electrónico ha sido confirmado."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Tu correo electrónico ya ha sido confirmado."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Autentificador de confirmación inválido."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s ya está asociado a una cuenta."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -135,12 +135,12 @@ msgstr ""
 "El atributo de identidad '%(attr)s' con el valor '%(value)s' ya está "
 "asociado con una cuenta."
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr "Identidad %(id)s no registrada"
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
@@ -148,57 +148,57 @@ msgstr ""
 "Se ha producido un error al comunicarse con el proveedor de OAuth. Por "
 "favor inténtalo de nuevo."
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "La contraseña no coincide"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Las contraseñas no coinciden"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Las redirecciones a sitios web externos están prohibidas"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr "Código de recuperación inválido"
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr "Aún no se han generado códigos de recuperación"
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Las instrucciones para restablecer tu contraseña han sido enviadas a "
 "%(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr "No has restablecido tu contraseña dentro de %(within)s. "
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Autentificador de restablecimiento de contraseña inválido."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "El correo electrónico requiere confirmación."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Las instrucciones de confirmación se han enviado a %(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr "No has confirmado tu correo electrónico dentro de %(within)s. "
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -207,170 +207,170 @@ msgstr ""
 "No has iniciado sesión antes de %(within)s. Nuevas instrucciones para "
 "iniciar sesión han sido enviadas a %(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Instrucciones para iniciar sesión han sido enviadas a %(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Autenticador de inicio de sesión inválido."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Cuenta deshabilitada."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Correo electrónico no indicado"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Dirección de correo electrónico inválida"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr "Código inválido"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Contraseña no indicada"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "La contraseña debe tener al menos %(length)s caracteres"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr "La contraseña no es lo suficientemente compleja"
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr "Contraseña en la lista de contraseñas violadas"
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr "No se ha podido contactar con el sitio de contraseñas violadas"
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr "El número de teléfono no es válido, p. ej. falta el código de país"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Usuario·a especificado·a no existe"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Contraseña inválida"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr "La contraseña o el código facilitado son inválidos"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Has iniciado sesión."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "¿Has olvidado tu contraseña?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Has restablecido tu contraseña y has iniciado sesión automáticamente."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr "Has restablecido tu contraseña. Autentícate con tu nueva contraseña."
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Tu nueva contraseña debe ser diferente de la antigua."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Has cambiado tu contraseña."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Debes iniciar sesión para poder acceder a esta página."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Debes iniciar sesión nuevamente para poder acceder a esta página."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr "Reautenticación exitosa"
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr "Solo puedes acceder a este recurso si no has iniciado sesión."
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr "El código se ha enviado."
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr "No se pudo enviar el código. Por favor inténtalo de nuevo más tarde"
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr "Tu código ha sido confirmado"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "Has cambiado tu método de dos factores."
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr "Actualmente no tienes permisos para acceder a esta página"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr "El método marcado no es válido"
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr "Has deshabilitado la autorización de dos factores."
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr "Opciones de inicio de sesión activas actualmente: %(method_list)s."
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr "El método solicitado no es válido"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 "La configuración debe completarse dentro de %(within)s. Por favor vuelve "
 "a empezar."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr "El inicio de sesión unificado se ha configurado correctamente"
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr "Debes especificar una identidad válida para iniciar sesión"
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Utiliza este código para iniciar sesión: %(code)s."
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -379,76 +379,76 @@ msgstr ""
 "El nombre de usuario debe tener al menos %(min)d caracteres y menos de "
 "%(max)d caracteres"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr "El nombre de usuario contiene caracteres no admitidos"
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr "El nombre de usuario solo puede contener letras y números"
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr "Nombre de usuario no proporcionado"
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s ya está asociado a una cuenta."
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 "La operación de WebAuthn debe completarse dentro de %(within)s. Por favor"
 " vuelve a empezar."
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr "Se requiere un nombre para la nueva credencial."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s ya está asociado a una credencial."
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s no registrado con el usuario actual."
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr "Se ha eliminado la credencial WebAuthn con nombre: %(name)s"
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr "Se ha añadido la credencial WebAuthn con nombre: %(name)s"
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr "Identificador de credencial de WebAuthn ya registrado."
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr "Identificador de credencial de WebAuthn no registrado."
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "La credencial WebAuthn no pertenece a ningún usuario."
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "No se pudo verificar la credencial WebAuthn: %(cause)s."
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr "Credencial no registrada para este uso (primaria o secundaria)"
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr "La credencial de usuario no coincide"
 
@@ -595,19 +595,19 @@ msgstr "contraseña"
 msgid "none"
 msgstr "ninguno"
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr "Métodos disponibles"
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr "Deshabilitar la autenticación de dos factores"
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr "¿Problemas para acceder a tu cuenta/has perdido tu dispositivo móvil?"
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr "Contactar con el administrador"
 
@@ -639,47 +639,47 @@ msgstr "Enviar el código por correo electrónico"
 msgid "Use previously downloaded recovery code"
 msgstr "Usar código de recuperación descargado anteriormente"
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr "Código o contraseña"
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr "Vía correo electrónico"
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "Vía SMS"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr "Configurar una opción de inicio de sesión adicional"
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr "Eliminar la opción de inicio de sesión activa"
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr "Nombre"
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr "Uso"
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr "Uso como factor de autenticación primario"
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr "Uso como factor de autenticación secundario"
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr "Iniciar"
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr "webauthn"
 
@@ -756,7 +756,7 @@ msgid "Enter Recovery Code"
 msgstr "Introducir código de recuperación"
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr "Códigos de recuperación"
@@ -800,13 +800,7 @@ msgstr "Además de tu nombre de usuario y contraseña, deberás utilizar un cód
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Método de dos factores actualmente configurado: %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-"Para completar el inicio de sesión, introduce el código enviado a tu "
-"correo electrónico"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -816,34 +810,39 @@ msgstr ""
 "siguiente código QR (o ingresa manualmente el código que aparece a "
 "continuación) para comenzar a recibir códigos:"
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr "Código de autenticación de dos factores"
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
-msgstr "¿A qué número de teléfono debemos enviar el código?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
-msgstr "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
-msgstr "Esta aplicación es compatible con las claves de seguridad de WebAuthn."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr "Esta aplicación permite establecer códigos de recuperación."
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Se pueden configurar aquí."
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
-msgstr "Esta aplicación permite establecer códigos de recuperación."
+msgid "WebAuthn"
+msgstr "WebAuthn"
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
+msgstr "Esta aplicación es compatible con las claves de seguridad de WebAuthn."
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
 msgid "Two-factor Authentication"
@@ -854,19 +853,13 @@ msgstr "Autenticación de dos factores"
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr "Introduce tu código de autenticación generado a través de: %(method)s"
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr "introduce el código"
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr "El código de autenticación se envió a tu dirección de correo electrónico"
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
-"Se nos envió un correo electrónico para restablecer tu cuenta de "
-"aplicación"
 
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
@@ -1090,3 +1083,20 @@ msgstr ""
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
 #~ msgstr "No estás autenticado. Proporciona las credenciales correctas."
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+#~ "Para completar el inicio de sesión, "
+#~ "introduce el código enviado a tu "
+#~ "correo electrónico"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr "¿A qué número de teléfono debemos enviar el código?"
+
+#~ msgid "enter code"
+#~ msgstr "introduce el código"
+
+#~ msgid "A mail was sent to us in order to reset your application account"
+#~ msgstr ""
+#~ "Se nos envió un correo electrónico "
+#~ "para restablecer tu cuenta de aplicación"

--- a/flask_security/translations/eu_ES/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/eu_ES/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2020-11-28 13:41+0100\n"
 "Last-Translator: Martin Mozos <martinmozos@gmail.com>\n"
 "Language: eu_ES\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Saioa hasi behar da"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,93 +31,93 @@ msgstr "Saioa hasi behar da"
 msgid "Welcome"
 msgstr "Ongi etorri"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Mesedez berretsi zure posta elektronikoa"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Saioa hasteko argibideak"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Zure pasahitza berrezarri da"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Zure pasahitza aldatu da"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Pasahitza berreskuratzeko argibideak"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "Bi faktoreko saioa hastea"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr "Bi faktoreko saioa berreskuratzea"
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr "Egiaztapen kodea"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr "Sarrera ez da egokia eskatutako APIarentzat"
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Ez duzu baliabide hau kontsultatzeko baimenik."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Baliabide honetara sartzeko berriro autentifikatu behar duzu"
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Eskerrik asko. Baieztapen argibideak %(email)s helbidera bidali dira."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Eskerrik asko. Zure posta elektronikoa berretsi da."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Zure posta elektronikoa dagoeneko baieztatuta dago."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Berrespen token baliogabea."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s dagoeneko kontu batekin lotuta dago."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -126,66 +126,66 @@ msgstr ""
 "'%(attr)s' identitate atributua '%(value)s' balioarekin dagoeneko kontu "
 "batekin lotuta dago"
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Pasahitza ez dator bat"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Pasahitzak ez datoz bat"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Domeinutik kanpoko birbideratzeak debekatuta daude"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "Pasahitza berrezartzeko argibideak %(email)s helbidera bidali dira."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Pasahitza berrezartzeko token baliogabea."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "Mezu elektronikoak berrespena behar du."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Baieztapen argibideak %(email)s helbidera bidali dira."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -194,168 +194,168 @@ msgstr ""
 "Ez duzu saioa hasi %(within)s barruan. Saioa hasteko argibide berriak "
 "%(email)s helbidera bidali dira."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Saioa hasteko argibideak %(email)s helbidera bidali dira."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Saioa hasteko token baliogabea."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Kontua desgaituta dago."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Helbide elektronikoa beharrezkoa da"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Helbide elektroniko baliogabea"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr "Kode baliogabea"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Pasahitza beharrezkoa da"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "Pasahitzak gutxienez %(length)s karaktere izan behar ditu"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr "Pasahitza ez da nahikoa konplexua"
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr "Pasahitza urratutako zerrendan"
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr "Ezin izan da urratutako pasahitzen iturburuarekin harremanetan jarri"
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr "Telefono zenbakiak ez du balio, baliteke herrialde kodea faltatzea"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Zehaztutako erabiltzea ez da existitzen"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Pasahitz okerra"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr "Zehaztutako pasahitzak edo kodeak ez du balio"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Behar bezala hasi duzu saioa."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Pasahitza ahaztua?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Pasahitza berrezarri duzunez automatikoki hasi duzu saioa."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Zure pasahitz berriak zure aurreko pasahitzaren ezberdin behar du izan."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Pasahitza behar bezala aldatu duzu."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Hasi saioa orri honetara sartzeko."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Mesedez, berriro autentifikatu orri honetara sartzeko."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr "Berautentifikatzea osatu da"
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr "Saioa amaitzen ez duzunean soilik sar zaitezke baliabide honetara"
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr "Ezin izan da kodea bidali. Saiatu berriro geroago"
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "Bi faktoretako metodoa ondo aldatu duzu."
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr "Une honetan ez duzu baimenik orrialde honetara sartzeko"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr "Markatutako metodoak ez du balio"
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr "Bi faktoreren baimena behar bezala desgaitu duzu."
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr "Eskatutako metodoak ez du balio"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr "Konfigurazioa %(within)s barruan osatu behar da. Mesedez, berriro hasi."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr "Bateratutako saio hasierarako konfigurazioa ongi egin da"
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr "Saioa hasteko identitate baliagarria zehaztu behar duzu"
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Erabili kode hau saioa hasteko: %(code)s."
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -364,74 +364,74 @@ msgstr ""
 "Erabiltzaile izenak gutxienez %(min)d karaktere eta %(max)d karaktere "
 "baino gutxiago izan behar ditu"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr "Erabiltzaile izenak legez kanpoko karaktereak ditu"
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr "Erabiltzaile izenak letrak eta zenbakiak soilik izan ditzake"
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr "Erabiltzaile izena ez da eman"
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s dagoeneko kontu batekin lotuta dago."
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -578,19 +578,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr "Eskuragarri dauden metodoak"
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -622,47 +622,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr "Kodea edo pasahitza"
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr "Posta elektronikoaren bidez"
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "SMS bidez"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -781,11 +781,7 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr "Saioa hasten bukatzeko, idatzi zure posta elektronikora bidalitako kodea"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -794,33 +790,38 @@ msgstr ""
 "Ireki autentifikazio aplikazio bat zure gailuan eta eskaneatu QR kode hau"
 " (edo idatzi beheko kodea eskuz) kodeak jasotzen hasteko:"
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr "Bi faktoretako autentifikazio kodea"
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
-msgstr "Zein telefono zenbakiri bidali beharko genioke kodea?"
-
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -832,17 +833,13 @@ msgstr "Bi faktoretako autentifikazioa"
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr "Autentifikaziorako kodea zure helbide elektronikora bidali da"
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
-msgstr "Zure eskaera kontua berrezartzeko mezu elektroniko bat bidali ziguten"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
+msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
@@ -1132,3 +1129,17 @@ msgstr ""
 
 #~ msgid "Currently active sign in options:"
 #~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+#~ "Saioa hasten bukatzeko, idatzi zure "
+#~ "posta elektronikora bidalitako kodea"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr "Zein telefono zenbakiri bidali beharko genioke kodea?"
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
+#~ msgstr "Zure eskaera kontua berrezartzeko mezu elektroniko bat bidali ziguten"

--- a/flask_security/translations/flask_security.pot
+++ b/flask_security/translations/flask_security.pot
@@ -1,15 +1,15 @@
 # Translations template for Flask-Security.
-# Copyright (C) 2023 ORGANIZATION
+# Copyright (C) 2024 ORGANIZATION
 # This file is distributed under the same license as the Flask-Security
 # project.
-# FIRST AUTHOR <EMAIL@ADDRESS>, 2023.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2024.
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 5.4.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr ""
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -30,401 +30,401 @@ msgstr ""
 msgid "Welcome"
 msgstr ""
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr ""
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr ""
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr ""
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr ""
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr ""
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr ""
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr ""
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr ""
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr ""
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr ""
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr ""
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr ""
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr ""
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr ""
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr ""
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr ""
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr ""
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
 "sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr ""
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr ""
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr ""
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr ""
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr ""
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr ""
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr ""
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr ""
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr ""
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr ""
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr ""
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr ""
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr ""
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr ""
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr ""
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr ""
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr ""
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr ""
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr ""
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr ""
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -569,19 +569,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -613,47 +613,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -770,44 +770,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -819,16 +820,12 @@ msgstr ""
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30

--- a/flask_security/translations/fr_FR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/fr_FR/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2017-06-08 10:13+0200\n"
 "Last-Translator: Alexandre Bulté <alexandre@bulte.net>\n"
 "Language: fr_FR\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Connexion requise"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,161 +31,161 @@ msgstr "Connexion requise"
 msgid "Welcome"
 msgstr "Bienvenue"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Merci de confirmer votre adresse email"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Instructions de connexion"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Votre mot de passe a été réinitialisé"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Votre mot de passe a été changé"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Instructions de réinitialisation de votre mot de passe"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr ""
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr ""
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Vous n'avez pas l'autorisation d'accéder à cette ressource."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Merci de vous reconnecter pour accéder à cette page."
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Merci. Les instructions de confirmation ont été envoyées à %(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Merci. Votre adresse email a été confirmée."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Votre adresse email a déjà été confirmée."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Token de confirmation non valide."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "L'adresse %(email)s est déjà utilisée."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Le mot de passe ne correspond pas"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Les mots de passe ne correspondent pas"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Les redirections en dehors du domaine sont interdites"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Les instructions de réinitialisation de votre mot de passe ont été "
 "envoyées à %(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Token de réinitialisation non valide."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "Une confirmation de l'adresse email est requise."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Les instructions de confirmation ont été envoyées à %(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -194,77 +194,77 @@ msgstr ""
 "Vous ne vous êtes pas connecté dans l'intervalle requis (%(within)s)De "
 "nouvelles instructions ont été envoyées à %(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Les instructions de connexion ont été envoyées à %(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Token de connexion non valide."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Le compte est désactivé."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Merci d'indiquer une adresse email"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Adresse email non valide"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr "Code invalide"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Merci d'indiquer un mot de passe"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, fuzzy, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "Le mot de passe doit comporter au moins %(length)s caractères"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr ""
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr "Numéro de téléphone non valide, par ex. code pays manquant"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Cet utilisateur n'existe pas"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Mot de passe non valide"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr "Le mot de passe ou le code soumis n'est pas valide"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Vous êtes bien connecté."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Mot de passe oublié&thinsp;?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -272,166 +272,166 @@ msgstr ""
 "Vous avez bien réinitialisé votre mot de passe et avez été "
 "automatiquement connecté."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Votre nouveau mot de passe doit être différent du précédent."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Vous avez bien changé votre mot de passe."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Merci de vous connecter pour accéder à cette page."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Merci de vous reconnecter pour accéder à cette page."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr "Réauthentification réussie"
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr ""
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "Vous avez réussi à modifier votre méthode à deux facteurs."
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr "Options de connexion actuellement actives : %(method_list)s."
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr "Configuration de la connexion unifiée réussie"
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr "Vous devez spécifier une identité valide pour vous connecter"
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr "Le surnom du nouvel identifiant est requis."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr "Identifiant non enregistré pour cet usage (premier ou secondaire)"
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -578,19 +578,19 @@ msgstr "mot de passe"
 msgid "none"
 msgstr "aucune"
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr "Méthodes disponibles"
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr "Désactiver l'authentification à deux facteurs"
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -622,47 +622,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr "Code ou mot de passe"
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "Par SMS"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr "Configurer une option de connexion supplémentaire"
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr "Surnom"
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr "Utiliser comme premier facteur d'authentification"
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr "Utiliser comme facteur d'authentification secondaire"
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr "Démarrer"
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -783,47 +783,46 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Méthode à deux facteurs actuellement configurée : %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-"Pour terminer la connexion, veuillez saisir le code envoyé à votre "
-"messagerie"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
-msgstr "Cette application prend en charge les clés de sécurité WebAuthn."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Vous pouvez les paramétrer ici."
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
 msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
+msgstr "Cette application prend en charge les clés de sécurité WebAuthn."
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
 msgid "Two-factor Authentication"
@@ -834,16 +833,12 @@ msgstr "Authentification à deux facteurs"
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr "Veuillez saisir votre code d'authentification généré via: %(method)s"
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr "entrez le code"
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
@@ -1085,3 +1080,18 @@ msgstr ""
 #~ " email dans l'intervalle requis "
 #~ "(%(within)s)De nouvelles instructions ont été"
 #~ " envoyées à %(email)s."
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+#~ "Pour terminer la connexion, veuillez "
+#~ "saisir le code envoyé à votre "
+#~ "messagerie"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr ""
+
+#~ msgid "enter code"
+#~ msgstr "entrez le code"
+
+#~ msgid "A mail was sent to us in order to reset your application account"
+#~ msgstr ""

--- a/flask_security/translations/hu_HU/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/hu_HU/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: hu_HU\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Bejelentkezés szükséges"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,49 +31,49 @@ msgstr "Bejelentkezés szükséges"
 msgid "Welcome"
 msgstr "Üdvözöljük"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Kérjük, erősítse meg e-mail címét"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Bejelentkezési utasítások"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "A jelszava visszaállításra került"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "A jelszava megváltozott"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Jelszó visszaállítási utasítások"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "Kétfaktoros Bejelentkezés"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr "Kétfaktoros Visszaállítás"
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr "Ellenőrző kód"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr "A bemenet nem megfelelő a kért API-hoz"
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr "Sikertelen hitelesítés - azonosító vagy jelszó/kód érvénytelen"
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -81,47 +81,47 @@ msgstr ""
 "Ha ez az e-mail cím szerepel a rendszerünkben, akkor kapni fog egy "
 "e-mailt a jelszó visszaállítási menetéről."
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr "Ha ez az azonosító szerepel a rendszerünkben, akkor kódot küldtünk."
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Nincs jogosultsága ennek az erőforrásnak a megtekintéséhez."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr "A végpont eléréséhez újra hitelesíteni kell"
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr ""
 "Köszönjük. A megerősítő utasításokat elküldtük a következő címre: "
 "%(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Köszönjük. E-mail címét megerősítettük."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Az e-mail címét már megerősítették."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Érvénytelen megerősítő token."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s már társítva van egy fiókhoz."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -130,68 +130,68 @@ msgstr ""
 "A \"%(attr)s\" azonosító attribútum \"%(value)s\" értékkel már társítva "
 "van egy fiókhoz."
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "A jelszó nem egyezik"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "A jelszavak nem egyeznek"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "A tartományon kívüli átirányítások tilosak"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr "A helyreállítási kód érvénytelen"
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "A jelszó visszaállítására vonatkozó utasításokat elküldtük a következő "
 "címre: %(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Érvénytelen jelszó-visszaállítási token."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "Az e-mail megerősítést igényel."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "A megerősítő utasításokat elküldtük a következő címre: %(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -200,170 +200,170 @@ msgstr ""
 "Nem jelentkezett be %(within)s-en belül. Új bejelentkezési utasításokat "
 "küldtünk a következő címre: %(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr ""
 "A bejelentkezéshez szükséges utasításokat elküldtük a következő címre: "
 "%(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Érvénytelen bejelentkezési token."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "A fiók le van tiltva."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "E-mail nincs megadva"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Érvénytelen e-mail cím"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr "Érvénytelen kód"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Nincs megadva a jelszó"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "A jelszónak legalább %(length)s karakterből kell állnia"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr "A jelszó nem elég összetett"
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr "A telefonszám nem érvényes, pl. hiányzik az országkód"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "A megadott felhasználó nem létezik"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Érvénytelen jelszó"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr "A beküldött jelszó vagy kód érvénytelen"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Sikeresen bejelentkezett."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Elfelejtette jelszavát?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Sikeresen visszaállította jelszavát, és automatikusan be is jelentkezett."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Az új jelszavának különböznie kell a korábbi jelszavától."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Sikeresen megváltoztatta a jelszavát."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Kérjük, jelentkezzen be az oldal eléréséhez."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Kérjük, hitelesítse újra az oldal eléréséhez."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr "Az újrahitelesítés sikeres"
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr "\"Csak akkor érheti el ezt a végpontot, ha nincs bejelentkezve."
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr "A kód elküldve."
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr "Nem sikerült elküldeni a kódot. Kérjük, próbálja újra később."
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr "A kódod megerősítésre került"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "Sikeresen megváltoztatta a kétfaktoros hitelesítést."
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr "Jelenleg nincs jogosultsága az oldal eléréséhez"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr "A megjelölt metódus nem érvényes"
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr "Sikeresen letiltotta a kétfaktoros hitelesítést."
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr "A kért metódus nem érvényes"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr "A telepítést %(within)s időn belül be kell fejezni. Kezdje újra."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr "Az egységes bejelentkezés beállítása sikeres"
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr "A bejelentkezéshez érvényes azonositót kell megadnia"
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Használja ezt a kódot a bejelentkezéshez: %(code)s."
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -372,80 +372,80 @@ msgstr ""
 "A felhasználónévnek legalább %(min)d karakterből és kevesebb mint %(max)d"
 " karakterből kell állnia"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr "A felhasználónév illegális karaktereket tartalmaz"
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr "A felhasználónév csak betűket és számokat tartalmazhat"
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr "A felhasználónév nincs megadva"
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s már hozzá van rendelve egy fiókhoz."
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr "A WebAuthn műveletet %(within)s időn belül be kell fejezni. Kezdje újra."
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr "Az új hitelesítő adatokhoz becenév szükséges."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s már hozzá van rendelve egy hitelesítő adathoz."
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s nincs regisztrálva az aktuális felhasználónál."
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 "A WebAuthn hitelesítő adatok sikeresen törölve a következő névvel: "
 "%(name)s"
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 "Sikeresen hozzáadva a WebAuthn hitelesítő adatot a következő névvel: "
 "%(name)s"
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr "A WebAuthn hitelesítő adatazonosítója már regisztrálva."
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr "Nem regisztrált WebAuthn hitelesítő adat azonosítója."
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "A WebAuthn hitelesítő adatok nem tartoznak egyetlen felhasználóhoz sem."
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "Nem sikerült ellenőrizni a WebAuthn hitelesítő adatait: %(cause)s."
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 "A hitelesítő adat nincs regisztrálva ehhez a felhasználáshoz (első vagy "
 "másodlagos)"
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -590,19 +590,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr "Elérhető módszerek"
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr "Kétfaktoros hitelesítés letiltása"
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -634,47 +634,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr "Kód vagy jelszó"
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr "E-mailben"
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "SMS-ben"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr "Kiegészítő bejelentkezési lehetőség beállítása"
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr "Az aktív bejelentkezési opció törlése"
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr "Becenév"
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr "Használat"
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr "Használat első hitelesítési lépésként"
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr "Használat másodlagos hitelesítési lépésként"
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgid "Enter Recovery Code"
 msgstr "Adja meg a helyreállítási kódot"
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr "Helyreállítási kódok"
@@ -793,11 +793,7 @@ msgstr "A felhasználóneve és a jelszava mellett egy kódot is kell használni
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr "A bejelentkezés befejezéséhez adja meg az e-mail címére küldött kódot"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -807,34 +803,39 @@ msgstr ""
 "következő QR-kódot (vagy írja be kézzel az alábbi kódot), hogy megkezdje "
 "a kódok fogadását:"
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr "Kétfaktoros hitelesítési kód"
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
-msgstr "Melyik telefonszámra küldjük a kódot?"
-
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
-msgstr "Ez az alkalmazás támogatja a WebAuthn biztonsági kulcsokat."
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr "Ez az alkalmazás támogatja a helyreállítási kódok beállítását."
+
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Itt állíthatja be."
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
-msgstr "Ez az alkalmazás támogatja a helyreállítási kódok beállítását."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
+msgstr "Ez az alkalmazás támogatja a WebAuthn biztonsági kulcsokat."
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
 msgid "Two-factor Authentication"
@@ -847,17 +848,13 @@ msgstr ""
 "Kérjük, adja meg hitelesítési kódját, amelyet a következővel generált: "
 "%(method)s"
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr "A hitelesítési kódot elküldtük az Ön e-mail címére"
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
-msgstr "E-mailt küldtünk nekünk az alkalmazás fiókjának visszaállítása érdekében"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
+msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
@@ -1105,3 +1102,17 @@ msgstr ""
 
 #~ msgid "Currently active sign in options:"
 #~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr "A bejelentkezés befejezéséhez adja meg az e-mail címére küldött kódot"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr "Melyik telefonszámra küldjük a kódot?"
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
+#~ msgstr ""
+#~ "E-mailt küldtünk nekünk az alkalmazás "
+#~ "fiókjának visszaállítása érdekében"

--- a/flask_security/translations/hy_AM/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/hy_AM/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2020-12-01 11:47+0400\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: hy_AM\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Անհրաժեշտ է մուտք գործել"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,49 +31,49 @@ msgstr "Անհրաժեշտ է մուտք գործել"
 msgid "Welcome"
 msgstr "Բարի գալուստ"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Հաստատեք Ձեր էլ․փոստի հասցեն"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Մուտքի հրահանգներ"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Ձեր գաղտնաբառը վերականգնվել է"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Ձեր գաղտնաբառը փոխվեց"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Գաղտնաբառի վերականգնման հրահանգներ"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "Երկու գործոնով մուտք"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr "Երկու գործոնով վերականգնում"
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr "Վերահաստատման ծածկագիր"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr "Մուտքը չի համապատասխանում հայցվող API֊ին"
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr "Նույնականացումը ձախողվեց. ինքնությունը կամ գաղտնաբառը/ծածկագիրը անվավեր է"
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -81,45 +81,45 @@ msgstr ""
 "Եթե այդ էլ․փոստի հասցեն գտնվում է մեր համակարգում, դուք կստանաք նամակ, "
 "որտեղ նկարագրված է, թե ինչպես վերականգնել ձեր գաղտնաբառը:"
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr "Եթե այդ ինքնությունը մեր համակարգում է, ձեզ ծածկագիր է ուղարկվել:"
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Դուք այս ռեսուրսը դիտելու թույլտվություն չունեք"
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Դուք պետք է կրկին նույնականցվեք որպեսզի այստեղ մուտք գործեք"
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Շնորհակալություն. Հաստատման հրահանգներն ուղարկվել են %(email)s հասցեին։"
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Շնորհակալություն. Ձեր էլ․փոստի հասցեն հաստատվել է։"
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Ձեր էլ․փոստի հասցեն արդեն հաստատված է։"
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Հաստատման տոկենը անվավեր է։"
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s արդեն կապված է այլ օգտահաշվի հետ։"
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -128,66 +128,66 @@ msgstr ""
 "«%(value)s» արժեքով «%(attr)s» ինքնության հատկանիշն արդեն կապված է հաշվի "
 "հետ:"
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr "«%(id)s» ինքնությունը գրանցված չէ"
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr "Oauth մատակարարի հետ կապի սխալ է տեղի ունեցել: Խնդրում եմ կրկին փորձեք."
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Գաղտնաբառը չի համապատասխանում"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Գաղտնաբառերը չեն համապատասխանում"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Դոմենից դուրս վերահղումներն արգելափակված են"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr "Վերականգնման ծածկագիրը անվավեր է"
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr "Վերականգնման ծածկագրեր դեռ չեն ստեղծվել"
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "Գաղտնաբառի վերականգնման հրահանգներն ուղարկվել են %(email)s հասցեին։"
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr "Դուք չեք վերականգնել ձեր գաղտնաբառը %(within)s-ի ընթացքում:"
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Գաղտնաբառի վերականգնման տոկենը անվավեր է։"
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "Էլ․փոստի հասցեն պետք է հաստատել։"
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Հաստատման հրահանգները ուղարկվել են %(email)s հասցեին։"
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr "Դուք չեք հաստատել ձեր էլ․փոստի հասցեն %(within)s-ի ընթացքում:"
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -196,77 +196,77 @@ msgstr ""
 "Դուք մուտք չեք գործել %(within)s֊ի ընթացքում. Մուտքի նոր հրահանգները "
 "ուղարկվել են %(email)s հասցեին։"
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Մուտքի հրահանգները ուղարկվել են %(email)s հասցեին։"
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Մուտքի անվավեր տոկեն։"
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Օգտահաշիվն արգելափակված է։"
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Էլ․փոստի հասցեն տրամադրված չէ"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Անվավեր էլ․փոստի հասցե"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr "Անվավեր ծածկագիր"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Գաղտնաբառը տրամադրված չէ"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "Գաղտնաբառը պետք է պարունակի առնվազն %(length)s նիշ"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr "Գաղտնաբառը բավարար բարդ չէ"
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr "Գաղտնաբառը բացված գաղտնաբառերի ցուցակում է"
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr "Չհաջողվեց կապվել բացված գաղտնաբառերի կայքի հետ"
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr "Հեռախոսահամարը անվավեր է, օրինակ՝ բացակայում է երկրի կոդը"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Նշված օգտատերը գոյություն չունի"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Անվավեր գաղտնաբառ"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr "Ներկայացված գաղտնաբառը կամ ծածկագիրը վավեր չէ"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Դուք բարեհաջող մուտք էք գործել։"
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Մոռացել ե՞ք գաղտնաբառը"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -274,7 +274,7 @@ msgstr ""
 "Դուք հաջողությամբ վերականգնել եք ձեր գաղտնաբառը եւ մուտք էք գործել "
 "համակարգ ինքնաբերաբար։"
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -282,160 +282,160 @@ msgstr ""
 "Դուք հաջողությամբ վերականգնել եք ձեր գաղտնաբառը: Խնդրում ենք "
 "նույնականացնել՝ օգտագործելով ձեր նոր գաղտնաբառը:"
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Ձեր նոր գաղտնաբառը պետք է տարբերվի նախկինից"
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Դուք հաջողությամբ փոխեցիք ձեր գաղտնաբառը։"
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Մուտք գործեք այս էջից օգտվելու համար։"
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Այս էջ մուտք գործելու համար անհրաժեշտ է նորից նույնականացվել:"
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr "Նույնականացումը հաջողված է"
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr "Դուք կարող եք մտնել այս վերջնակետ միայն այն ժամանակ, երբ մուտք չեք գործել"
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr "Ծածկագիրը ուղարկվել է։"
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr "Չհաջողվեց ուղարկել ծածկագիրը: Խնդրում ենք փորձել ավելի ուշ"
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr "Ձեր ծածկագիրը հաստատվեց"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "Դուք հաջողությամբ փոխեցիք ձեր երկու֊գործոն տարբերակը"
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr "Ներկայումս դուք չունեք այս էջ մուտք գործելու թույլտվություն"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr "Նշված տարբերակը վավեր չէ"
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr "Դուք հաջողությամբ անջատել եք երկու գործոնի թույլտվությունը"
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr "Հայցվող մեթոդը վավեր չէ"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr "Կարգավորումը պետք է ավարտվի %(within)s ընթացքում։ Խնդրում ենք նորից սկսել։"
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr "Միասնական մուտքի տեղադրումը հաջող է"
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr "Մուտք գործելու համար պետք է նշեք վավեր ինքնություն"
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Մուտքի համար օգտագործեք այս ծածկագիրը․ %(code)s։"
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr "Օգտանունը պետք է լինի առնվազն %(min)d նիշ և %(max)d նիշից պակաս"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr "Օգտանունը պարունակում է անօրինական նիշեր"
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr "Օգտանունը կարող է պարունակել միայն տառեր և թվեր"
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr "Օգտանուն չի տրամադրվել"
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s արդեն կապված է օգտահաշվի հետ:"
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr "WebAuthn գործողությունը պետք է ավարտվի %(within)s։ Խնդրում եմ սկսել նորից:"
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr "Նոր հավատարմագրի մականունը պարտադիր է:"
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s-ն արդեն կապված է հավատարմագրի հետ:"
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s գրանցված չէ ընթացիկ օգտատիրոջ մոտ:"
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr "%(name)s անունով WebAuthn հավատարմագիրը հաջողությամբ ջնջվեց"
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr "%(name)s անունով WebAuthn հավատարմագիրը հաջողությամբ ավելացվեց"
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr "WebAuthn հավատարմագրի ID-ն արդեն գրանցված է"
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr "Չգրանցված WebAuthn հավատարմագրի ID:"
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "WebAuthn հավատարմագիրը չի պատկանում որևէ օգտվողի:"
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "Չհաջողվեց հաստատել WebAuthn հավատարմագիրը՝ %(cause)s:"
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr "Հավատարմագրերը գրանցված չեն այս օգտագործման համար (առաջին կամ երկրորդական)"
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr "Հավատարմագրերի օգտատիրոջ կապը չի համընկնում"
 
@@ -582,19 +582,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr "Առկա տարբերակներ"
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr "Անջատել երկու գործոնով նույնականացումը"
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -626,47 +626,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr "Ծածկագիր կամ Գաղտնաբառ"
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr "Էլ․ Փոստով"
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "SMS հաղորդագրությամբ"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr "Կարգավորեք մուտքի լրացուցիչ տարբերակ"
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr "Ջնջել ակտիվ մուտքի տարբերակը"
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr "Մականուն"
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr "Կիրառում"
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr "Օգտագործեք որպես նույնականացման առաջին գործոն"
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr "Օգտագործեք որպես նույնականացման երկրորդական գործոն"
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr "Սկսել"
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr "webauthn"
 
@@ -743,7 +743,7 @@ msgid "Enter Recovery Code"
 msgstr "Մուտքագրեք վերականգնման ծածկագիրը"
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr "Վերականգնման ծածկագրեր"
@@ -787,13 +787,7 @@ msgstr "Բացի ձեր օգտանունից և գաղտնաբառից, դուք
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Ներկայիս կարգավորված երկգործոն մեթոդը. %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-"Մուտքն ավարտելու համար մուտքագրեք ձեր էլեկտրոնային հասցեին ուղարկված "
-"ծածկագիրը"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -802,34 +796,39 @@ msgstr ""
 "Բացեք վավերացնող հավելվածը ձեր սարքում և սկանավորեք հետևյալ QRcode-ը (կամ"
 " մուտքագրեք ստորև նշված ծածկագիրը) ծածկագրեր ստանալու համար."
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr "Երկու գործոն նույնականացման ծածկագիր"
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
-msgstr "Ո՞ր հեռախոսահամարին պետք է ուղարկել ծածկագիրը"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
-msgstr "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
-msgstr "Այս հավելվածն օժանդակում է WebAuthn անվտանգության բանալիներին:"
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr "Այս հավելվածն օժանդակում է վերականգնման ծածկագրերի կարգավորումը:"
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Դուք կարող եք դրանք կարգավորել այստեղ:"
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
-msgstr "Այս հավելվածն օժանդակում է վերականգնման ծածկագրերի կարգավորումը:"
+msgid "WebAuthn"
+msgstr "WebAuthn"
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
+msgstr "Այս հավելվածն օժանդակում է WebAuthn անվտանգության բանալիներին:"
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
 msgid "Two-factor Authentication"
@@ -842,17 +841,13 @@ msgstr ""
 "Խնդրում ենք մուտքագրել ձեր նույնականացման ծածկագիրը, որը ստեղծվել է "
 "%(method)s միջոցով."
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr "Նույնականացման ծածկագիրն ուղարկվել է Ձեր էլ․հասցեին"
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
-msgstr "Ձեր օգտահաշվի կիրառումը վերականգնելու համար մեզ նամակ է ուղարկվել"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
+msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
@@ -1078,3 +1073,17 @@ msgstr "Խնդրում ենք վերսկսել գրանցման գործընթա
 
 #~ msgid "Currently active sign in options:"
 #~ msgstr "Ներկայում ակտիվ մուտքի տարբերակներ."
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+#~ "Մուտքն ավարտելու համար մուտքագրեք ձեր "
+#~ "էլեկտրոնային հասցեին ուղարկված ծածկագիրը"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr "Ո՞ր հեռախոսահամարին պետք է ուղարկել ծածկագիրը"
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
+#~ msgstr "Ձեր օգտահաշվի կիրառումը վերականգնելու համար մեզ նամակ է ուղարկվել"

--- a/flask_security/translations/is_IS/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/is_IS/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 4.0.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2022-04-23 17:04+0000\n"
 "Last-Translator: \n"
 "Language: is_IS\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Innskráningar er þörf"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,240 +31,240 @@ msgstr "Innskráningar er þörf"
 msgid "Welcome"
 msgstr "Velkomin(n)"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Vinsamlegast staðfestu netfangið þitt"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Leiðbeiningar fyrir innskráningu"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Lykilorðið þitt hefur verið endurstillt"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Lykilorðinu þínu hefur verið breytt"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Leiðbeiningar um endurstillingu lykilorðs"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "Tveggja þátta innskráning"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr "Staðfestingarkóði"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr ""
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Þú hefur ekki heimild til að skoða þessa auðlind."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr ""
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr ""
 "Þakka þér fyrir. Leiðbeiningar fyrir staðfestingu hafa verið sendar á "
 "%(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Þakka þér fyrir. Netfangið þitt hefur verið staðfest."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Netfangið þitt hefur þegar verið staðfest."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Ógildur staðfestingarkóði."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s er þegar í notkun á öðrum reikningi."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Lykilorðið er ekki eins"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Lykilorðin eru ekki eins"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr ""
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "Leiðbeiningar um hvernig þú getur endurstillt lykilorðið þitt hafa verið "
 "sendar á %(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr ""
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "Netfangið þarfnast staðfestingar."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
 "sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr ""
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr ""
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Aðgangurinn er óvirkur."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Netfang var ekki gefið upp"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Ógilt netfang"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr "Ógildur kóði"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Lykilorð var ekki gefið upp"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "Lykilorð verða að vera að minnsta kosti %(length)s stafir"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr "Lykilorðið er ekki nógu flókið"
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr "Lykilorðið er á lista yfir brotin lykilorð"
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr "Gat ekki haft samband við síðu yfir brotin lykilorð"
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr "Símanúmerið er ekki gilt, t.d. vegna þess að landakóða vantar"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr ""
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Ógilt lykilorð"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Þér tókst að skrá þig inn."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Gleymt lykilorð?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -272,92 +272,92 @@ msgstr ""
 "Þér tókst að endurstilla lykilorðið þitt og þú hefur verið skráð(ur) inn "
 "sjálfkrafa."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Nýja lykilorðið þitt verður að vera öðruvísi en gamla lykilorðið."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Þér tókst að breyta lykilorðinu þínu."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Vinsamlegast skráðu þig inn til að opna þessa síðu."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr ""
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr ""
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr ""
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -366,74 +366,74 @@ msgstr ""
 "Notendanafnið verður að vera að minnsta kosti %(min)d stafir að lengd og "
 "styttra en %(max)d stafir"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr "Notendanafnið inniheldur óleyfileg tákn"
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr "Notendanafnið má eingöngu innihalda bókstafi og tölustafi"
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr "Notendanafn var ekki gefið upp"
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -578,19 +578,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -622,47 +622,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr "Kóði eða lykilorð"
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr "Með tölvupósti"
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "Með SMS skilaboði"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr "Gælunafn"
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr "Notkun"
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr "Byrja"
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -779,44 +779,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -828,16 +829,12 @@ msgstr "Tveggja-þátta auðkenning"
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
@@ -1091,4 +1088,16 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Currently active sign in options:"
+#~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr ""
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
 #~ msgstr ""

--- a/flask_security/translations/it_IT/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/it_IT/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 5.4.0\n"
 "Report-Msgid-Bugs-To: jwag956@github.com\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2023-12-20 15:32+0100\n"
 "Last-Translator: Giorgio Stampa <giorgio.stampa@sanofi.com>\n"
 "Language: it_IT\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Accesso richiesto"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,49 +31,49 @@ msgstr "Accesso richiesto"
 msgid "Welcome"
 msgstr "Benvenuto/a"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Conferma la tua email"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Istruzioni per l'accesso"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "La tua password è stata reimpostata"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "La tua password è stata cambiata"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Istruzioni per reimpostare la password"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "Accesso a due fattori"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr "Recupero dell'accesso a due fattori"
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr "Codice di verifica"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr "Input non appropriato per l'API richiesta"
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr "Autenticazione fallita - identità o password/passcode non validi"
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -81,45 +81,45 @@ msgstr ""
 "Se quell'indirizzo email è nel nostro sistema, riceverai un'email che "
 "descrive come reimpostare la tua password."
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr "Se quell'identità è nel nostro sistema, ti è stato inviato un codice."
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Non hai il permesso per visualizzare questa risorsa."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr "È necessario accedere per accedere a questa risorsa."
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr "È necessario riautenticarsi per accedere a questa risorsa"
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Grazie. Istruzioni di conferma sono state inviate a %(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Grazie. La tua email è stata confermata."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "La tua email è già stata confermata."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Token di conferma non valido."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s è già associata ad un account."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -128,12 +128,12 @@ msgstr ""
 "L'attributo di identità '%(attr)s' con valore '%(value)s' è già associato"
 " ad un account."
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr "Identità %(id)s non registrata"
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
@@ -141,55 +141,55 @@ msgstr ""
 "Si è verificato un errore durante la comunicazione con il prestatore "
 "OAuth. Per favore prova di nuovo."
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "La password non corrisponde"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Le password non corrispondono"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "I reindirizzamenti all'esterno del dominio sono vietati"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr "Codice di ripristino non valido"
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr "Non sono ancora stati generati codici di recupero"
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "Le istruzioni per reimpostare la password sono state inviate a %(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr "Non hai reimpostato la password entro %(within)s. "
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Token di reimpostazione della password non valido."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "L'email richiede conferma."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Le istruzioni di conferma sono state inviate a %(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr "Non hai confermato la tua email entro %(within)s. "
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -198,79 +198,79 @@ msgstr ""
 "Non hai effettuato l'accesso entro %(within)s. Nuove istruzioni per il "
 "login sono state inviate a %(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Le istruzioni per accedere sono state inviate a %(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Token di accesso non valido."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "L'account è disabilitato."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Email non fornita"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Indirizzo email non valido"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr "Codice non valido"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Password non fornita"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "La password deve contenere almeno %(length)s caratteri"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr "Password non abbastanza complessa"
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr "Password nell'elenco delle password violate"
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr "Impossibile contattare il sito delle password violate"
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr ""
 "Numero di telefono non valido, potrebbe mancare il corretto prefisso "
 "internazionale"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "L'utente specificato non esiste"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Password non valida"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr "La password o il codice inviato non sono validi"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Hai effettuato l'accesso."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Password dimenticata?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -278,7 +278,7 @@ msgstr ""
 "Hai reimpostato la tua password e l'accesso è stato effettuato "
 "automaticamente."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
@@ -286,88 +286,88 @@ msgstr ""
 "Hai reimpostato la tua password. Autenticati utilizzando la nuova "
 "password."
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "La tua nuova password deve essere diversa dalla password precedente."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Hai cambiato la tua password."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Devi effettuare l'accesso per accedere a questa pagina."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Devi autenticarti nuovamente per accedere a questa pagina."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr "Riautenticazione riuscita"
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr "Puoi accedere a questa risorsa solo se non hai effettuato l'accesso."
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr "Il codice è stato inviato."
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr "Impossibile inviare il codice. Per favore prova di nuovo più tardi"
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr "Il tuo codice è stato confermato"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "Hai cambiato il tuo metodo a due fattori."
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr "Al momento non disponi dei permessi per accedere a questa pagina"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr "Il metodo selezionato non è valido"
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr "Hai disabilitato l'autorizzazione a due fattori."
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr "Opzioni di accesso attualmente attive: %(method_list)s."
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr "Il metodo richiesto non è valido"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 "La configurazione deve essere completata entro %(within)s. Per favore "
 "ricomincia da capo."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr "Configurazione dell'accesso unificato riuscita"
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr "Devi specificare un'identità valida per accedere"
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Utilizza questo codice per accedere: %(code)s."
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -376,76 +376,76 @@ msgstr ""
 "Il nome utente deve essere composto da almeno %(min)d caratteri e meno di"
 " %(max)d caratteri"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr "Il nome utente contiene caratteri non ammessi"
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr "Il nome utente può contenere solo lettere e numeri"
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr "Nome utente non fornito"
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "%(username)s è già associato ad un account."
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 "L'operazione WebAuthn deve essere completata entro %(within)s. Per favore"
 " ricomincia da capo."
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr "Il nome per la nuova credenziale è obbligatorio."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s è già associato ad una credenziale."
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s non registrato con l'utente attuale."
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr "Credenziale WebAuthn con nome: %(name)s eliminata"
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr "Credenziale WebAuthn con nome: %(name)s aggiunta"
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr "Identificativo di credenziale WebAuthn già registrato."
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr "Identificativo di credenziale WebAuthn non registrato."
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "La credenziale WebAuthn non appartiene a nessun utente."
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "Impossibile verificare la credenziale WebAuthn: %(cause)s."
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr "Credenziale non registrata per questo uso (primaria o secondaria)"
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr "La credenziale dell'utente non corrisponde"
 
@@ -592,19 +592,19 @@ msgstr "password"
 msgid "none"
 msgstr "nessuno"
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr "Metodi disponibili"
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr "Disabilitare l'autenticazione a due fattori"
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr "Problemi di accesso al tuo account?/Dispositivo mobile smarrito?"
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr "Contatta l'amministratore"
 
@@ -636,47 +636,47 @@ msgstr "Invia codice tramite email"
 msgid "Use previously downloaded recovery code"
 msgstr "Utilizza codice di ripristino scaricato in precedenza"
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr "Codice o password"
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr "Tramite email"
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "Tramite SMS"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr "Imposta opzione di accesso aggiuntiva"
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr "Elimina l'opzione di accesso attiva"
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr "Nome"
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr "Utilizzo"
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr "Utilizzare come fattore di autenticazione primario"
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr "Utilizzare come fattore di autenticazione secondario"
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr "Inizio"
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr "webauthn"
 
@@ -753,7 +753,7 @@ msgid "Enter Recovery Code"
 msgstr "Inserisci codice di ripristino"
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr "Codici di ripristino"
@@ -797,11 +797,7 @@ msgstr "Oltre al nome utente e alla password, dovrai utilizzare un codice."
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Metodo a due fattori attualmente attivo: %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr "Per completare l'accesso, inserisci il codice inviato alla tua email"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -811,34 +807,39 @@ msgstr ""
 " codice QR (o inserisci manualmente il codice sottostante) per iniziare a"
 " ricevere i codici:"
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr "Codice di autenticazione a due fattori"
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
-msgstr "A quale numero di telefono dobbiamo inviare il codice?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
-msgstr "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
-msgstr "Questa applicazione supporta le chiavi di sicurezza WebAuthn."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr "Questa applicazione supporta l'impostazione dei codici di ripristino."
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Si possono impostare qui."
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
-msgstr "Questa applicazione supporta l'impostazione dei codici di ripristino."
+msgid "WebAuthn"
+msgstr "WebAuthn"
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
+msgstr "Questa applicazione supporta le chiavi di sicurezza WebAuthn."
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
 msgid "Two-factor Authentication"
@@ -849,17 +850,13 @@ msgstr "Autenticazione a due fattori"
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr "Inserisci il tuo codice di autenticazione generato tramite: %(method)s"
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr "inserisci il codice"
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr "Il codice per l'autenticazione è stato inviato al tuo indirizzo email"
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
-msgstr "Ci è stata inviata un'email per reimpostare l'account dell'applicazione"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
+msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
@@ -1078,3 +1075,15 @@ msgstr ""
 
 #~ msgid "You are not authenticated. Please supply the correct credentials."
 #~ msgstr "Non sei autenticato. Fornisci le credenziali corrette."
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr "Per completare l'accesso, inserisci il codice inviato alla tua email"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr "A quale numero di telefono dobbiamo inviare il codice?"
+
+#~ msgid "enter code"
+#~ msgstr "inserisci il codice"
+
+#~ msgid "A mail was sent to us in order to reset your application account"
+#~ msgstr "Ci è stata inviata un'email per reimpostare l'account dell'applicazione"

--- a/flask_security/translations/ja_JP/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ja_JP/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2018-01-25 14:12+0900\n"
 "Last-Translator: \n"
 "Language: ja\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "ログインが必要です"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,402 +31,402 @@ msgstr "ログインが必要です"
 msgid "Welcome"
 msgstr "ようこそ"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "メール アドレスの検証"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "ログイン手順"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "パスワード変更"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "パスワードが変更されました。"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "パスワード再設定手順"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr ""
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr ""
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "アクセス権がありません"
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 #, fuzzy
 msgid "You must re-authenticate to access this endpoint"
 msgstr "再度ログインしてください"
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "ご登録ありがとうございます。%(email)sにメール アドレス検証手順が送信されました。"
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "ありがとうございます。メール アドレスが検証されました。"
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "メール アドレスは検証済みです"
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "リンクが無効です"
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s のアカウントは既に作成されています"
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "パスワードが一致しません"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "入力したパスワードが一致していません"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "ドメイン外へのリダイレクトは禁止されています"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "パスワードの再設定手順が %(email)s に送信されました"
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "リンクが無効です"
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "メール アドレスの検証が必要です"
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "%(email)sにメール アドレス検証手順が再送信されました"
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
 "sent to %(email)s."
 msgstr "%(within)s以内にログインしませんでした。ログイン手順を %(email)s に再度送信しました。"
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "%(email)sにログイン手順が送信されました"
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "リンクが無効です"
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "アカウントが無効になっています"
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "メール アドレスを入力してください"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "正しいメール アドレスを入力してください"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr ""
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "パスワードを入力してください"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr ""
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr ""
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr ""
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "入力を確認してください"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "入力を確認してください"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "ログインしました"
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "パスワードを忘れた場合"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "パスワードの再設定が完了しました。"
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "新旧パスワードが同じです"
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "パスワードが変更されました"
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "ログインしてください"
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "再度ログインしてください"
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr ""
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr ""
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -571,19 +571,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -615,47 +615,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -732,7 +732,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -772,44 +772,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -821,16 +822,12 @@ msgstr ""
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
@@ -1121,4 +1118,16 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Currently active sign in options:"
+#~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr ""
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
 #~ msgstr ""

--- a/flask_security/translations/nl_NL/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/nl_NL/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2017-05-01 17:52+0200\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language: nl_NL\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Inloggen Verplicht"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,163 +31,163 @@ msgstr "Inloggen Verplicht"
 msgid "Welcome"
 msgstr "Welkom"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Gelieve uw e-mailadres te bevestigen"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Aanmeld instructies"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Uw wachtwoord werd gereset"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Uw wachtwoord werd gewijzigd"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Wachtwoord reset instructies"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "Dubbele Authenticatie Aanmelding"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr "Dubbele Authenticatie Herstellen"
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 #, fuzzy
 msgid "Verification Code"
 msgstr "Authenticatie Code"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr ""
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "U heeft niet de nodige rechten om deze pagina te zien."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 #, fuzzy
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Gelieve opnieuw in te loggen om deze pagina te zien."
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Bedankt. Instructies voor bevestiging zijn verzonden naar %(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Bedankt. Uw e-mailadres werd bevestigd."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Uw e-mailadres werd reeds bevestigd."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Ongeldige bevestiging token."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s is al gelinkt aan een ander account."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Wachtwoord komt niet overeen"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Wachtwoorden komen niet overeen"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Omleidingen buiten het domein zijn niet toegelaten"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "Instructies om uw wachtwoord te resetten werden verzonden naar %(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Ongeldig wachtwoord reset token."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "E-mailadres moet bevestigd worden."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr ""
 "Instructies ter bevestiging van uw e-mailadres werden verzonden naar "
 "%(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -196,244 +196,244 @@ msgstr ""
 "Je bent niet ingelogd geweest gedurende %(within)s. Nieuwe instructies om"
 " in te loggen werden verzonden naar%(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Instructies om in te loggen werden verzonden naar %(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Ongeldige aanmelding."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Account is geblokkeerd."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Email niet ingevuld"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Ongeldig e-mailadres"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 #, fuzzy
 msgid "Invalid code"
 msgstr "Niet valide token"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Wachtwoord niet ingevuld"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, fuzzy, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "Uw wachtwoord moet minstens %(length)s karakters bevatten"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr ""
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr ""
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Deze gebruiker bestaat niet"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Ongeldig wachtwoord"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "U bent succesvol ingelogd."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Wachtwoord vergeten?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "U heeft uw wachtwoord succesvol gereset en bent nu automatisch ingelogd."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Uw nieuw wachtwoord moet verschillend zijn van het voorgaande wachtwoord."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Uw wachtwoord werd met succes gewijzigd."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Gelieve in te loggen om deze pagina te zien."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Gelieve opnieuw in te loggen om deze pagina te zien."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr ""
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr ""
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "U heeft succesvol uw Dubbele Authenticatie methode veranderd."
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr "U heeft niet de juiste permissies om deze pagina te laden"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr "De gemarkeerde methode is niet valide"
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr "U heeft succesvol Dubbele Authenticatie uitgeschakeld."
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 #, fuzzy
 msgid "Requested method is not valid"
 msgstr "De gemarkeerde methode is niet valide"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -579,19 +579,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -623,47 +623,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -782,46 +782,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-"Om verder in te loggen moet U de code die we naar uw e-mail hebben "
-"gezonden invoeren"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr "Dubbele Authenticatie code"
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
-msgstr "Naar welk telefoonnummer kunnen we code verzenden?"
-
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -833,17 +832,13 @@ msgstr "Dubbele Authenticatie"
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr "The code voor authenticatie is naar uw e-mail adres verzonden"
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
-msgstr "Een bericht is naar uw e-mail adres verzonden om uw account te herstellen"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
+msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
@@ -1148,3 +1143,21 @@ msgstr ""
 
 #~ msgid "Currently active sign in options:"
 #~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+#~ "Om verder in te loggen moet U "
+#~ "de code die we naar uw e-mail "
+#~ "hebben gezonden invoeren"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr "Naar welk telefoonnummer kunnen we code verzenden?"
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
+#~ msgstr ""
+#~ "Een bericht is naar uw e-mail "
+#~ "adres verzonden om uw account te "
+#~ "herstellen"

--- a/flask_security/translations/pl_PL/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/pl_PL/LC_MESSAGES/flask_security.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2020-11-28 10:19+0100\n"
 "Last-Translator: Kamil Daniewski <kamil.daniewski@gmail.com>\n"
 "Language: pl_PL\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Logowanie jest wymagane"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,95 +31,95 @@ msgstr "Logowanie jest wymagane"
 msgid "Welcome"
 msgstr "Witamy"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Prosimy o potwierdzenie Twojego adresu e-mail"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Instrukcje logowania"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Twoje hasło zostało zresetowane"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Twoje hasło zostało zmienione"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Instrukcje zmiany hasła"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "Logowanie dwuskładnikowe"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr "Pomoc w logowaniu dwuskładnikowym"
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr "Kod weryfikacyjny"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr "Nieprawidłowe dane dla żądanego API"
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Nie posiadasz uprawnień, aby wyświetlić tę stronę."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Musisz zalogować się ponownie, aby wyświetlić tę stronę"
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr ""
 "Dziękujemy. Instrukcje potwierdzenia rejestracji zostały wysłane na adres"
 " %(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Dziękujemy. Twój adres e-mail został potwierdzony."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Twój adres e-mail już został potwierdzony."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Nieprawidłowy token potwierdzania adresu e-mail."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s jest już powiązany z kontem."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -128,66 +128,66 @@ msgstr ""
 "Atrybut identyfikujący '%(attr)s' z wartością '%(value)s' jest już "
 "powiązany z kontem."
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Hasło nie pasuje"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Hasła nie pasują do siebie"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Przekierowania poza domenę są zabronione"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "Instrukcje resetowania hasła zostały wysłane na adres %(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Nieprawidłowy token resetowania hasła."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "Wymagane jest potwierdzenie adresu e-mail."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Instrukcje potwierdzenia adresu e-mail zostały wysłane na adres %(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -196,246 +196,246 @@ msgstr ""
 "Nie zalogowałeś się w ciągu %(within)s. Nowe instrukcje logowania zostały"
 " wysłane na adres %(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Instrukcje logowania zostały wysłane na adres %(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Nieprawidłowy token logowania."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Konto jest wyłączone."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Adres e-mail nie został wprowadzony"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Nieprawidłowy adres e-mail"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr "Nieprawidłowy kod"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Hasło nie zostało wprowadzone"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "Hasło musi zawierać co najmniej %(length)s znaków"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr "Hasło nie jest wystarczająco złożone"
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr "Hasło znajduje się na liście haseł wykradzionych"
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 "Nie udało się dotrzeć do podmiotu sprawdzającego hasło w bazie "
 "wykradzionych haseł"
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr "Nieprawidłowiy numer telefonu (upewnij się, że zawiera kod kraju)"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Ten użytkownik nie istnieje"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Nieprawidłowe hasło"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr "Hasło lub wprowadzony kod są nieprawidłowe"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Zostałeś zalogowany pomyślnie."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Zapomniałeś hasło?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Ustawiono nowe hasło i zostałeś zalogowany pomyślnie."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Twoje nowe hasło musi być inne, niż obecne hasło."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Pomyślnie zmieniłeś hasło."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Prosimy o zalogowanie się, aby móc odwiedzić tę stronę."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Prosimy o ponowne zalogowanie się, aby móc odwiedzić tę stronę."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr "Ponownie zalogowano"
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr "Możesz odwiedzić tę stronę tylko będąc niezalogowanym."
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr "Nie udało się wysłać kodu. Prosimy spróbować później"
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "Metoda logowania dwuskładnikowego została zmieniona pomyślnie."
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr "Nie posiadasz uprawnień, aby odwiedzić tę stronę"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr "Wybrana metoda jest niewłaściwa"
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr "Pomyślnie wyłączyłeś logowanie dwuskładnikowe."
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr "Żądana metoda jest niewłaściwa"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 "Ustawienie musi zostać ukończone w ciągu %(within)s. Prosimy zacząć "
 "ponownie."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr "Ujednolicone logowanie przebiegło pomyślnie"
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr "Musisz ustawić prawidłowy identyfikator, aby się zalogować"
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Użyj tego kodu, aby się zalogować: %(code)s."
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -582,19 +582,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr "Dostępne metody"
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -626,47 +626,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr "Kod lub hasło"
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr "Poprzez adres e-mail"
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "Poprzez wiadomość SMS"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -743,7 +743,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -785,46 +785,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-"Aby dokończyć proces logowania, prosimy wprowadzić kod, który został "
-"wysłany na Twój adres e-mail"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr "Kod uwierzytelniania dwuskładnikowego"
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
-msgstr "Na jaki numer telefonu powinien zostać wysłany kod?"
-
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -836,19 +835,13 @@ msgstr "Uwierzytelnianie dwuskładnikowe"
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr "Kod uwierzytelniania został do Ciebie wysłany na adres e-mail"
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
-"Wiadomość e-mail została do nas wysłana w celu zresetowania Twojego konta"
-" aplikacji"
 
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
@@ -1149,3 +1142,21 @@ msgstr ""
 
 #~ msgid "Currently active sign in options:"
 #~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+#~ "Aby dokończyć proces logowania, prosimy "
+#~ "wprowadzić kod, który został wysłany na"
+#~ " Twój adres e-mail"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr "Na jaki numer telefonu powinien zostać wysłany kod?"
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
+#~ msgstr ""
+#~ "Wiadomość e-mail została do nas wysłana"
+#~ " w celu zresetowania Twojego konta "
+#~ "aplikacji"

--- a/flask_security/translations/pt_BR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/pt_BR/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2017-09-27 23:39-0300\n"
 "Last-Translator: José Neto <josenetodino@gmail.com>\n"
 "Language: pt_BR\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Login obrigatório"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,160 +31,160 @@ msgstr "Login obrigatório"
 msgid "Welcome"
 msgstr "Bem-vindo"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Por favor, confirme seu email"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Instruções de login"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Sua senha foi redefinida"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Sua senha foi alterada"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Instruções para redfinir a senha"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr ""
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr ""
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Você não tem permissão para ver este recurso"
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 #, fuzzy
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Por favor, reautentique-se para acessar esta página."
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Obrigado. As instruções para a confirmação foram enviadas para %(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Obrigado. Seu email foi confirmado."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Seu email já foi confirmado."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Token de confirmação inválido."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s já está associado a uma conta."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Senha não confere"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Senhas não conferem"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Redirecionamentos para fora do domínio são proibidos"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "As instruções para redefinir sua senha foram enviadas para %(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Token de redefinição de senha inválido."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "O email requer confirmação."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "As instruções de confirmaç foram enviadas para %(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -193,243 +193,243 @@ msgstr ""
 "Você não logou dentro de %(within)s. Novas instruções para logar foram "
 "enviadas para %(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Instruções para logar foram enviadas para %(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Token de login inválido."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Conta desabilitada."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Email não informado"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Endereço de email inválido"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 #, fuzzy
 msgid "Invalid code"
 msgstr "Senha inválida"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Senha não informada"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, fuzzy, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "A senha deve ter pelo menos 6 caracteres"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr ""
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr ""
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Usuário não existe"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Senha inválida"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Você logou com sucesso."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Esqueceu a senha?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Você redefiniu sua senha com sucesso e foi logado automaticamente."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Sua nova senha deve ser diferente da sua senha anterior."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Você alterou sua senha com sucesso."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Por favor, logue para acessar esta página."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Por favor, reautentique-se para acessar esta página."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr ""
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr ""
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -574,19 +574,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -618,47 +618,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -735,7 +735,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -775,44 +775,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -824,16 +825,12 @@ msgstr ""
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
@@ -1130,4 +1127,16 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Currently active sign in options:"
+#~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr ""
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
 #~ msgstr ""

--- a/flask_security/translations/pt_PT/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/pt_PT/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2018-04-27 14:00+0100\n"
 "Last-Translator: Micael Grilo <micael.grilo@outlook.com>\n"
 "Language: pt_PT\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Login obrigatório"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,162 +31,162 @@ msgstr "Login obrigatório"
 msgid "Welcome"
 msgstr "Bem-vindo"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Por favor, confirme o seu email"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Instruções de login"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "A sua palavra-passe foi redefinida"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "A sua palavra-passe foi alterada"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Instruções para redefinir a palavra-passe"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr ""
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr ""
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Não tem permissões para ver este recurso"
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 #, fuzzy
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Por favor, reautentique-se para aceder esta página."
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Obrigado. As instruções para a confirmação foram enviadas para %(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Obrigado. O seu email foi confirmado."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "O seu email já foi confirmado."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Token de confirmação inválido."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s já está associado a uma conta."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Palavra-passe não coincide"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Palavras-passe não coincidem"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Redirecionamentos para fora do domínio são proibidos"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr ""
 "As instruções para redefinir a sua palavra-passe foram enviadas para "
 "%(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Token de redefinição de senha inválido."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "O email requer confirmação."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "As instruções de confirmação foram enviadas para %(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -195,77 +195,77 @@ msgstr ""
 "Não iniciou sessão dentro de %(within)s. Novas instruções de inicio de "
 "sessão foram enviadas para %(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Instruções para o inicio de sessão foram enviadas para %(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Token de login inválido."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Conta desactivada."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Email em falta"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Endereço de email inválido"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr ""
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Palavra-passe em falta"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, fuzzy, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "A palavra-passe deve ter pelo menos %(length)s caracteres"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr ""
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr ""
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Utilizador não existe"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Palavra-passe inválida"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Sessão iniciada com sucesso."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Esqueceu a palavra-passe?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
@@ -273,166 +273,166 @@ msgstr ""
 "Redefiniu a sua palavra-passe com sucesso e iniciou sessão "
 "automaticamente."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "A sua nova palavra-passe deve ser diferente da anterior."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Alterou a sua palavra-passe com sucesso."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Por favor, inicie sessão para aceder a esta página."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Por favor, reautentique-se para aceder esta página."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr ""
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr ""
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -577,19 +577,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -621,47 +621,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -778,44 +778,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -827,16 +828,12 @@ msgstr ""
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
@@ -1133,4 +1130,16 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Currently active sign in options:"
+#~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr ""
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
 #~ msgstr ""

--- a/flask_security/translations/ru_RU/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/ru_RU/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2023-01-25 04:14+0530\n"
 "Last-Translator: Ivan Fedorov <inbox@titaniumhocker.ru>\n"
 "Language: ru_RU\n"
@@ -20,11 +20,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Требуется авторизация"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -32,51 +32,51 @@ msgstr "Требуется авторизация"
 msgid "Welcome"
 msgstr "Добро пожаловать"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Пожалуйста, подтвердите свой адрес электронной почты"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Инструкция для входа"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Ваш пароль был сброшен"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Ваш пароль был изменён"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Инструкции для восстановления пароля"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "Двухфакторный вход"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr "Двухфакторное восстановление"
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr "Код подтверждения"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr "Ввод некорректен для запрошенного API"
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 "Аутентификация не удалась — идентификатор или пароль/код доступа "
 "недействительны"
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
@@ -84,45 +84,45 @@ msgstr ""
 "Если этот адрес электронной почты есть в нашей системе, вы получите "
 "письмо с описанием того, как сбросить пароль."
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr "Если этот идентификатор есть в нашей системе, вам был выслан код."
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "У вас нет прав доступа к этому ресурсу."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Пожалуйста, войдите повторно чтобы получить доступ к этой странице"
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Спасибо. Инструкции по подтверждению были отправлены на %(email)s."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Спасибо. Ваш почтовый адрес был подтверждён."
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "Ваш почтовый адрес уже подтверждён."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Неверный токен для подтверждения аккаунта."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s уже привязан к другому аккаунту."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
@@ -131,12 +131,12 @@ msgstr ""
 "Идентификационный атрибут '%(attr)s' со значением '%(value)s' уже "
 "ассоциирован с учетной записью."
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr "Идентификация %(id)s не зарегистрирована"
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
@@ -144,55 +144,55 @@ msgstr ""
 "Произошла ошибка при взаимодействии с провайдером Oauth. Пожалуйста, "
 "попробуйте ещё раз."
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Пароль не подходит"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Пароли не совпадают"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Перенаправления вне текущего домена запрещены"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr "Код восстановления недействителен"
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr "Коды восстановления еще не сгенерированы"
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "Инструкции по восстановлению пароля были отправлены на %(email)s."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Неверный токен для восстановления пароля."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "Почтовый адрес требует подтверждения."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Инструкции по подтверждению были отправлены на %(email)s."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -201,170 +201,170 @@ msgstr ""
 "Вы не вошли в течение %(within)s. Новые инструкции по входу отправлены на"
 " %(email)s."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Инструкции по входу отправлены на %(email)s."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Неверный токен для входа."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Аккаунт отключён."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "Почтовый адрес не введён"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Неверный почтовый адрес"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr "Код недействителен"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Пароль не введён"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "Пароль должен содержать не менее %(length)s символов"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr "Пароль недостаточно сложный"
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr "Пароль в списке скомпрометированных"
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr "Не удалось соединиться с сайтом скомпрометированных паролей"
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr "Номер телефона некорректен, например, отсутствует код страны"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Указанный пользователь не существует"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Неверный пароль"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr "Предоставленный пароль или код недействительны"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Вы успешно вошли в систему."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Забыли пароль?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Вы успешно сбросили пароль и автоматически вошли в систему."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Ваш новый пароль должен отличаться от предыдущего."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Вы успешно изменили свой пароль."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Пожалуйста, войдите чтобы получить доступ к этой странице."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Пожалуйста, войдите заново, чтобы получить доступ к этой странице."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr "Повторный вход выполнен успешно"
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr "Вы можете получить доступ к данной странице, только если не авторизованы."
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr "Код отправлен."
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr "Не удалось отправить код. Пожалуйста, попробуйте позже"
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr "Ваш код был подтвержден"
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "Вы успешно изменили метод двухфакторной авторизации."
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr "В настоящее время у вас нет доступа к данной странице"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr "Отмеченный метод недействителен"
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr "Вы успешно отключили двухфакторную авторизацию."
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr "Запрошенный метод недействителен"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 "Настройка должна быть завершена в течение %(within)s. Пожалуйста, начните"
 " заново."
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr "Настройка единого способа входа прошла успешно"
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr "Вы должны указать действительный идентификатор для входа"
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "Используйте данный код для входа: %(code)s."
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
@@ -373,78 +373,78 @@ msgstr ""
 "Имя пользователя должно содержать не менее %(min)d и не более %(max)d "
 "символов"
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr "Имя пользователя содержит недопустимые символы"
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr "Имя пользователя может содержать только буквы и цифры"
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr "Имя пользователя не указано"
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr "Имя пользователя %(username)s уже связано с учётной записью."
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 "Операция WebAuthn должна быть завершена в течение %(within)s. Пожалуйста,"
 " начните сначала."
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr "Требуется псевдоним для новых учётных данных."
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr "%(name)s уже связан с учётными данными."
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr "%(name)s не зарегистрирован с текущим пользователем."
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr "Учётные данные WebAuthn с именем %(name)s успешно удалены"
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr "Учётные данные WebAuthn с именем %(name)s успешно добавлены"
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr "Учётные данные WebAuthn уже зарегистрированы."
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr "Незарегистрированный идентификатор учетных данных WebAuthn."
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr "Учётные данные WebAuthn не принадлежат ни одному пользователю."
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr "Не удалось проверить учётные данные WebAuthn: %(cause)s."
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 "Учётные данные не зарегистрированы для этого использования (первичное или"
 " вторичное)"
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr "Несовпадение учётных данных пользователя"
 
@@ -591,19 +591,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr "Доступные методы"
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr "Отключить двухфакторную аутентификацию"
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -635,47 +635,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr "Код или пароль"
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr "По электронной почте"
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "По СМС"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr "Настроить дополнительный метод входа"
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr "Удаление активной опции входа"
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr "Псевдоним"
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr "Использование"
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr "Использовать как первичный метод аутентификации"
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr "Использовать как вторичный метод аутентификации"
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr "Начать"
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr "webauthn"
 
@@ -752,7 +752,7 @@ msgid "Enter Recovery Code"
 msgstr "Введите код восстановления"
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr "Коды восстановления"
@@ -796,11 +796,7 @@ msgstr "Помимо имени пользователя и пароля, вам
 msgid "Currently setup two-factor method: %(method)s"
 msgstr "Текущий настроенный двухфакторный метод: %(method)s"
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr "Для завершения входа введите код, отправленный на вашу электронную почту"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
@@ -810,34 +806,39 @@ msgstr ""
 "следующий QR-код (или введите код ниже вручную), чтобы начать получать "
 "коды:"
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr "Код двухфакторной аутентификации"
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
-msgstr "На какой номер телефона необходимо отправить код?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
-msgstr "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
+msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
-msgstr "Это приложение поддерживает ключи безопасности WebAuthn."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr "Это приложение поддерживает настройку кодов восстановления."
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr "Вы можете настроить их здесь."
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
-msgstr "Это приложение поддерживает настройку кодов восстановления."
+msgid "WebAuthn"
+msgstr "WebAuthn"
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
+msgstr "Это приложение поддерживает ключи безопасности WebAuthn."
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
 msgid "Two-factor Authentication"
@@ -848,17 +849,13 @@ msgstr "Двухфакторная аутентификация"
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr "Пожалуйста, введите код аутентификации, сгенерированный через: %(method)s"
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr "Код аутентификации был отправлен вам на адрес электронной почты"
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
-msgstr "Нам было отправлено письмо для сброса вашей учетной записи"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
+msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
 msgid "Setup Unified Sign In"
@@ -1176,3 +1173,17 @@ msgstr "Пожалуйста, повторите процесс регистра
 
 #~ msgid "Currently active sign in options:"
 #~ msgstr "Активные на данный момент варианты входа в систему:"
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+#~ "Для завершения входа введите код, "
+#~ "отправленный на вашу электронную почту"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr "На какой номер телефона необходимо отправить код?"
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
+#~ msgstr "Нам было отправлено письмо для сброса вашей учетной записи"

--- a/flask_security/translations/tr_TR/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/tr_TR/LC_MESSAGES/flask_security.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2018-12-20 18:48+0300\n"
 "Last-Translator: Ecmel B. Canlıer <me@ecmelberk.com>\n"
 "Language: tr_TR\n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "Giriş yapmanız gerekmektedir"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -30,160 +30,160 @@ msgstr "Giriş yapmanız gerekmektedir"
 msgid "Welcome"
 msgstr "Hoş Geldiniz"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "Lütfen e-posta adresinizi onaylayın"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "Giriş talimatları"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "Şifreniz yenilenmiştir"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "Şifreniz değiştirilmiştir"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "Şifre yenileme talimatları"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr ""
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr ""
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr ""
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "Bu maddeyi görmeye yetkiniz yoktur."
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 #, fuzzy
 msgid "You must re-authenticate to access this endpoint"
 msgstr "Bu sayfaya erişebilmek için lütfen tekrardan giriş yapın."
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "Teşekkür ederiz. Onaylama talimatları %(email)s adresine gönderilmiştir."
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "Teşekkür ederiz. E-posta adresiniz onaylanmıştır"
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "E-posta adresiniz zaten onaylanmış."
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "Yanlış onaylama kodu."
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s başka bir hesaba bağlı."
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "Şifre yanlış"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "Şifreler uymuyor"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "Adres dışına yönlendirmeler yasaktır"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "Şifrenizi yenileme talimatları %(email)s adresine gönderilmiştir."
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "Yanlış şifre yenileme kodu."
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "E-posta onayı gerekmektedir."
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "Onaylama talimatları %(email)s adresine gönderilmiştir."
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
@@ -192,242 +192,242 @@ msgstr ""
 "%(within)s içinde giriş yapmadınız. Yeni giriş yapma talimatları "
 "%(email)s adresine gönderilmiştir."
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "Giriş yapma talimatları %(email)s adresine gönderilmiştir."
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "Yanlış giriş kodu."
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "Hesap kapalıdır."
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "E-posta verilmemiş"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "Yanlış e-posta adresi"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 msgid "Invalid code"
 msgstr ""
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "Şifre verilmemiş"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, fuzzy, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "Şifreniz en az %(length)s karakter olmalıdır"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr ""
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr ""
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr ""
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr ""
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "Böyle bir kullanıcı yok"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "Şifre yanlış"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr ""
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "Başarıyla giriş yaptınız."
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "Şifrenizi mi unuttunuz?"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "Şifreniz yenilenmiştir ve otomatik olarak giriş yapmış bulunmaktasınız."
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "Yeni şifreniz eski şifrenizden farklı olmalıdır."
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "Şifrenizi başarıyla değiştirdiniz."
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "Bu sayfaya erişebilmek için lütfen giriş yapın."
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "Bu sayfaya erişebilmek için lütfen tekrardan giriş yapın."
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr ""
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr ""
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr ""
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr ""
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr ""
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr ""
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr ""
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr ""
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr ""
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr ""
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr ""
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -572,19 +572,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -616,47 +616,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr ""
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr ""
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -733,7 +733,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -773,44 +773,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -822,16 +823,12 @@ msgstr ""
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
@@ -1128,4 +1125,16 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Currently active sign in options:"
+#~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr ""
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr ""
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
 #~ msgstr ""

--- a/flask_security/translations/zh_Hans_CN/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/zh_Hans_CN/LC_MESSAGES/flask_security.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Flask-Security 2.0.1\n"
 "Report-Msgid-Bugs-To: info@inveniosoftware.org\n"
-"POT-Creation-Date: 2023-12-17 20:22-0800\n"
+"POT-Creation-Date: 2024-01-07 15:34-0800\n"
 "PO-Revision-Date: 2018-08-02 19:55+0800\n"
 "Last-Translator: SteinKuo <guoming054@gmail.com>\n"
 "Language: zh_CN\n"
@@ -19,11 +19,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.14.0\n"
 
-#: flask_security/core.py:267
+#: flask_security/core.py:269
 msgid "Login Required"
 msgstr "需要登录"
 
-#: flask_security/core.py:268
+#: flask_security/core.py:270
 #: flask_security/templates/security/email/two_factor_instructions.html:1
 #: flask_security/templates/security/email/two_factor_instructions.txt:1
 #: flask_security/templates/security/email/us_instructions.html:9
@@ -31,403 +31,403 @@ msgstr "需要登录"
 msgid "Welcome"
 msgstr "欢迎"
 
-#: flask_security/core.py:269
+#: flask_security/core.py:271
 msgid "Please confirm your email"
 msgstr "请激活你的电子邮箱"
 
-#: flask_security/core.py:270
+#: flask_security/core.py:272
 msgid "Login instructions"
 msgstr "登录邮件"
 
-#: flask_security/core.py:271
+#: flask_security/core.py:273
 #: flask_security/templates/security/email/reset_notice.html:1
 #: flask_security/templates/security/email/reset_notice.txt:1
 msgid "Your password has been reset"
 msgstr "你的密码已重置"
 
-#: flask_security/core.py:272
+#: flask_security/core.py:274
 msgid "Your password has been changed"
 msgstr "你的密码已更改"
 
-#: flask_security/core.py:273
+#: flask_security/core.py:275
 msgid "Password reset instructions"
 msgstr "密码重置"
 
-#: flask_security/core.py:276
+#: flask_security/core.py:278
 msgid "Two-factor Login"
 msgstr "双因素认证登录"
 
-#: flask_security/core.py:277
+#: flask_security/core.py:279
 msgid "Two-factor Rescue"
 msgstr ""
 
-#: flask_security/core.py:325
+#: flask_security/core.py:327
 msgid "Verification Code"
 msgstr "验证码"
 
-#: flask_security/core.py:371
+#: flask_security/core.py:373
 msgid "Input not appropriate for requested API"
 msgstr "输入信息不适合所请求的API"
 
-#: flask_security/core.py:373
+#: flask_security/core.py:375
 msgid "Authentication failed - identity or password/passcode invalid"
 msgstr ""
 
-#: flask_security/core.py:377
+#: flask_security/core.py:379
 msgid ""
 "If that email address is in our system, you will receive an email "
 "describing how to reset your password."
 msgstr ""
 
-#: flask_security/core.py:384
+#: flask_security/core.py:386
 msgid "If that identity is in our system, you were sent a code."
 msgstr ""
 
-#: flask_security/core.py:387
+#: flask_security/core.py:389
 msgid "You do not have permission to view this resource."
 msgstr "你无权查看此资源！"
 
-#: flask_security/core.py:389
+#: flask_security/core.py:391
 msgid "You must sign in to view this resource."
 msgstr ""
 
-#: flask_security/core.py:393
+#: flask_security/core.py:395
 #, fuzzy
 msgid "You must re-authenticate to access this endpoint"
 msgstr "请重新进行身份验证，以访问此页面。"
 
-#: flask_security/core.py:397
+#: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
 msgstr "谢谢你。已发送激活邮件到 %(email)s。"
 
-#: flask_security/core.py:400
+#: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
 msgstr "谢谢。你的邮箱已激活！"
 
-#: flask_security/core.py:401
+#: flask_security/core.py:403
 msgid "Your email has already been confirmed."
 msgstr "你的邮箱已激活！"
 
-#: flask_security/core.py:402
+#: flask_security/core.py:404
 msgid "Invalid confirmation token."
 msgstr "无效验证码！"
 
-#: flask_security/core.py:404
+#: flask_security/core.py:406
 #, python-format
 msgid "%(email)s is already associated with an account."
 msgstr "%(email)s 已关联账户。"
 
-#: flask_security/core.py:408
+#: flask_security/core.py:410
 #, python-format
 msgid ""
 "Identity attribute '%(attr)s' with value '%(value)s' is already "
 "associated with an account."
 msgstr ""
 
-#: flask_security/core.py:415
+#: flask_security/core.py:417
 #, python-format
 msgid "Identity %(id)s not registered"
 msgstr ""
 
-#: flask_security/core.py:419
+#: flask_security/core.py:421
 msgid ""
 "An error occurred while communicating with the Oauth provider. Please try"
 " again."
 msgstr ""
 
-#: flask_security/core.py:425
+#: flask_security/core.py:427
 msgid "Password does not match"
 msgstr "密码不匹配"
 
-#: flask_security/core.py:426
+#: flask_security/core.py:428
 msgid "Passwords do not match"
 msgstr "密码不匹配"
 
-#: flask_security/core.py:427
+#: flask_security/core.py:429
 msgid "Redirections outside the domain are forbidden"
 msgstr "禁止域名外重定向"
 
-#: flask_security/core.py:428
+#: flask_security/core.py:430
 msgid "Recovery code invalid"
 msgstr ""
 
-#: flask_security/core.py:429
+#: flask_security/core.py:431
 msgid "No recovery codes generated yet"
 msgstr ""
 
-#: flask_security/core.py:431
+#: flask_security/core.py:433
 #, python-format
 msgid "Instructions to reset your password have been sent to %(email)s."
 msgstr "重置密码邮件已发送到 %(email)s。"
 
-#: flask_security/core.py:435
+#: flask_security/core.py:437
 #, python-format
 msgid "You did not reset your password within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:438
+#: flask_security/core.py:440
 msgid "Invalid reset password token."
 msgstr "密码重置验证码无效！"
 
-#: flask_security/core.py:439
+#: flask_security/core.py:441
 msgid "Email requires confirmation."
 msgstr "请先激活邮箱。"
 
-#: flask_security/core.py:441
+#: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
 msgstr "激活邮件已发送到  %(email)s。"
 
-#: flask_security/core.py:445
+#: flask_security/core.py:447
 #, python-format
 msgid "You did not confirm your email within %(within)s. "
 msgstr ""
 
-#: flask_security/core.py:449
+#: flask_security/core.py:451
 #, python-format
 msgid ""
 "You did not login within %(within)s. New instructions to login have been "
 "sent to %(email)s."
 msgstr "你未在 %(within)s 登录账户。新登录邮件已发送到 %(email)s。"
 
-#: flask_security/core.py:456
+#: flask_security/core.py:458
 #, python-format
 msgid "Instructions to login have been sent to %(email)s."
 msgstr "登录邮件已发送到 %(email)s。"
 
-#: flask_security/core.py:459
+#: flask_security/core.py:461
 msgid "Invalid login token."
 msgstr "无效登录验证码！"
 
-#: flask_security/core.py:460
+#: flask_security/core.py:462
 msgid "Account is disabled."
 msgstr "账户已被禁用！"
 
-#: flask_security/core.py:461
+#: flask_security/core.py:463
 msgid "Email not provided"
 msgstr "未填写电子邮箱"
 
-#: flask_security/core.py:462
+#: flask_security/core.py:464
 msgid "Invalid email address"
 msgstr "无效邮箱地址"
 
-#: flask_security/core.py:463 flask_security/core.py:509
+#: flask_security/core.py:465 flask_security/core.py:511
 #, fuzzy
 msgid "Invalid code"
 msgstr "密码不正确"
 
-#: flask_security/core.py:464
+#: flask_security/core.py:466
 msgid "Password not provided"
 msgstr "未填写密码"
 
-#: flask_security/core.py:466
+#: flask_security/core.py:468
 #, python-format
 msgid "Password must be at least %(length)s characters"
 msgstr "密码至少包含%(length)s个字符"
 
-#: flask_security/core.py:469
+#: flask_security/core.py:471
 msgid "Password not complex enough"
 msgstr "密码不够复杂"
 
-#: flask_security/core.py:470
+#: flask_security/core.py:472
 msgid "Password on breached list"
 msgstr "密码在易被泄露名单上"
 
-#: flask_security/core.py:472
+#: flask_security/core.py:474
 msgid "Failed to contact breached passwords site"
 msgstr "未能连通检测易泄露密码的网站"
 
-#: flask_security/core.py:475
+#: flask_security/core.py:477
 msgid "Phone number not valid e.g. missing country code"
 msgstr "手机号码非法。例如: 缺少国家代码"
 
-#: flask_security/core.py:476
+#: flask_security/core.py:478
 msgid "Specified user does not exist"
 msgstr "此用户不存在"
 
-#: flask_security/core.py:477
+#: flask_security/core.py:479
 msgid "Invalid password"
 msgstr "密码不正确"
 
-#: flask_security/core.py:478
+#: flask_security/core.py:480
 msgid "Password or code submitted is not valid"
 msgstr "提交的密码或代码无效"
 
-#: flask_security/core.py:479
+#: flask_security/core.py:481
 msgid "You have successfully logged in."
 msgstr "你已成功登录！"
 
-#: flask_security/core.py:480
+#: flask_security/core.py:482
 msgid "Forgot password?"
 msgstr "忘记密码？"
 
-#: flask_security/core.py:482
+#: flask_security/core.py:484
 msgid ""
 "You successfully reset your password and you have been logged in "
 "automatically."
 msgstr "你的密码已成功重置，并已自动登录。"
 
-#: flask_security/core.py:489
+#: flask_security/core.py:491
 msgid ""
 "You successfully reset your password. Please authenticate using your new "
 "password."
 msgstr ""
 
-#: flask_security/core.py:496
+#: flask_security/core.py:498
 msgid "Your new password must be different than your previous password."
 msgstr "你的新密码不能与当前密码相同。"
 
-#: flask_security/core.py:499
+#: flask_security/core.py:501
 msgid "You successfully changed your password."
 msgstr "你已成功更改密码！"
 
-#: flask_security/core.py:500
+#: flask_security/core.py:502
 msgid "Please log in to access this page."
 msgstr "请登录访问此页面。"
 
-#: flask_security/core.py:501
+#: flask_security/core.py:503
 msgid "Please reauthenticate to access this page."
 msgstr "请重新进行身份验证，以访问此页面。"
 
-#: flask_security/core.py:502
+#: flask_security/core.py:504
 msgid "Reauthentication successful"
 msgstr "成功进行重新认证"
 
-#: flask_security/core.py:504
+#: flask_security/core.py:506
 msgid "You can only access this endpoint when not logged in."
 msgstr "您只能在未登录时访问此端点。"
 
-#: flask_security/core.py:507
+#: flask_security/core.py:509
 msgid "Code has been sent."
 msgstr ""
 
-#: flask_security/core.py:508
+#: flask_security/core.py:510
 msgid "Failed to send code. Please try again later"
 msgstr "发送代码失败。请稍后再试"
 
-#: flask_security/core.py:510
+#: flask_security/core.py:512
 msgid "Your code has been confirmed"
 msgstr ""
 
-#: flask_security/core.py:512
+#: flask_security/core.py:514
 msgid "You successfully changed your two-factor method."
 msgstr "你成功改变了你的双因素验证方法。"
 
-#: flask_security/core.py:516
+#: flask_security/core.py:518
 msgid "You currently do not have permissions to access this page"
 msgstr "你现在还没有权限访问这个页面"
 
-#: flask_security/core.py:519
+#: flask_security/core.py:521
 msgid "Marked method is not valid"
 msgstr "选择的方法无效"
 
-#: flask_security/core.py:521
+#: flask_security/core.py:523
 msgid "You successfully disabled two factor authorization."
 msgstr "你成功地禁用了双因素授权。"
 
-#: flask_security/core.py:525
+#: flask_security/core.py:527
 #, python-format
 msgid "Currently active sign in options: %(method_list)s."
 msgstr ""
 
-#: flask_security/core.py:528
+#: flask_security/core.py:530
 msgid "Requested method is not valid"
 msgstr "非法的请求方法"
 
-#: flask_security/core.py:530
+#: flask_security/core.py:532
 #, python-format
 msgid "Setup must be completed within %(within)s. Please start over."
 msgstr "必须在%(within)s内完成设置。请重新开始。"
 
-#: flask_security/core.py:533
+#: flask_security/core.py:535
 msgid "Unified sign in setup successful"
 msgstr "统一登录设置成功"
 
-#: flask_security/core.py:534
+#: flask_security/core.py:536
 msgid "You must specify a valid identity to sign in"
 msgstr "您必须指定一个有效的身份才能登录"
 
-#: flask_security/core.py:535
+#: flask_security/core.py:537
 #, python-format
 msgid "Use this code to sign in: %(code)s."
 msgstr "使用此代码登录：%(code)s"
 
-#: flask_security/core.py:537
+#: flask_security/core.py:539
 #, python-format
 msgid ""
 "Username must be at least %(min)d characters and less than %(max)d "
 "characters"
 msgstr ""
 
-#: flask_security/core.py:544
+#: flask_security/core.py:546
 msgid "Username contains illegal characters"
 msgstr ""
 
-#: flask_security/core.py:548
+#: flask_security/core.py:550
 msgid "Username can contain only letters and numbers"
 msgstr ""
 
-#: flask_security/core.py:551
+#: flask_security/core.py:553
 msgid "Username not provided"
 msgstr ""
 
-#: flask_security/core.py:553
+#: flask_security/core.py:555
 #, python-format
 msgid "%(username)s is already associated with an account."
 msgstr ""
 
-#: flask_security/core.py:557
+#: flask_security/core.py:559
 #, python-format
 msgid "WebAuthn operation must be completed within %(within)s. Please start over."
 msgstr ""
 
-#: flask_security/core.py:561
+#: flask_security/core.py:563
 msgid "Nickname for new credential is required."
 msgstr ""
 
-#: flask_security/core.py:565
+#: flask_security/core.py:567
 #, python-format
 msgid "%(name)s is already associated with a credential."
 msgstr ""
 
-#: flask_security/core.py:569
+#: flask_security/core.py:571
 #, python-format
 msgid "%(name)s not registered with current user."
 msgstr ""
 
-#: flask_security/core.py:573
+#: flask_security/core.py:575
 #, python-format
 msgid "Successfully deleted WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:577
+#: flask_security/core.py:579
 #, python-format
 msgid "Successfully added WebAuthn credential with name: %(name)s"
 msgstr ""
 
-#: flask_security/core.py:581
+#: flask_security/core.py:583
 msgid "WebAuthn credential id already registered."
 msgstr ""
 
-#: flask_security/core.py:585
+#: flask_security/core.py:587
 msgid "Unregistered WebAuthn credential id."
 msgstr ""
 
-#: flask_security/core.py:589
+#: flask_security/core.py:591
 msgid "WebAuthn credential doesn't belong to any user."
 msgstr ""
 
-#: flask_security/core.py:593
+#: flask_security/core.py:595
 #, python-format
 msgid "Could not verify WebAuthn credential: %(cause)s."
 msgstr ""
 
-#: flask_security/core.py:597
+#: flask_security/core.py:599
 msgid "Credential not registered for this use (first or secondary)"
 msgstr ""
 
-#: flask_security/core.py:601
+#: flask_security/core.py:603
 msgid "Credential user handle didn't match"
 msgstr ""
 
@@ -572,19 +572,19 @@ msgstr ""
 msgid "none"
 msgstr ""
 
-#: flask_security/forms.py:774 flask_security/unified_signin.py:164
+#: flask_security/forms.py:774 flask_security/unified_signin.py:165
 msgid "Available Methods"
 msgstr ""
 
-#: flask_security/forms.py:782
+#: flask_security/forms.py:776
 msgid "Disable two factor authentication"
 msgstr ""
 
-#: flask_security/forms.py:864
+#: flask_security/forms.py:860
 msgid "Trouble Accessing Your Account?/Lost Mobile Device?"
 msgstr ""
 
-#: flask_security/forms.py:866
+#: flask_security/forms.py:862
 msgid "Contact Administrator"
 msgstr ""
 
@@ -616,47 +616,47 @@ msgstr ""
 msgid "Use previously downloaded recovery code"
 msgstr ""
 
-#: flask_security/unified_signin.py:157
+#: flask_security/unified_signin.py:158
 msgid "Code or Password"
 msgstr ""
 
-#: flask_security/unified_signin.py:166
+#: flask_security/unified_signin.py:167
 msgid "Via email"
 msgstr "通过邮件"
 
-#: flask_security/unified_signin.py:167
+#: flask_security/unified_signin.py:168
 msgid "Via SMS"
 msgstr "通过SMS"
 
-#: flask_security/unified_signin.py:295
+#: flask_security/unified_signin.py:296
 msgid "Setup additional sign in option"
 msgstr ""
 
-#: flask_security/unified_signin.py:308
+#: flask_security/unified_signin.py:309
 msgid "Delete active sign in option"
 msgstr ""
 
-#: flask_security/webauthn.py:121 flask_security/webauthn.py:345
+#: flask_security/webauthn.py:120 flask_security/webauthn.py:344
 msgid "Nickname"
 msgstr ""
 
-#: flask_security/webauthn.py:125
+#: flask_security/webauthn.py:124
 msgid "Usage"
 msgstr ""
 
-#: flask_security/webauthn.py:127
+#: flask_security/webauthn.py:126
 msgid "Use as a first authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:130
+#: flask_security/webauthn.py:129
 msgid "Use as a secondary authentication factor"
 msgstr ""
 
-#: flask_security/webauthn.py:212
+#: flask_security/webauthn.py:211
 msgid "Start"
 msgstr ""
 
-#: flask_security/webauthn.py:919
+#: flask_security/webauthn.py:918
 msgid "webauthn"
 msgstr ""
 
@@ -733,7 +733,7 @@ msgid "Enter Recovery Code"
 msgstr ""
 
 #: flask_security/templates/security/mf_recovery_codes.html:6
-#: flask_security/templates/security/two_factor_setup.html:75
+#: flask_security/templates/security/two_factor_setup.html:69
 #: flask_security/templates/security/wan_register.html:75
 msgid "Recovery Codes"
 msgstr ""
@@ -773,44 +773,45 @@ msgstr ""
 msgid "Currently setup two-factor method: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:36
-msgid "To complete logging in, please enter the code sent to your mail"
-msgstr "要完成登录，请输入发送到您邮箱的代码"
-
-#: flask_security/templates/security/two_factor_setup.html:42
+#: flask_security/templates/security/two_factor_setup.html:46
 #: flask_security/templates/security/us_setup.html:61
 msgid ""
 "Open an authenticator app on your device and scan the following QRcode "
 "(or enter the code below manually) to start receiving codes:"
 msgstr "打开设备上的身份验证应用，扫描以下二维码(或手动输入以下代码)开始接收代码："
 
-#: flask_security/templates/security/two_factor_setup.html:45
+#: flask_security/templates/security/two_factor_setup.html:49
 msgid "Two factor authentication code"
 msgstr "双因素验证代码"
 
-#: flask_security/templates/security/two_factor_setup.html:52
-msgid "To Which Phone Number Should We Send Code To?"
-msgstr "我们应该将代码发送到哪个电话号码？"
-
-#: flask_security/templates/security/two_factor_setup.html:59
-msgid "WebAuthn"
+#: flask_security/templates/security/two_factor_setup.html:60
+msgid "Enter code to complete setup"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:61
-#: flask_security/templates/security/us_setup.html:88
-msgid "This application supports WebAuthn security keys."
+#: flask_security/templates/security/two_factor_setup.html:63
+#: flask_security/templates/security/two_factor_verify_code.html:10
+msgid "enter numeric code"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_setup.html:62
-#: flask_security/templates/security/two_factor_setup.html:78
+#: flask_security/templates/security/two_factor_setup.html:71
+#: flask_security/templates/security/wan_register.html:77
+msgid "This application supports setting up recovery codes."
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:72
+#: flask_security/templates/security/two_factor_setup.html:80
 #: flask_security/templates/security/us_setup.html:89
 #: flask_security/templates/security/wan_register.html:78
 msgid "You can set them up here."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_setup.html:77
-#: flask_security/templates/security/wan_register.html:77
-msgid "This application supports setting up recovery codes."
+msgid "WebAuthn"
+msgstr ""
+
+#: flask_security/templates/security/two_factor_setup.html:79
+#: flask_security/templates/security/us_setup.html:88
+msgid "This application supports WebAuthn security keys."
 msgstr ""
 
 #: flask_security/templates/security/two_factor_verify_code.html:6
@@ -822,16 +823,12 @@ msgstr "双因素授权"
 msgid "Please enter your authentication code generated via: %(method)s"
 msgstr ""
 
-#: flask_security/templates/security/two_factor_verify_code.html:10
-msgid "enter code"
-msgstr ""
-
-#: flask_security/templates/security/two_factor_verify_code.html:18
+#: flask_security/templates/security/two_factor_verify_code.html:19
 msgid "The code for authentication was sent to your email address"
 msgstr "认证代码已发送至您的电子邮件地址。"
 
-#: flask_security/templates/security/two_factor_verify_code.html:21
-msgid "A mail was sent to us in order to reset your application account"
+#: flask_security/templates/security/two_factor_verify_code.html:22
+msgid "An email was sent to us in order to reset your application account"
 msgstr ""
 
 #: flask_security/templates/security/us_setup.html:30
@@ -1122,4 +1119,16 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Currently active sign in options:"
+#~ msgstr ""
+
+#~ msgid "To complete logging in, please enter the code sent to your mail"
+#~ msgstr "要完成登录，请输入发送到您邮箱的代码"
+
+#~ msgid "To Which Phone Number Should We Send Code To?"
+#~ msgstr "我们应该将代码发送到哪个电话号码？"
+
+#~ msgid "enter code"
+#~ msgstr ""
+
+#~ msgid "A mail was sent to us in order to reset your application account"
 #~ msgstr ""

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -4,7 +4,7 @@
 
     Flask-Security WebAuthn module
 
-    :copyright: (c) 2021-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2021-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 
     This implements support for webauthn/FIDO2 Level 2 using the py_webauthn package.
@@ -36,7 +36,6 @@
 
 """
 
-import datetime
 import json
 import time
 import typing as t
@@ -678,7 +677,7 @@ def webauthn_signin_response(token: str) -> "ResponseValue":
         after_this_request(view_commit)
         assert form.cred
         assert form.user
-        form.cred.lastuse_datetime = datetime.datetime.utcnow()
+        form.cred.lastuse_datetime = _security.datetime_factory()
         form.cred.sign_count = form.authentication_verification.new_sign_count
         form.cred.backup_state = getattr(
             form.authentication_verification, "credential_backed_up", False
@@ -835,7 +834,7 @@ def webauthn_verify_response(token: str) -> "ResponseValue":
         # update last use and sign count
         after_this_request(view_commit)
         assert form.cred
-        form.cred.lastuse_datetime = datetime.datetime.utcnow()
+        form.cred.lastuse_datetime = _security.datetime_factory()
         form.cred.sign_count = form.authentication_verification.new_sign_count
         _datastore.put(form.cred)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers=[
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Development Status :: 5 - Production/Stable",
@@ -70,7 +71,6 @@ low = [
     "babel==2.12.1",
     "bcrypt==4.0.1",
     "bleach==6.0.0",
-    "python-dateutil==2.8.2",
     "jinja2==3.1.2",
     "itsdangerous==2.1.2",
     "markupsafe==2.1.2",
@@ -82,6 +82,8 @@ low = [
     "qrcode==7.4.2",
     # authlib requires requests
     "requests",
+    # passlib required setuptools
+    "setuptools",
     "sqlalchemy==2.0.12",
     "sqlalchemy-utils==0.41.1",
     "webauthn==1.11.0",

--- a/pytest.ini
+++ b/pytest.ini
@@ -21,6 +21,8 @@ filterwarnings =
     ignore::DeprecationWarning:mongoengine:
     ignore::DeprecationWarning:flask_login:0
     ignore::DeprecationWarning:pydantic_core:0
+    # next for py 3.12
+    ignore::DeprecationWarning:pkg_resources:0
     ignore::UserWarning:cbor2:0
     ignore:.*passwordless feature.*:DeprecationWarning:flask_security:0
     ignore::DeprecationWarning:passlib:0

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -3,7 +3,7 @@ Babel
 Flask-Login
 Flask-Mailman
 Flask-Principal
-peewee
+peewee; python_version < '3.12'
 Flask-SQLAlchemy
 argon2_cffi
 authlib
@@ -13,7 +13,6 @@ check-manifest
 coverage
 cryptography
 djlint
-python-dateutil
 mongoengine
 mongomock
 msgcheck
@@ -27,6 +26,8 @@ pytest
 qrcode
 # authlib requires requests
 requests
+# passlib requires setuptools which is deprecated
+setuptools
 sqlalchemy
 sqlalchemy-utils
 webauthn

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@
     Test fixtures and what not
 
     :copyright: (c) 2017 by CERN.
-    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -37,6 +37,7 @@ from flask_security import (
     auth_token_required,
     http_auth_required,
     get_request_attr,
+    naive_utcnow,
     roles_accepted,
     roles_required,
     permissions_accepted,
@@ -569,7 +570,7 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl, **engine_kwargs):
             DateTime,
             nullable=False,
             server_default=func.now(),
-            onupdate=datetime.utcnow,
+            onupdate=naive_utcnow,
         )
 
     class User(Base, UserMixin):
@@ -603,7 +604,7 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl, **engine_kwargs):
             DateTime,
             nullable=False,
             server_default=func.now(),
-            onupdate=datetime.utcnow,
+            onupdate=naive_utcnow,
         )
 
         @declared_attr

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -5,15 +5,21 @@
     Datastore tests
 
     :copyright: (c) 2012 by Matt Wright.
-    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
-import datetime
 from pytest import raises, skip, importorskip
 from tests.test_utils import init_app_with_options, get_num_queries, is_sqlalchemy
 
-from flask_security import RoleMixin, Security, UserMixin, LoginForm, RegisterForm
+from flask_security import (
+    RoleMixin,
+    Security,
+    UserMixin,
+    LoginForm,
+    RegisterForm,
+    naive_utcnow,
+)
 from flask_security.datastore import Datastore, UserDatastore
 
 
@@ -309,7 +315,7 @@ def test_modify_permissions(app, datastore):
         assert perms == t1.get_permissions()
         if hasattr(t1, "update_datetime"):
             orig_update_time = t1.update_datetime
-            assert t1.update_datetime <= datetime.datetime.utcnow()
+            assert t1.update_datetime <= naive_utcnow()
 
         ds.add_permissions_to_role(t1, "execute")
         ds.commit()
@@ -429,7 +435,7 @@ def test_uuid(app, request, tmpdir, realdburl):
         username = Column(String(255), unique=True, nullable=True)
         password = Column(String(255))
         active = Column(Boolean())
-        created_at = Column(DateTime, default=datetime.datetime.utcnow)
+        created_at = Column(DateTime, default=naive_utcnow())
         confirmed_at = Column(DateTime())
         roles = relationship(
             "Role", secondary="roles_users", backref=backref("users", lazy="dynamic")

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -4,7 +4,7 @@
 
     WebAuthn tests
 
-    :copyright: (c) 2021-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2021-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 
 """
@@ -12,7 +12,6 @@
 from base64 import urlsafe_b64encode
 import copy
 import datetime
-from dateutil import parser
 import json
 import re
 import typing as t
@@ -383,7 +382,7 @@ def test_basic_json(app, clients, get_message):
     response = clients.get("/wan-register", headers=headers)
     active_creds = response.json["response"]["registered_credentials"]
     assert active_creds[0]["name"] == "testr1"
-    assert parser.parse(active_creds[0]["lastuse"]) == fake_dt
+    assert datetime.datetime.fromisoformat(active_creds[0]["lastuse"]) == fake_dt
 
     # sign in - simple case use identity so we get back allowCredentials
     logout(clients)
@@ -409,7 +408,7 @@ def test_basic_json(app, clients, get_message):
     # fetch credentials and verify lastuse was updated
     response = clients.get("/wan-register", headers=headers)
     active_creds = response.json["response"]["registered_credentials"]
-    assert parser.parse(active_creds[0]["lastuse"]) != fake_dt
+    assert datetime.datetime.fromisoformat(active_creds[0]["lastuse"]) != fake_dt
     assert active_creds[0]["transports"] == ["usb"]
     assert active_creds[0]["usage"] == "first"
 

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -1,4 +1,4 @@
-# :copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
+# :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
 # :license: MIT, see LICENSE for more details.
 
 """
@@ -21,7 +21,7 @@ data and a mail sender that flashes what mail would be sent!
 
 """
 
-import datetime
+from datetime import timedelta
 import os
 import typing as t
 
@@ -45,7 +45,12 @@ from flask_security.signals import (
     user_not_registered,
     user_registered,
 )
-from flask_security.utils import hash_password, uia_email_mapper, uia_phone_mapper
+from flask_security.utils import (
+    hash_password,
+    naive_utcnow,
+    uia_email_mapper,
+    uia_phone_mapper,
+)
 
 
 def _find_bool(v):
@@ -100,8 +105,8 @@ def create_app():
     app.config["SECURITY_TOTP_SECRETS"] = {
         "1": "TjQ9Qa31VOrfEzuPy4VHQWPCTmRzCnFzMKLxXYiZu9B"
     }
-    app.config["SECURITY_FRESHNESS"] = datetime.timedelta(minutes=10)
-    app.config["SECURITY_FRESHNESS_GRACE_PERIOD"] = datetime.timedelta(minutes=20)
+    app.config["SECURITY_FRESHNESS"] = timedelta(minutes=10)
+    app.config["SECURITY_FRESHNESS_GRACE_PERIOD"] = timedelta(minutes=20)
     app.config["SECURITY_USERNAME_ENABLE"] = True
     app.config["SECURITY_USERNAME_REQUIRED"] = True
     app.config["SECURITY_PASSWORD_REQUIRED"] = False  # allow registration w/o password
@@ -277,7 +282,7 @@ def add_user(ds, email, password, roles):
     roles = [ds.find_or_create_role(rn) for rn in roles]
     ds.commit()
     user = ds.create_user(
-        email=email, password=pw, active=True, confirmed_at=datetime.datetime.utcnow()
+        email=email, password=pw, active=True, confirmed_at=naive_utcnow()
     )
     ds.commit()
     for role in roles:

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{38,39,310,311,py39}-{low,release}
+    py{38,39,310,311,312,py39}-{low,release}
     mypy
     async
     nowebauthn
@@ -22,14 +22,14 @@ commands =
     tox -e compile_catalog
     pytest -W ignore --basetemp={envtmpdir} {posargs:tests}
 
-[testenv:py{38,39,310,311}-release]
+[testenv:py{38,39,310,311,312}-release]
 deps =
     -r requirements/tests.txt
 commands =
     tox -e compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}
 
-[testenv:py{38,39,310,311,py39}-low]
+[testenv:py{38,39,310,311,312,py39}-low]
 deps =
     pytest
 extras = low


### PR DESCRIPTION
- add CI support
- utcnow is deprecated - create our own so DB is still naive UTC timestamps
- remove use of dateutil (it was just used for tests)
- many places didn't use DATETIME_FACTORY - now they do
- update translations
- many copyright dates
- remove JSON compatibility code for Flask pre 2.x