### PR TITLE
German translations for 'confirmation instructions'

### DIFF
--- a/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
+++ b/flask_security/translations/de_DE/LC_MESSAGES/flask_security.po
@@ -105,7 +105,9 @@ msgstr "Bitte neu authentisieren, um auf diese Seite zuzugreifen."
 #: flask_security/core.py:399
 #, python-format
 msgid "Thank you. Confirmation instructions have been sent to %(email)s."
-msgstr "Vielen Dank. Bestätigungsanleitung wurde an %(email)s gesendet."
+msgstr ""
+"Vielen Dank. Um Ihre E-Mail-Adresse %(email)s zu bestätigen, klicken Sie bitte auf "
+"den Link in der E-Mail, die wir gerade an Sie gesendet haben."
 
 #: flask_security/core.py:402
 msgid "Thank you. Your email has been confirmed."
@@ -189,7 +191,9 @@ msgstr "Die E-Mail-Adresse muss bestätigt werden."
 #: flask_security/core.py:443
 #, python-format
 msgid "Confirmation instructions have been sent to %(email)s."
-msgstr "Bestätigungsanleitung wurde an %(email)s gesendet."
+msgstr ""
+"Um Ihre E-Mail-Adresse %(email)s zu bestätigen, klicken Sie bitte auf "
+"den Link in der E-Mail, die wir gerade an Sie gesendet haben."
 
 #: flask_security/core.py:447
 #, python-format
@@ -487,7 +491,7 @@ msgstr "Registrieren"
 
 #: flask_security/forms.py:65
 msgid "Resend Confirmation Instructions"
-msgstr "Bestätigungsanleitung neu senden"
+msgstr "Bestätigungslink erneut senden"
 
 #: flask_security/forms.py:66
 msgid "Recover Password"
@@ -781,7 +785,7 @@ msgstr "Passwort zurücksetzen"
 
 #: flask_security/templates/security/send_confirmation.html:6
 msgid "Resend confirmation instructions"
-msgstr "Bestätigungsanleitung erneut versenden"
+msgstr "Bestätigungslink erneut versenden"
 
 #: flask_security/templates/security/two_factor_select.html:6
 msgid "Select Two Factor Method"


### PR DESCRIPTION
In this PR, I am trying to get some better, more user-friendly wording for the German translations of 'confirmation instructions'. Even more, I differ from the English original and try to give the user helpful instructions. So, the current English version is:

> Thank you. Confirmation instructions have been sent to user@example.com.

I have translated that to something like:

> Thank you. To confirm your email address %(email)s, please click on the link in the email we have just sent to you.

One may want to adapt that for other languages as well.

I also translated "confirmation instructions" to "confirmation link" ("Bestätigungslink"). But "confirmation instructions" doesn't sound as weird (to me as a non-native speaker) as it does in German.