### PR TITLE
Improve oauth glue

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,7 +58,7 @@ jobs:
         - uses: actions/checkout@v4
         - uses: actions/setup-python@v5
           with:
-            python-version: "3.9"
+            python-version: "3.11"
         - name: update pip
           run: |
             python -m pip install -U pip
@@ -73,7 +73,7 @@ jobs:
         - uses: actions/checkout@v4
         - uses: actions/setup-python@v5
           with:
-            python-version: "3.9"
+            python-version: "3.11"
         - name: update pip
           run: |
             python -m pip install -U pip
@@ -87,7 +87,7 @@ jobs:
         - uses: actions/checkout@v4
         - uses: actions/setup-python@v5
           with:
-            python-version: "3.9"
+            python-version: "3.11"
         - name: update pip
           run: |
             python -m pip install -U pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-    python: python3.9
+    python: python3.11
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,9 +36,10 @@ Fixes
   redirect location.
 - (:pr:`908`) Improve CSRF documentation and testing. Fix bug where a CSRF failure could
   return an HTML page even if the request was JSON.
-- (:pr:`xxx`) Chore - stop setting all config as attributes. init_app(\*\*kwargs) can only
+- (:pr:`911`) Chore - stop setting all config as attributes. init_app(\*\*kwargs) can only
   set forms, flags, and utility classes.
-- (:pr:`xxx`) Remove deprecation of AUTO_LOGIN_AFTER_CONFIRM - it has a reasonable use case.
+- (:pr:`911`) Remove deprecation of AUTO_LOGIN_AFTER_CONFIRM - it has a reasonable use case.
+- (:issue:`912`) Improve oauth debugging support. Handle next propagation in a more general way.
 
 Notes
 ++++++
@@ -57,7 +58,8 @@ Backwards Compatibility Concerns
 - Passing in an AnonymousUser class as part of Security initialization has been removed.
 - The never-public method _get_unauthorized_response has been removed.
 - Social-Oauth - a new configuration variable :py:data:`SECURITY_POST_OAUTH_LOGIN_VIEW` was introduced
-  and it replaces :py:data:`SECURITY_POST_LOGIN_VIEW` in the oauthresponse logic.
+  and it replaces :py:data:`SECURITY_POST_LOGIN_VIEW` in the oauthresponse logic when
+  :py:data:`SECURITY_REDIRECT_BEHAVIOR` == `"spa"`.
 - Two-Factor setup. Prior to this release when setting up "SMS" the `/tf-setup` endpoint could
   be POSTed to w/o a phone number, and then another POST could be made to set the phone number.
   This has always been confusing and added complexity to the code. Now, if "SMS" is selected, the phone number

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -164,7 +164,17 @@ Utils
 .. autoclass:: flask_security.SmsSenderFactory
   :members: createSender
 
+.. py:class:: OauthCbType[oauth: OAuth, token: t.Any]
+
+    This callback is called when the oauth
+    redirect happens. It must take the response from the provider and return
+    a tuple of <user_model_field_name, value> - which will be used
+    to look up the user in the datastore.
+
 .. autoclass:: flask_security.OAuthGlue
+  :members: register_provider, register_provider_ext
+
+.. autoclass:: flask_security.FsOAuthProvider
   :members:
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,14 +101,19 @@ nitpick_ignore = [
     ("py:class", "AuthenticatorSelectionCriteria"),
     ("py:class", "UserVerificationRequirement"),
     ("py:class", "OAuth"),
+    ("py:class", "OAuthError"),
     ("py:class", "authlib.integrations.flask_client.OAuth"),
     ("py:class", "t.Type"),
     ("py:class", "t.Callable"),
+    ("py:class", "t.Tuple"),
     ("py:class", "t.Any"),
     ("py:class", "timedelta"),
 ]
 autodoc_typehints = "description"
 # autodoc_mock_imports = ["flask_sqlalchemy"]
