### PR TITLE
Chore - stop setting config variables as attributes for MOST config.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/psf/black
-    rev: 24.1.0
+    rev: 24.1.1
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,8 +34,11 @@ Fixes
 - (:pr:`901`) Work with py_webauthn 2.0
 - (:pr:`906`) Remove undocumented and untested looking in session for possible 'next'
   redirect location.
-- (:pr:`xxx`) Improve CSRF documentation and testing. Fix bug where a CSRF failure could
+- (:pr:`908`) Improve CSRF documentation and testing. Fix bug where a CSRF failure could
   return an HTML page even if the request was JSON.
+- (:pr:`xxx`) Chore - stop setting all config as attributes. init_app(\*\*kwargs) can only
+  set forms, flags, and utility classes.
+- (:pr:`xxx`) Remove deprecation of AUTO_LOGIN_AFTER_CONFIRM - it has a reasonable use case.
 
 Notes
 ++++++

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,6 +102,10 @@ nitpick_ignore = [
     ("py:class", "UserVerificationRequirement"),
     ("py:class", "OAuth"),
     ("py:class", "authlib.integrations.flask_client.OAuth"),
+    ("py:class", "t.Type"),
+    ("py:class", "t.Callable"),
+    ("py:class", "t.Any"),
+    ("py:class", "timedelta"),
 ]
 autodoc_typehints = "description"
 # autodoc_mock_imports = ["flask_sqlalchemy"]

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -1,6 +1,10 @@
 Configuration
 =============
 
+.. warning::
+    Be sure to set all configuration (in app.config["xxx"]) *PRIOR* to instantiating
+    the Security class or calling security.init_app().
+
 The following configuration values are used by Flask-Security:
 
 Core
@@ -916,11 +920,11 @@ Confirmable
 
     If ``True``, then the user corresponding to the confirmation token will be automatically signed in.
     If ``False`` (the default) then the user will be requires to authenticate using the usual mechanism(s).
-    Note that the confirmation token is not valid after being used once.
+    Note that the confirmation token is not valid after being used once. This is not recommended by OWASP
+    however an application that is by invite only (no self-registration) might find this useful.
 
     Default: ``False``.
 
-    .. deprecated:: 5.3.0
 .. py:data:: SECURITY_LOGIN_WITHOUT_CONFIRMATION
 
     Specifies if a user may login before confirming their email when

