### PR TITLE
Improve CSRF

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # Black
 721d31e9cb02af22e3ad9d579b7b82123527fafe
+# Black 2024
+af6e7176eb54e7e9de77dd6e2cba03630c13f14e

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,8 +32,10 @@ Fixes
 - (:issue:`884`) Oauth re-used POST_LOGIN_VIEW which caused confusion. See below for the new configuration and implications.
 - (:pr:`899`) Improve (and simplify) Two-Factor setup. See below for backwards compatability issues and new functionality.
 - (:pr:`901`) Work with py_webauthn 2.0
-- (:pr:`xxx`) Remove undocumented and untested looking in session for possible 'next'
+- (:pr:`906`) Remove undocumented and untested looking in session for possible 'next'
   redirect location.
+- (:pr:`xxx`) Improve CSRF documentation and testing. Fix bug where a CSRF failure could
+  return an HTML page even if the request was JSON.
 
 Notes
 ++++++
@@ -101,6 +103,12 @@ Backwards Compatibility Concerns
   This implementation is independent of Werkzeug (and relative Location headers are again the default).
   The entire regex option has been removed.
   Instead, any user-supplied path used as a redirect is parsed and quoted.
+- JSON error response has changed due to issue with WTForms form-level errors. When WTForms
+  introduced form-level errors they added it to the form.errors response using `None` as a key.
+  When serializing it, it would turn into "null". However, if there is more than one error
+  the default settings for JSON serialization in Flask attempt to sort the keys - which fails
+  with the `None` key. An issue has been filed with WTForms - and maybe it will be changed.
+  Flask-Security now changes any `None` key to `""`.
 
 Version 5.3.3
 -------------

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -212,6 +212,7 @@ Flask-Security strives to support various options for both its endpoints (e.g. `
 and the application endpoints (protected with Flask-Security decorators such as :func:`.auth_required`).
 
 If your application just uses forms that are derived from ``Flask-WTF::Flaskform`` - you are done.
+Note that all of Flask-Security's endpoints are form based (regardless of how the request was made).
 
 
 CSRF: Single-Page-Applications and AJAX/XHR
@@ -387,7 +388,7 @@ CSRF: Pro-Tips
        (or clients must use CSRF/session cookie for logging
        in then once they have an authentication token, no further need for cookie).
 
-    #) If you enable CSRFProtect(app) and you want to support non-form based JSON requests,
+    #) If you enable CSRFProtect(app) and you want to send request data as JSON,
        then you must include the CSRF token in the header (e.g. X-CSRF-Token)
 
     #) You must enable CSRFProtect(app) if you want to accept the CSRF token in the request

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -289,6 +289,13 @@ Be aware that if you enable this it will ONLY work if you send the session cooki
 .. note::
     It is IMPORTANT that you initialize/call ``CSRFProtect`` PRIOR to initializing Flask_Security.
 
+.. note::
+    Calling CSRFProtect(app) will setup a @before_request handler to verify CSRF - this occurs BEFORE any Flask-Security decorators
+    or other view/form logic. One side effect is that CSRFProtect, on error, will raise a BadRequest error which returns a small
+    piece of HTML by default - your application will need to add a Flask ErrorHandler to change that. Alternatively, and recommended
+    is to set `WTF_CSRF_CHECK_DEFAULT` to `False` - which will disable the @before_request and let Flask-Security handle CSRF protection
+    including properly returning a JSON response if the caller asks for it.
+
 
 Using a Cookie
 --------------

--- a/flask_security/templates/security/change_password.html
+++ b/flask_security/templates/security/change_password.html
@@ -1,11 +1,12 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 
 {% block content %}
   {% include "security/_messages.html" %}
   <h1>{{ _fsdomain('Change password') }}</h1>
   <form action="{{ url_for_security('change_password') }}" method="post" name="change_password_form">
     {{ change_password_form.hidden_tag() }}
+    {{ render_form_errors(change_password_form) }}
     {% if active_password %}
       {{ render_field_with_errors(change_password_form.password) }}
     {% else %}
@@ -13,6 +14,7 @@
     {% endif %}
     {{ render_field_with_errors(change_password_form.new_password) }}
     {{ render_field_with_errors(change_password_form.new_password_confirm) }}
+    {{ render_field_errors(change_password_form.csrf_token) }}
     {{ render_field(change_password_form.submit) }}
   </form>
 {% endblock content %}

--- a/flask_security/templates/security/forgot_password.html
+++ b/flask_security/templates/security/forgot_password.html
@@ -1,12 +1,14 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 
 {% block content %}
   {% include "security/_messages.html" %}
   <h1>{{ _fsdomain('Send password reset instructions') }}</h1>
   <form action="{{ url_for_security('forgot_password') }}" method="post" name="forgot_password_form">
     {{ forgot_password_form.hidden_tag() }}
+    {{ render_form_errors(forgot_password_form) }}
     {{ render_field_with_errors(forgot_password_form.email) }}
+    {{ render_field_errors(forgot_password_form.csrf_token) }}
     {{ render_field(forgot_password_form.submit) }}
   </form>
   {% include "security/_menu.html" %}

--- a/flask_security/templates/security/reset_password.html
+++ b/flask_security/templates/security/reset_password.html
@@ -1,13 +1,15 @@
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
 
 {% block content %}
   {% include "security/_messages.html" %}
   <h1>{{ _fsdomain('Reset password') }}</h1>
   <form action="{{ url_for_security('reset_password', token=reset_password_token) }}" method="post" name="reset_password_form">
     {{ reset_password_form.hidden_tag() }}
+    {{ render_form_errors(reset_password_form) }}
     {{ render_field_with_errors(reset_password_form.password) }}
     {{ render_field_with_errors(reset_password_form.password_confirm) }}
+    {{ render_field_errors(reset_password_form.csrf_token) }}
     {{ render_field(reset_password_form.submit) }}
   </form>
   {% include "security/_menu.html" %}

--- a/flask_security/templates/security/two_factor_setup.html
+++ b/flask_security/templates/security/two_factor_setup.html
@@ -17,7 +17,7 @@
 #}
 
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_no_label, render_field_errors %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_no_label, render_field_errors, render_form_errors %}
 
 {% block content %}
   {% include "security/_messages.html" %}
@@ -25,6 +25,7 @@
   <h3>{{ _fsdomain("In addition to your username and password, you'll need to use a code.") }}</h3>
   <form action="{{ url_for_security('two_factor_setup') }}" method="post" name="two_factor_setup_form">
     {{ two_factor_setup_form.hidden_tag() }}
+    {{ render_form_errors(two_factor_setup_form) }}
     <div class="fs-div">{{ _fsdomain("Currently setup two-factor method: %(method)s", method=primary_method) }}</div>
     <hr class="fs-gap">
     {% for subfield in two_factor_setup_form.setup %}
@@ -37,6 +38,7 @@
     </div>
     <div class="fs-gap">
       {{ render_field_errors(two_factor_setup_form.setup) }}
+      {{ render_field_errors(two_factor_setup_form.csrf_token) }}
       {{ render_field(two_factor_setup_form.submit) }}
     </div>
     {% if chosen_method=="authenticator" %}

--- a/flask_security/templates/security/wan_signin.html
+++ b/flask_security/templates/security/wan_signin.html
@@ -3,7 +3,7 @@
 #}
 
 {% extends "security/base.html" %}
-{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, prop_next %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors, prop_next %}
 
 {% block head_scripts %}
   {{ super() }}
@@ -21,11 +21,13 @@
   {% if not credential_options %}
     <form action="{{ url_for_security('wan_signin') }}{{ prop_next() }}" method="post" name="wan_signin_form" id="wan-signin-form">
       {{ wan_signin_form.hidden_tag() }}
+      {{ render_form_errors(wan_signin_form) }}
       {% if not is_secondary %}
         {{ render_field_with_errors(wan_signin_form.identity) }}
         {{ render_field_with_errors(wan_signin_form.remember) }}
       {% endif %}
       {{ render_field_errors(wan_signin_form.credential) }}
+      {{ render_field_errors(wan_signin_form.csrf_token) }}
       {{ render_field(wan_signin_form.submit) }}
     </form>
   {% else %}

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -767,6 +767,7 @@ def two_factor_setup():
 
     else:
         # Caller is changing their TFA profile. This requires a 'fresh' authentication
+        # N.B unauth_csrf has done the CSRF check already.
         if not check_and_update_authn_fresh(
             cv("FRESHNESS"),
             cv("FRESHNESS_GRACE_PERIOD"),

--- a/flask_security/webauthn.py
+++ b/flask_security/webauthn.py
@@ -560,8 +560,9 @@ def webauthn_register_response(token: str) -> "ResponseValue":
 
     if _security._want_json(request):
         return base_render_json(form)
-    if len(form.errors) > 0:
-        do_flash(form.errors["credential"][0], "error")
+    if form.errors:
+        for v in form.errors.values():
+            do_flash(v[0], "error")
     return redirect(url_for_security("wan_register"))
 
 
@@ -742,8 +743,9 @@ def webauthn_signin_response(token: str) -> "ResponseValue":
 
     # Since the response is auto submitted - we go back to
     # signin form - for now use flash.
-    if form.credential.errors:
-        do_flash(form.credential.errors[0], "error")
+    if form.errors:
+        for v in form.errors.values():
+            do_flash(v[0], "error")
     return redirect(url_for_security("wan_signin"))
 
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -15,6 +15,7 @@ markers =
     unified_signin
     webauthn
     flask_async
+    csrf
 
 filterwarnings =
     error

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -886,10 +886,12 @@ def test_json_form_errors(app, client):
     """Test wtforms form level errors are correctly sent via json"""
     with app.test_request_context():
         form = ChangePasswordForm()
+        form.validate()
         form.form_errors.append("I am an error")
         response = base_render_json(form)
-        assert len(response.json["response"]["errors"]) == 1
-        assert response.json["response"]["errors"][0] == "I am an error"
+        error_list = response.json["response"]["errors"]
+        assert len(error_list) == 3
+        assert "I am an error" in error_list
 
 
 def test_method_view(app, client):
@@ -1313,7 +1315,7 @@ def test_open_redirect(app, client, get_message):
         (r"/\github.com", "/%5Cgithub.com"),
         (r"\/github.com", "%5C/github.com"),
         ("//github.com", ""),
-        ("\t//github.com", ""),
+        ("\t//github.com", "%09//github.com"),
     ]
     for i, o in test_urls:
         data = dict(email="matt@lp.com", password="password", next=i)

--- a/tests/test_oauthglue.py
+++ b/tests/test_oauthglue.py
@@ -87,7 +87,7 @@ def test_github(app, sqlalchemy_datastore, get_message):
 
     # make sure required CSRF
     response = client.post(github_url, follow_redirects=False)
-    assert "The CSRF token is missing"
+    assert b"The CSRF token is missing" in response.data
 
     response = client.post(
         github_url, data=dict(csrf_token=csrf_token), follow_redirects=False

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -516,7 +516,7 @@ def test_username(app, client, get_message):
     assert response.status_code == 400
     assert (
         get_message("USER_DOES_NOT_EXIST")
-        == response.json["response"]["field_errors"]["null"][0].encode()
+        == response.json["response"]["field_errors"][""][0].encode()
     )
 
     # login using us-signin

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -2030,9 +2030,9 @@ def test_generic_response(app, client, get_message):
     data = dict(identity="matt@lp.com", code="12345")
     response = client.post("/us-signin", json=data)
     assert response.status_code == 400
-    assert list(response.json["response"]["field_errors"].keys()) == ["null"]
-    assert len(response.json["response"]["field_errors"]["null"]) == 1
-    assert response.json["response"]["field_errors"]["null"][0].encode(
+    assert list(response.json["response"]["field_errors"].keys()) == [""]
+    assert len(response.json["response"]["field_errors"][""]) == 1
+    assert response.json["response"]["field_errors"][""][0].encode(
         "utf-8"
     ) == get_message("GENERIC_AUTHN_FAILED")
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(
@@ -2047,9 +2047,9 @@ def test_generic_response(app, client, get_message):
     data = dict(identity="matt2@lp.com", code="12345")
     response = client.post("/us-signin", json=data)
     assert response.status_code == 400
-    assert list(response.json["response"]["field_errors"].keys()) == ["null"]
-    assert len(response.json["response"]["field_errors"]["null"]) == 1
-    assert response.json["response"]["field_errors"]["null"][0].encode(
+    assert list(response.json["response"]["field_errors"].keys()) == [""]
+    assert len(response.json["response"]["field_errors"][""]) == 1
+    assert response.json["response"]["field_errors"][""][0].encode(
         "utf-8"
     ) == get_message("GENERIC_AUTHN_FAILED")
     assert response.json["response"]["errors"][0].encode("utf-8") == get_message(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,9 +36,17 @@ _missing = object
 
 
 def authenticate(
-    client, email="matt@lp.com", password="password", endpoint=None, **kwargs
+    client,
+    email="matt@lp.com",
+    password="password",
+    endpoint=None,
+    csrf=False,
+    **kwargs,
 ):
     data = dict(email=email, password=password, remember="y")
+    if csrf:
+        response = client.get(endpoint or "/login")
+        data["csrf_token"] = get_form_input(response, "csrf_token")
     return client.post(endpoint or "/login", data=data, **kwargs)
 
 


### PR DESCRIPTION
Added testing to /tf-setup - there wasn't any CSRF issue - all working.

CSRF handling is complex and there are few unit tests.

- Added @pytest.mark.csrf to make it easier to turn on and test CSRF w/o lots of boilerplate
- Added tests and improved many templates to show CSRF errors - mostly for developers - but otherwise CSRF errors tent do just disappear and are difficult to debug
- Found issue with WTFforms with the new form-level errors - it uses a `None` key - which, if there are multiple errors, isn't sortable by Flasks default JSON serializer. Filed issue and now change if from `None` to ""
- Fixed issue in webauthn with CSRF errors causing exceptions - added tests.
- In the case of CSRFprotect() (the app configuring CSRF for the entire app) a CSRF error would raise an exception which would always return an HTML response - added code to return a JSON response if desired.

closes #905