+autodoc_type_aliases = {
+    "CbType": "oauth_provider.CbType",
+}
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
@@ -121,6 +126,7 @@ intersphinx_mapping = {
     "flask_sqlalchemy": ("https://flask-sqlalchemy.palletsprojects.com/", None),
     "flask_login": ("https://flask-login.readthedocs.io/en/latest/", None),
     "passlib": ("https://passlib.readthedocs.io/en/stable", None),
+    "authlib": ("https://docs.authlib.org/en/latest/", None),
 }
 
 # -- Options for HTML output ---------------------------------------------

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -281,7 +281,7 @@ views and features (such as two-factor authentication). Flask-Security is shippe
 with support for github and google - others can be added by the application (see `loginpass`_
 for many examples).
 
-See :py:class:`flask_security.OAuthGlue`
+See :py:class:`flask_security.OAuthGlue` and :py:class:`flask_security.FsOAuthProvider`
 
 Please note - this is for authentication only, and the authenticating user must
 already be a registered user in your application. Once authenticated, all further
@@ -291,6 +291,10 @@ See `Flask OAuth Client <https://docs.authlib.org/en/latest/client/flask.html>`_
 for details. Note in particular, that you must setup and provide provider specific
 information - and most importantly - XX_CLIENT_ID and XX_CLIENT_SECRET should be
 specified as environment variables.
+
+We have seen issues with some providers when `SESSION_COOKIE_SAMESITE` = "strict".
+The handshake (sometimes just the first time when the user is being asked to accept your application)
+fails due to the session cookie not getting sent as part of the redirect.
 
 A very simple example of configuring social auth with Flask-Security is available
 in the `examples` directory.

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -60,6 +60,7 @@ from .forms import (
 )
 from .mail_util import MailUtil
 from .oauth_glue import OAuthGlue
