### PR TITLE
Fixes for py_webauthn 2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,7 +30,8 @@ Fixes
 - (:pr:`866`) Improve German translations (sr-verde)
 - (:pr:`889`) Improve method translations for unified signin and two factor. Remove support for Flask-Babelex.
 - (:issue:`884`) Oauth re-used POST_LOGIN_VIEW which caused confusion. See below for implications.
-- (:pr:`xxx`) Improve (and simplify) Two-Factor setup. See below for backwards compatability issues and new functionality.
+- (:pr:`900`) Improve (and simplify) Two-Factor setup. See below for backwards compatability issues and new functionality.
+- (:pr:`xxx`) Work with py_webauthn 2.0
 
 Notes
 ++++++
@@ -86,6 +87,15 @@ Backwards Compatibility Concerns
   This shouldn't be used - instead use Flask-Security's :meth:`flask_security.auth_required` decorator.
 - Support for Flask-Babelex has been removed. Please convert to Flask-Babel.
 
+Version 5.3.3
+-------------
+
+Released December 29, 2023
+
+Fixes
++++++
+- (:issue:`893`) Once again work on open-redirect vulnerability - this time due to newer Werkzeug.
+  Addresses: CVE-2023-49438
 
 Version 5.3.2
 -------------

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -59,6 +59,7 @@ try:
     )
     from webauthn.helpers.exceptions import (
         InvalidAuthenticationResponse,
+        InvalidJSONStructure,
         InvalidRegistrationResponse,
     )
     from webauthn.helpers.structs import (
@@ -171,7 +172,12 @@ class WebAuthnRegisterResponseForm(Form):
             return False
         try:
             reg_cred = parse_registration_credential_json(self.credential.data)
-        except (ValueError, KeyError, InvalidRegistrationResponse):
+        except (
+            ValueError,
+            KeyError,
+            InvalidJSONStructure,
+            InvalidRegistrationResponse,
+        ):
             self.credential.errors.append(get_message("API_ERROR")[0])
             return False
         try:
@@ -262,7 +268,12 @@ class WebAuthnSigninResponseForm(Form, NextFormMixin):
             return False  # pragma: no cover
         try:
             auth_cred = parse_authentication_credential_json(self.credential.data)
-        except (ValueError, KeyError, InvalidAuthenticationResponse):
+        except (
+            ValueError,
+            KeyError,
+            InvalidJSONStructure,
+            InvalidAuthenticationResponse,
+        ):
             self.credential.errors.append(get_message("API_ERROR")[0])
             return False
 
@@ -405,7 +416,7 @@ def webauthn_register() -> "ResponseValue":
             challenge=challenge.encode(),
             rp_name=cv("WAN_RP_NAME"),
             rp_id=request.host.split(":")[0],
-            user_id=current_user.fs_webauthn_user_handle,
+            user_id=current_user.fs_webauthn_user_handle.encode(),
             user_name=current_user.calc_username(),
             timeout=cv("WAN_REGISTER_TIMEOUT"),
             exclude_credentials=create_credential_list(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 babel = ["babel>=2.12.1", "flask_babel>=3.1.0"]
 fsqla = ["flask_sqlalchemy>=3.0.3", "sqlalchemy>=2.0.12", "sqlalchemy-utils>=0.41.1"]
 common = ["bcrypt>=4.0.1", "flask_mailman>=0.3.0", "bleach>=6.0.0"]
-mfa = ["cryptography>=40.0.2", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=1.11.0"]
+mfa = ["cryptography>=40.0.2", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.0.0"]
 low = [
     # Lowest supported versions
     "Flask==2.3.2",
@@ -78,7 +78,6 @@ low = [
     "mongomock==4.1.2",
     "pony==0.7.16;python_version<'3.11'",
     "phonenumberslite==8.13.11",
-    "pydantic<2.0",
     "qrcode==7.4.2",
     # authlib requires requests
     "requests",
@@ -86,7 +85,7 @@ low = [
     "setuptools",
     "sqlalchemy==2.0.12",
     "sqlalchemy-utils==0.41.1",
-    "webauthn==1.11.0",
+    "webauthn==2.0.0",
     "werkzeug==2.3.3",
     "zxcvbn==4.4.28"
 ]

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -31,6 +31,5 @@ setuptools
 sqlalchemy
 sqlalchemy-utils
 webauthn
-pydantic<2.0
 werkzeug
 zxcvbn

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -508,7 +508,7 @@ def test_bad_data_register(app, client, get_message):
     register_options, response_url = _register_start_json(client, name="testr3")
 
     # first try mangling json - should get API_ERROR
-    response = client.post(response_url, json=dict(credential="hi there"))
+    response = client.post(response_url, json=dict(credential='"hi there"'))
     assert response.status_code == 400
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "API_ERROR"
@@ -556,7 +556,7 @@ def test_bad_data_signin(app, client, get_message):
 
     logout(client)
     signin_options, response_url, _ = _signin_start_json(client, "matt@lp.com")
-    response = client.post(response_url, json=dict(credential="hi there"))
+    response = client.post(response_url, json=dict(credential='"hi there"'))
     assert response.status_code == 400
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
         "API_ERROR"
@@ -1202,12 +1202,9 @@ def test_user_handle(app, clients, get_message):
         user = app.security.datastore.find_user(email="matt@lp.com")
         app.security.datastore.set_webauthn_user_handle(user)
         app.security.datastore.commit()
-
-        b64_user_handle = (
-            urlsafe_b64encode(user.fs_webauthn_user_handle.encode())
-            .decode("utf-8")
-            .replace("=", "")
-        )
+        b64_user_handle = urlsafe_b64encode(
+            user.fs_webauthn_user_handle.encode()
+        ).decode("utf-8")
     upd_signin_data = copy.deepcopy(SIGNIN_DATA_UH)
     upd_signin_data["response"]["userHandle"] = b64_user_handle
     signin_options, response_url, _ = _signin_start_json(clients, "matt@lp.com")


### PR DESCRIPTION
py_webauthn dumped pydantic and did some other changes that fixed the user_handle issue we had with pydantic 2.0. Furthermore they adopted the design of user.id/user_handle being b64encoded on the wire - so they now handle that both at registration and at authentication time - so no more hacks...