### PR TITLE
Minor fix for mail_util and check_deliverability

### DIFF
--- a/flask_security/mail_util.py
+++ b/flask_security/mail_util.py
@@ -126,9 +126,8 @@ class MailUtil:
         Will throw email_validator.EmailNotValidError (ValueError)
         if email isn't syntactically valid.
         """
-        validator_args = config_value("EMAIL_VALIDATOR_ARGS") or {
-            "check_deliverability": False
-        }
+        validator_args = config_value("EMAIL_VALIDATOR_ARGS")
+        validator_args["check_deliverability"] = False
         valid = email_validator.validate_email(email, **validator_args)
         return valid.normalized
 


### PR DESCRIPTION
A test recently started failing - probably because matt@lp.com no longer actually exists. If SECURITY_EMAIL_VALIDATOR_ARGS were set and had check_deliverability=True - then even for login it would check deliverability - it shouldn't.