+from .oauth_provider import FsOAuthProvider
 from .password_util import PasswordUtil
 from .phone_util import PhoneUtil
 from .recovery_codes import (

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -418,7 +418,8 @@ _default_messages = {
     ),
     "OAUTH_HANDSHAKE_ERROR": (
         _(
-            "An error occurred while communicating with the Oauth provider. "
+            "An error occurred while communicating with the Oauth provider:"
+            " (%(exerror)s - %(exdesc)s). "
             "Please try again."
         ),
         "error",
@@ -1076,7 +1077,8 @@ class Security:
         and signin. Defaults to :class:`WebauthnUtil`
     :param mf_recovery_codes_util_cls: Class for generating, checking, encrypting
         and decrypting recovery codes. Defaults to :class:`MfRecoveryCodesUtil`
-    :param oauth: An instance of authlib.integrations.flask_client.OAuth
+    :param oauth: An instance of authlib.integrations.flask_client.OAuth. If not set,
+        Flask-Security will create one.
 
     .. tip::
         Be sure that all your configuration values have been set PRIOR to

--- a/flask_security/oauth_glue.py
+++ b/flask_security/oauth_glue.py
@@ -9,33 +9,38 @@
 
 """
 
+from __future__ import annotations
+
 import typing as t
-from typing import Any
 
 try:
     from authlib.integrations.flask_client import OAuth
     from authlib.integrations.base_client.errors import (
-        MismatchingStateError,
         OAuthError,
     )
 except ImportError:  # pragma: no cover
     pass
 
-from flask import abort, after_this_request, redirect, request
+from flask import abort, after_this_request, redirect, request, session
 from flask_login import current_user
 
 from .decorators import unauth_csrf
+from .oauth_provider import (
+    OauthCbType,
+    FsOAuthProvider,
+    GoogleFsOauthProvider,
+    GitHubFsOauthProvider,
+)
 from .proxies import _security
 from .utils import (
     config_value as cv,
     do_flash,
     login_user,
     get_message,
-    get_post_login_redirect,
+    get_post_action_redirect,
     get_url,
     is_user_authenticated,
     json_error_response,
-    propagate_next,
     slash_url_suffix,
     url_for_security,
     view_commit,
@@ -45,40 +50,9 @@ if t.TYPE_CHECKING:  # pragma: no cover
     import flask
     from flask.typing import ResponseValue
 
-CbType = t.Callable[["OAuth", str], t.Tuple[str, t.Any]]
-
-
-GITHUB = dict(
-    access_token_url="https://github.com/login/oauth/access_token",
-    access_token_params=None,
-    authorize_url="https://github.com/login/oauth/authorize",
-    authorize_params=None,
-    api_base_url="https://api.github.com/",
-    client_kwargs={"scope": "user:email"},
-)
-
-
-def github_fetch_identity(oauth: "OAuth", token: str) -> t.Tuple[str, t.Any]:
-    resp = oauth.github.get("user", token=token)
-    profile = resp.json()
-    return "email", profile["email"]
-
-
-GOOGLE = dict(
-    server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
-    client_kwargs={"scope": "openid email profile"},
-)
-
-
-def google_fetch_identity(
-    oauth: "OAuth", token: t.Any
-) -> t.Tuple[str, t.Any]:  # pragma no cover
-    profile = token["userinfo"]
-    return "email", profile["email"]
-
 
 @unauth_csrf()
-def oauthstart(name: str) -> "ResponseValue":
+def oauthstart(name: str) -> ResponseValue:
     """View to start an oauth authentication.
     Name is a pre-registered oauth provider.
     TODO: remember me?
@@ -99,45 +73,47 @@ def oauthstart(name: str) -> "ResponseValue":
         else:
             return redirect(get_url(cv("POST_LOGIN_VIEW")))
     # we never want to return here or to the redirect location.
-    values = dict(next=request.args.get("next", "/"))
-    return _security.oauthglue.get_redirect(name, **values)
+    # Some providers match on entire redirect url - so we don't want to
+    # store next there. Use session.
+    session.pop("fs_oauth_next", None)
+    if request.args.get("next"):
+        session["fs_oauth_next"] = request.args.get("next")
+    return _security.oauthglue.get_redirect(name)
 
 
-def oauthresponse(name: str) -> "ResponseValue":
+def oauthresponse(name: str) -> ResponseValue:
     """
     Callback from oauth provider - response is provider specific
     Since this is a callback from oauth provider - there is no form,
-    however the ?next= parameter is returned as we specified in oauthstart
+    We may have stored the original 'next' in the session
     N.B. all responses MUST be redirects.
     """
     assert _security.oauthglue
-    oauth_provider = _security.oauthglue.oauth_provider(name)
-    if not oauth_provider:
-        # this shouldn't really be able to happen
+    authlib_provider = _security.oauthglue.authlib_provider(name)
+    oauth_provider = _security.oauthglue.providers.get(name)
+    if not authlib_provider or not oauth_provider:
+        # this should only happen with purposeful bad API call
         abort(404)  # TODO - redirect... to where?
     # This parses the Flask Request
     try:
-        token = oauth_provider.authorize_access_token()
-    except (MismatchingStateError, OAuthError):
+        token = authlib_provider.authorize_access_token()
+    except OAuthError as e:
         """One known way this can happen is if the session cookie 'samesite'
         is set to 'strict' and e.g. the first time the user goes to github
         and has to authorize this app and then redirect - the session
         cookie isn't sent - and by default that is where the state is kept.
         """
-        # N.B. flashing doesn't seem to work - probably for same reason as
-        # the original failure...
-        m, c = get_message("OAUTH_HANDSHAKE_ERROR")
-        if cv("REDIRECT_BEHAVIOR") == "spa":
-            return redirect(get_url(cv("LOGIN_ERROR_VIEW"), qparams={c: m}))
-        do_flash(m, c)
-        return redirect(url_for_security("login"))
+        return oauth_provider.oauth_response_failure(e)
 
-    field_name, value = _security.oauthglue._oauth_response(name, token)
+    field_name, value = oauth_provider.fetch_identity_cb(
+        _security.oauthglue.oauth_app, token
+    )
     user = _security.datastore.find_user(**{field_name: value})
     if user:
         after_this_request(view_commit)
+        next_loc = session.pop("fs_oauth_next", None)
         response = _security.two_factor_plugins.tf_enter(
-            user, False, "oauth", next_loc=propagate_next(request.url, None)
+            user, False, "oauth", next_loc=next_loc
         )
         if response:
             return response
@@ -149,7 +125,10 @@ def oauthresponse(name: str) -> "ResponseValue":
                     cv("POST_OAUTH_LOGIN_VIEW"), qparams=user.get_redirect_qparams()
                 )
             )
