### PR TITLE
A better fix for open redirect vulnerability.

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Black
+721d31e9cb02af22e3ad9d579b7b82123527fafe

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,19 +19,21 @@ Features
 Fixes
 +++++
 
-- (:issue:`845`) us-signin magic link should use fs_uniquifier (not email)
-- (:issue:`893`) Once again work on open-redirect vulnerability - this time due to newer Werkzeug
-- (:pr:`873`) Update Spanish and Italian translations (gissimo)
-- (:pr:`877`) Make AnonymousUser optional and deprecated
-- (:issue:`875`) user_datastore.create_user has side effects on mutable inputs (NoRePercussions)
+- (:issue:`845`) us-signin magic link should use fs_uniquifier. (not email)
+- (:issue:`893`) Improve open-redirect vulnerability mitigation. (see below)
+- (:pr:`873`) Update Spanish and Italian translations. (gissimo)
+- (:pr:`877`) Make AnonymousUser optional and deprecated.
+- (:issue:`875`) user_datastore.create_user has side effects on mutable inputs. (NoRePercussions)
 - (:pr:`878`) The long deprecated _unauthorized_callback/handler has been removed.
 - (:pr:`881`) No longer rely on Flask-Login.unauthorized callback. See below for implications.
-- (:pr:`855`) Improve translations for two-factor method selection (gissimo)
-- (:pr:`866`) Improve German translations (sr-verde)
+- (:pr:`855`) Improve translations for two-factor method selection. (gissimo)
+- (:pr:`866`) Improve German translations. (sr-verde)
 - (:pr:`889`) Improve method translations for unified signin and two factor. Remove support for Flask-Babelex.
-- (:issue:`884`) Oauth re-used POST_LOGIN_VIEW which caused confusion. See below for implications.
-- (:pr:`900`) Improve (and simplify) Two-Factor setup. See below for backwards compatability issues and new functionality.
-- (:pr:`xxx`) Work with py_webauthn 2.0
+- (:issue:`884`) Oauth re-used POST_LOGIN_VIEW which caused confusion. See below for the new configuration and implications.
+- (:pr:`899`) Improve (and simplify) Two-Factor setup. See below for backwards compatability issues and new functionality.
+- (:pr:`901`) Work with py_webauthn 2.0
+- (:pr:`xxx`) Remove undocumented and untested looking in session for possible 'next'
+  redirect location.
 
 Notes
 ++++++
@@ -86,6 +88,19 @@ Backwards Compatibility Concerns
 - Flask-Security no longer configures anything related to Flask-Login's `fresh_login` logic.
   This shouldn't be used - instead use Flask-Security's :meth:`flask_security.auth_required` decorator.
 - Support for Flask-Babelex has been removed. Please convert to Flask-Babel.
+- Open Redirect mitigation. Release 4.1.0 had a fix for :issue:`486` involving a potential
+  open redirect. This was very low priority since the default configuration of Werkzeug (always
+  convert the Location header to absolute URL) rendered the vulnerability un-exploitable. The solution at that
+  time was to add an optional regex looking for these bizarre URLs that from a HTTP spec perspective
+  are relative, but various browsers would interpret as absolute. In Werkzeug release 2.1 the
+  default was changed so that the Location header was allowed to be a relative URL. This made the
+  open redirect vulnerability much more likely to be exploitable. More recently, additional bizarre
+  URLs were found, as documented in :issue:`893`. More work was done and a patch release 5.3.3
+  was published.  This fix utilized changing the Werkzeug default back to absolute and an updated
+  regex. Comments and thoughts by @gmanfuncky proposed a much better solution and that is in 5.4.
+  This implementation is independent of Werkzeug (and relative Location headers are again the default).
+  The entire regex option has been removed.
+  Instead, any user-supplied path used as a redirect is parsed and quoted.
 
 Version 5.3.3
 -------------

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -114,38 +114,9 @@ The following endpoints accept a ``next`` parameter:
     - .us_signin ("/us-signin")
     - .us_verify ("/us-verify")
 
+Flask-Security always quotes the path portion of a user supplied URL.
+This `link <https://www.cve.org/CVERecord?id=CVE-2021-32618>`_ provides background of why simple parsing of URLs isn't enough.
 