--- a/flask_security/confirmable.py
+++ b/flask_security/confirmable.py
@@ -15,7 +15,7 @@ from flask import current_app
 from .proxies import _security, _datastore
 from .signals import confirm_instructions_sent, user_confirmed
 from .utils import (
-    config_value,
+    config_value as cv,
     get_token_status,
     hash_data,
     send_mail,
@@ -38,7 +38,7 @@ def send_confirmation_instructions(user):
     confirmation_link, token = generate_confirmation_link(user)
 
     send_mail(
-        config_value("EMAIL_SUBJECT_CONFIRM"),
+        cv("EMAIL_SUBJECT_CONFIRM"),
         user.email,
         "confirmation_instructions",
         user=user,
@@ -68,7 +68,7 @@ def requires_confirmation(user):
     """Returns `True` if the user requires confirmation."""
     return (
         _security.confirmable
-        and not _security.login_without_confirmation
+        and not cv("LOGIN_WITHOUT_CONFIRMATION")
         and user.confirmed_at is None
     )
 

--- a/flask_security/oauth_glue.py
+++ b/flask_security/oauth_glue.py
@@ -4,7 +4,7 @@
 
     Class and methods to glue our login path with authlib for to support 'social' auth.
 
-    :copyright: (c) 2022-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2022-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 
 """
@@ -127,7 +127,7 @@ def oauthresponse(name: str) -> "ResponseValue":
         # N.B. flashing doesn't seem to work - probably for same reason as
         # the original failure...
         m, c = get_message("OAUTH_HANDSHAKE_ERROR")
-        if _security.redirect_behavior == "spa":
+        if cv("REDIRECT_BEHAVIOR") == "spa":
             return redirect(get_url(cv("LOGIN_ERROR_VIEW"), qparams={c: m}))
         do_flash(m, c)
         return redirect(url_for_security("login"))
@@ -143,7 +143,7 @@ def oauthresponse(name: str) -> "ResponseValue":
             return response
         # two factor not required - login user
         login_user(user)
-        if _security.redirect_behavior == "spa":
+        if cv("REDIRECT_BEHAVIOR") == "spa":
             return redirect(
                 get_url(
                     cv("POST_OAUTH_LOGIN_VIEW"), qparams=user.get_redirect_qparams()
@@ -153,7 +153,7 @@ def oauthresponse(name: str) -> "ResponseValue":
     # Seems ok to show identity - the only identity it could be is the callers
     # so seems no way this can be used to enumerate registered users.
     m, c = get_message("IDENTITY_NOT_REGISTERED", id=value)
-    if _security.redirect_behavior == "spa":
+    if cv("REDIRECT_BEHAVIOR") == "spa":
         return redirect(get_url(cv("LOGIN_ERROR_VIEW"), qparams={c: m}))
     do_flash(m, c)
     # TODO: should redirect to where we came from?

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -8,6 +8,8 @@
     :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
 """
 
+from __future__ import annotations
+
 import typing as t
 
 from flask import current_app, redirect, request, session
@@ -121,7 +123,7 @@ def complete_two_factor_process(user, primary_method, totp_secret, is_changing):
     return completion_message, token
 
 
-def set_rescue_options(form: TwoFactorRescueForm, user: "User") -> t.Dict[str, str]:
+def set_rescue_options(form: TwoFactorRescueForm, user: User) -> t.Dict[str, str]:
     # Based on config - set up options for rescue.
     # Note that this modifies the passed in Form as well as returns
     # a dict that can be returned as part of a JSON response.
@@ -165,22 +167,22 @@ def is_tf_setup(user):
 
 
 class CodeTfPlugin(TfPluginBase):
-    def __init__(self, app: "flask.Flask"):
+    def __init__(self, app: flask.Flask):
         super().__init__(app)
 
     def create_blueprint(
-        self, app: "flask.Flask", bp: "flask.Blueprint", state: "Security"
+        self, app: flask.Flask, bp: flask.Blueprint, state: Security
     ) -> None:
         pass
 
-    def get_setup_methods(self, user: "User") -> t.List[t.Optional[str]]:
+    def get_setup_methods(self, user: User) -> t.List[t.Optional[str]]:
         if is_tf_setup(user):
             return [user.tf_primary_method]
         return []
 
     def tf_login(
-        self, user: "User", json_payload: t.Dict[str, t.Any], next_loc: t.Optional[str]
-    ) -> "ResponseValue":
+        self, user: User, json_payload: t.Dict[str, t.Any], next_loc: t.Optional[str]
+    ) -> ResponseValue:
         """Helper for two-factor authentication login
 
         This is called only when login/password have already been validated.

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -689,7 +689,7 @@ def us_verify_link() -> "ResponseValue":
     code = request.args.get("code", None)
     if not fs_uniquifier or not code:
         m, c = get_message("API_ERROR")
-        if _security.redirect_behavior == "spa":
+        if cv("REDIRECT_BEHAVIOR") == "spa":
             return redirect(get_url(cv("LOGIN_ERROR_VIEW"), qparams={c: m}))
         do_flash(m, c)
         return redirect(url_for_security("us_signin"))
@@ -700,7 +700,7 @@ def us_verify_link() -> "ResponseValue":
             m, c = generic_message("USER_DOES_NOT_EXIST", "GENERIC_AUTHN_FAILED")
         else:
             m, c = generic_message("DISABLED_ACCOUNT", "GENERIC_AUTHN_FAILED")
-        if _security.redirect_behavior == "spa":
+        if cv("REDIRECT_BEHAVIOR") == "spa":
             return redirect(get_url(cv("LOGIN_ERROR_VIEW"), qparams={c: m}))
         do_flash(m, c)
         return redirect(url_for_security("us_signin"))
@@ -713,7 +713,7 @@ def us_verify_link() -> "ResponseValue":
         window=cv("US_TOKEN_VALIDITY"),
     ):
         m, c = generic_message("INVALID_CODE", "GENERIC_AUTHN_FAILED")
-        if _security.redirect_behavior == "spa":
+        if cv("REDIRECT_BEHAVIOR") == "spa":
             return redirect(
                 get_url(
                     cv("LOGIN_ERROR_VIEW"),
@@ -735,7 +735,7 @@ def us_verify_link() -> "ResponseValue":
         # isn't quite ready for SPA. So we return an error via a redirect rather
         # than mess up SPA applications. To be clear - this simply doesn't
         # work - using a magic link w/ 2FA - need to use code.
-        if _security.redirect_behavior == "spa":
+        if cv("REDIRECT_BEHAVIOR") == "spa":
             return redirect(
                 get_url(
                     cv("LOGIN_ERROR_VIEW"),
@@ -750,7 +750,7 @@ def us_verify_link() -> "ResponseValue":
 
     login_user(user, authn_via=["email"])
     after_this_request(view_commit)
-    if _security.redirect_behavior == "spa":
+    if cv("REDIRECT_BEHAVIOR") == "spa":
         # We do NOT send the authentication token here since the only way to
         # send it would be via a query param and that isn't secure. (logging and
         # possibly HTTP Referer header).

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -522,7 +522,7 @@ def transform_url(
 
 
 def get_security_endpoint_name(endpoint):
-    return f"{_security.blueprint_name}.{endpoint}"
+    return f"{config_value('BLUEPRINT_NAME')}.{endpoint}"
 
 
 def url_for_security(endpoint: str, **values: t.Any) -> str:
@@ -769,7 +769,7 @@ def send_mail(subject, recipient, template, **context):
 
     subject = localize_callback(subject)
 
-    sender = _security.email_sender
+    sender = config_value("EMAIL_SENDER")
     if isinstance(sender, LocalProxy):
         sender = sender._get_current_object()
 
@@ -949,7 +949,7 @@ def use_double_hash(password_hash=None):
     single_hash = config_value("PASSWORD_SINGLE_HASH") or {"plaintext"}
 
     if password_hash is None:
-        scheme = _security.password_hash
+        scheme = config_value("PASSWORD_HASH")
     else:
         scheme = _pwd_context.identify(password_hash)
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -981,7 +981,7 @@ def test_verifying_token_from_version_3x(in_app_context):
         token = get_auth_token_version_3x(app, user)
 
         data = app.security.remember_token_serializer.loads(
-            token, max_age=app.security.token_max_age
+            token, max_age=app.config["SECURITY_TOKEN_MAX_AGE"]
         )
 
         assert user.verify_auth_token(data) is True


### PR DESCRIPTION
Flags, forms, utility classes are still set as attributes and can still be set via kwags during init_app() time.

Remove deprecation of AUTO_LOGIN_AFTER_CONFIRM (documentation change only).

Add Annotations to more files.