-        return redirect(get_post_login_redirect())
+        redirect_url = get_post_action_redirect(
+            "SECURITY_POST_LOGIN_VIEW", dict(next=next_loc)
+        )
+        return redirect(redirect_url)
     # Seems ok to show identity - the only identity it could be is the callers
     # so seems no way this can be used to enumerate registered users.
     m, c = get_message("IDENTITY_NOT_REGISTERED", id=value)
@@ -167,26 +146,30 @@ class OAuthGlue:
 
     There are some builtin providers which can be used or not - configured via
     :py:data:`SECURITY_OAUTH_BUILTIN_PROVIDERS`. Any other provider can be registered
-    using app.security.oauthglue.register_provider().
+    using :py:meth:`register_provider_ext`.
 
     See `Flask OAuth Client <https://docs.authlib.org/en/latest/client/flask.html>`_
 
     .. versionadded:: 5.1.0
+
+    .. versionchanged:: 5.4.0
+        Added register_provider_ext which allows applications more control to
+        manage new providers (such as extended error handling).
     """
 
-    def __init__(self, app: "flask.Flask", oauthapp: t.Optional["OAuth"] = None):
+    def __init__(self, app: flask.Flask, oauthapp: OAuth | None = None):
         if not oauthapp:
             oauthapp = OAuth(app)
         self.oauth = oauthapp
-        self.providers: t.Dict[str, t.Dict[str, CbType]] = dict()
+        self.providers: t.Dict[str, FsOAuthProvider] = dict()
         if cv("OAUTH_BUILTIN_PROVIDERS", app=app):
             for provider in cv("OAUTH_BUILTIN_PROVIDERS", app=app):
                 if provider == "github":
-                    self.register_provider("github", GITHUB, github_fetch_identity)
+                    self.register_provider_ext(GitHubFsOauthProvider("github"))
                 elif provider == "google":
-                    self.register_provider("google", GOOGLE, google_fetch_identity)
+                    self.register_provider_ext(GoogleFsOauthProvider("google"))
 
-    def _create_blueprint(self, app: "flask.Flask", bp: "flask.Blueprint") -> None:
+    def _create_blueprint(self, app: flask.Flask, bp: flask.Blueprint) -> None:
         # Routes for each type of oauth provider
         start_url = cv("OAUTH_START_URL", app=app)
         response_url = cv("OAUTH_RESPONSE_URL", app=app)
@@ -201,14 +184,14 @@ class OAuthGlue:
             endpoint="oauthresponse",
         )(oauthresponse)
 
-    def get_redirect(self, name: str, **values: t.Any) -> "ResponseValue":
-        oauth_provider = self.oauth_provider(name)
-        if not oauth_provider:
+    def get_redirect(self, name: str, **values: t.Any) -> ResponseValue:
+        authlib_provider = self.authlib_provider(name)
+        if not authlib_provider:
             return abort(404)
         start_uri = url_for_security(
             "oauthresponse", name=name, _external=True, **values
         )
-        redirect_url = oauth_provider.authorize_redirect(start_uri)
+        redirect_url = authlib_provider.authorize_redirect(start_uri)
         return redirect_url
 
     @property
@@ -219,14 +202,14 @@ class OAuthGlue:
     def oauth_app(self):
         return self.oauth
 
-    def oauth_provider(self, name):
+    def authlib_provider(self, name):
         return getattr(self.oauth, name, None)
 
     def register_provider(
         self,
         name: str,
-        registration_info: t.Optional[t.Dict[str, t.Any]],
-        fetch_identity_cb: CbType,
+        registration_info: dict[str, t.Any] | None,
+        fetch_identity_cb: OauthCbType,
     ) -> None:
         """Add a provider to the list.
 