-Flask-Security attempts to verify that redirects are always relative.
-FS uses the standard Python library urlsplit() to parse the URL and verify
-that the ``netloc`` hasn't been altered.
-However, many browsers actually accept URLs that should be considered
-relative and perform various stripping and conversions that can cause them
-to be interpreted as absolute. A trivial example of this is:
-
-.. line-block::
-    /login?next=%20///github.com
-
-This will pass the urlsplit() test that it is relative - but many browsers
-will simply strip off the space and interpret it as an absolute URL!
-
-Prior to Werkzeug 2.1, Werkzeug set the response configuration variable
-``autocorrect_location_header = True`` which forced the response `Location`
-header to always be an absolute path - thus effectively squashing any open
-redirect possibility. However since 2.1 it is now `False`.
-
-Flask Security offers
-2 mitigations for this via the :py:data:`SECURITY_REDIRECT_VALIDATE_MODE` and
-:py:data:`SECURITY_REDIRECT_VALIDATE_RE` configuration variables.
-
-- The first mode - `"absolute"`, which is the default, is to once again set Werkzeug's ``autocorrect_location_header``
-  to ``True``. Please note that this is set JUST for Flask-Security's blueprint - not all requests.
-- With the second mode - `"regex"` - FS uses a regular expression to validate all ``next`` parameters to make sure
-  they will be interpreted as `relative`. Be aware that the default regular
-  expression is based on in-the-field testing and it is quite possible that there
-  are other crafted relative URLs that could escape detection.
-
-:py:data:`SECURITY_REDIRECT_VALIDATE_MODE` actually takes a list - so both
-mechanisms can be specified.
 
 .. _pass_validation_topic:
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -4,7 +4,7 @@
 
     Test common functionality
 
-    :copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -78,6 +78,15 @@ def test_authenticate_with_invalid_next(client, get_message):
     data = dict(email="matt@lp.com", password="password")
     response = client.post("/login?next=http://google.com", data=data)
     assert get_message("INVALID_REDIRECT") in response.data
+
+
+@pytest.mark.settings(flash_messages=False)
+def test_authenticate_with_invalid_next_json(client, get_message):
+    data = dict(email="matt@lp.com", password="password")
+    response = client.post("/login?next=http://google.com", json=data)
+    assert response.json["response"]["errors"][0].encode() == get_message(
+        "INVALID_REDIRECT"
+    )
 
 
 def test_authenticate_with_invalid_malformed_next(client, get_message):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,6 @@ from flask_security.signals import (
     us_security_token_sent,
 )
 from flask_security.utils import hash_data, hash_password
-from flask_security.utils import config_value as cv
 
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from werkzeug.http import parse_cookie
@@ -68,13 +67,9 @@ def is_authenticated(client, get_message, auth_token=None):
 
 
 def check_location(app, location, expected_base):
-    # verify response location. This can be absolute or relative based
-    # on configuration
-    redirect_validate_mode = cv("REDIRECT_VALIDATE_MODE", app=app) or []
-    if "absolute" in redirect_validate_mode:
-        return location == f"http://localhost{expected_base}"
-    else:
-        return location == expected_base
+    # verify response location. Historically this can be absolute or relative based
+    # on configuration. As of 5.4 and Werkzeug 2.1 it is always relative
+    return location == expected_base
 
 
 def verify_token(client_nc, token, status=None):

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -206,14 +206,6 @@ def create_app():
     except ImportError:
         pass
 
-    @app.after_request
-    def allow_absolute_redirect(r):
-        # This is JUST to test odd possible redirects that look relative but are
-        # interpreted by browsers as absolute.
-        # DON'T SET THIS IN YOUR APPLICATION!
-        r.autocorrect_location_header = False
-        return r
-
     @user_registered.connect_via(app)
     def on_user_registered(myapp, user, confirm_token, **extra):
         flash(f"To confirm {user.email} - go to /confirm/{confirm_token}")


### PR DESCRIPTION
In the few cases where user input is used for redirecting (via the 'next' parameter) pull apart the URL and quote the path. This will render any of the bizarre URLs that are relative according to the spec, but interpreted as absolute by many browsers definitely relative (and harmless).

Remove the previous fix including REDIRECT_VALIDATE_MODE and REDIRECT_VALIDATE_RE configuration variables. The Werkzeug default of sending relative URLs in Location header was restored as well.

closes #893 