@@ -243,10 +226,26 @@ class OAuthGlue:
         application. If you register directly with OAuth make sure to use
         the same `name`.
 
-        """
-        self.providers[name] = dict(cb=fetch_identity_cb)
-        if registration_info:
-            self.oauth.register(name, **registration_info)
+        .. deprecated:: 5.4.0
+            Use :py:meth:`register_provider_ext` instead.
 
-    def _oauth_response(self, name: str, token: str) -> t.Tuple[str, Any]:
-        return self.providers[name]["cb"](self.oauth, token)
+        """
+        pcls = FsOAuthProvider(
+            name,
+            registration_info=registration_info,
+            fetch_identity_cb=fetch_identity_cb,
+        )
+        self.register_provider_ext(pcls)
+
+    def register_provider_ext(self, provider: FsOAuthProvider) -> None:
+        """Register a provider via an instance of subclass.
+        This is the new way - to provide more control for applications
+
+        The authlib provider can be registered here (by calling Oauth)
+        or already be done by the application.
+        If you register directly with OAuth make sure to use
+        the same `name` when instantiating the class.
+        """
+        self.providers[provider.name] = provider
+        if not self.authlib_provider(provider.name):
+            self.oauth.register(provider.name, **provider.authlib_config())

--- a/flask_security/oauth_provider.py
+++ b/flask_security/oauth_provider.py
@@ -1,0 +1,130 @@
+"""
+    flask_security.oauth_provider
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Class and methods to create providers for oauth_glue.
+    Example providers for github and google.
+
+    :copyright: (c) 2024-2024 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+
+"""
+
+from __future__ import annotations
+import collections.abc as cabc
+import sys
+
+try:
+    from authlib.integrations.flask_client import OAuth
+    from authlib.integrations.base_client.errors import (
+        OAuthError,
+    )
+except ImportError:  # pragma: no cover
+    pass
+
+import typing as t
+
+from flask import redirect
+
+from .utils import (
+    config_value as cv,
+    do_flash,
+    get_message,
+    get_url,
+    url_for_security,
+)
+
+if t.TYPE_CHECKING:  # pragma: no cover
+    from flask.typing import ResponseValue
+
+if sys.version_info >= (3, 9):
+    OauthCbType = cabc.Callable[["OAuth", t.Any], tuple[str, t.Any]]
+else:
+    OauthCbType = t.Callable[["OAuth", t.Any], t.Tuple[str, t.Any]]  # pragma: no cover
+
+
+class FsOAuthProvider:
+    """
+    Subclass this or instantiate to add new oauth providers.
+
+    Subclassing allows for customizing additional aspects of the oauth flow
+    in particular - a custom error path for oauth flow state mismatches and
+    other errors thrown by authlib.
+
+    Call security.oauthglue.register_provider_ext(myproviderclass("myprovider"))
+
+    :param name: a name for provider - must match what was passed if this
+     is already registered with Oauth.
+    :param registration_info: This dict is passed directly to Oauth as
+     part of registration - not needed if provider already registered with
+     Oauth
+    :param fetch_identity_cb: Call back from response to oauth flow.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        registration_info: dict[str, t.Any] | None = None,
+        fetch_identity_cb: OauthCbType | None = None,
+    ):
+        self.name = name
+        self._registration_info = registration_info or {}
+        self._fetch_identity_cb = fetch_identity_cb
+
+    def authlib_config(self) -> dict[str, t.Any]:
+        """Return dict with authlib configuration.
+        This is called as part of provider registration."""
+        return self._registration_info
+
+    def fetch_identity_cb(self, oauth: OAuth, token: t.Any) -> t.Tuple[str, t.Any]:
+        """This callback is called when the oauth
+        redirect happens. It must take the response from the provider and return
+        a tuple of <user_model_field_name, value> - which will be used
+        to look up the user in the datastore."""
+        if not self._fetch_identity_cb:  # pragma no cover
+            raise NotImplementedError
+        return self._fetch_identity_cb(oauth, token)
+
+    def oauth_response_failure(self, e: OAuthError) -> ResponseValue:
+        """Called if authlib authorize_access_token throws an error.
+
+        N.B. flashing doesn't seem to work in some cases - if the session
+        cookie has samesite='strict' and it is the first registration.
+        """
+        m, c = get_message(
+            "OAUTH_HANDSHAKE_ERROR", exerror=e.error, exdesc=e.description
+        )
+        if cv("REDIRECT_BEHAVIOR") == "spa":
+            return redirect(get_url(cv("LOGIN_ERROR_VIEW"), qparams={c: m}))
+        do_flash(m, c)
+        return redirect(url_for_security("login"))
+
+
+class GitHubFsOauthProvider(FsOAuthProvider):
+    def authlib_config(self):
+        return dict(
+            access_token_url="https://github.com/login/oauth/access_token",
+            access_token_params=None,
+            authorize_url="https://github.com/login/oauth/authorize",
+            authorize_params=None,
+            api_base_url="https://api.github.com/",
+            client_kwargs={"scope": "user:email"},
+        )
+
+    def fetch_identity_cb(self, oauth, token):
+        resp = oauth.github.get("user", token=token)
+        profile = resp.json()
+        return "email", profile["email"]
+
+
+class GoogleFsOauthProvider(FsOAuthProvider):
+    def authlib_config(self):
+        return dict(
+            server_metadata_url="https://accounts.google.com/"
+            ".well-known/openid-configuration",
+            client_kwargs={"scope": "openid email profile"},
+        )
+
+    def fetch_identity_cb(self, oauth, token):  # pragma no cover
+        profile = token["userinfo"]
+        return "email", profile["email"]

--- a/tox.ini
+++ b/tox.ini
@@ -52,7 +52,7 @@ commands =
     pytest --basetemp={envtmpdir} {posargs:tests}
 
 [testenv:async]
-basepython = python3.10
+basepython = python3.11
 deps =
     -r requirements/tests.txt
 commands =
@@ -87,6 +87,7 @@ commands =
     pytest --basetemp={envtmpdir} {posargs:tests}
 
 [testenv:style]
+basepython = python3.11
 deps = pre-commit
 skip_install = true
 commands =
@@ -94,11 +95,13 @@ commands =
     pre-commit run --all-files --show-diff-on-failure
 
 [testenv:docs]
+basepython = python3.11
 deps = -r requirements/docs.txt
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 
 
 [testenv:coverage]
+basepython = python3.11
 deps =
     -r requirements/tests.txt
 commands =
@@ -116,6 +119,7 @@ commands =
     pytest --basetemp={envtmpdir} {posargs}
 
 [testenv:makedist]
+basepython = python3.11
 deps =
     -r requirements/tests.txt
     build
@@ -128,6 +132,7 @@ commands =
     check-wheel-contents dist
 
 [testenv:mypy]
+basepython = python3.11
 deps =
     -r requirements/tests.txt
     types-setuptools


### PR DESCRIPTION
Some providers e.g. Azure require the redirect URL to match exactly - including query params etc. To support that we now store any 'next' value in the session (fs_oauth_next).

To enable better debugging a class that can be subclassed for each provider - the auth_response_error() method can be subclassed for better debugging/UX.

Convert our Github and Google pre-defined providers to the new class method.

Add support for Azure in the Oauth example code.

Change OAUTH_HANDSHAKE_ERROR to include info from authlib.

closes #912