### PR TITLE
Doc updates.

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -57,6 +57,10 @@ Datastores
 ----------
 .. autoclass:: flask_security.UserDatastore
     :members:
+    :exclude-members: create_webauthn, find_user_from_webauthn,
+        mf_set_recovery_codes, mf_delete_recovery_code,
+        set_webauthn_user_handle,
+        us_get_totp_secrets, us_put_totp_secrets
 
 .. autoclass:: flask_security.SQLAlchemyUserDatastore
     :show-inheritance:
@@ -104,6 +108,11 @@ Datastores
     The WebAuthn model. This must be provided by the application.
     See :ref:`Models <models_topic>`.
 
+Packaged Models
+---------------
+.. autoclass:: flask_security.models.fsqla.FsModels
+   :members:
+
 Utils
 -----
 .. autofunction:: flask_security.lookup_identity
@@ -147,8 +156,6 @@ Utils
 .. autofunction:: flask_security.password_breached_validator
 
 .. autofunction:: flask_security.pwned
-
-.. autofunction:: flask_security.transform_url
 
 .. autofunction:: flask_security.unique_identity_attribute
 

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -12,6 +12,8 @@ and `Role` data model. The fields on your models must follow a particular conven
 depending on the functionality your app requires. Aside from this, you're free
 to add any additional fields to your model(s) if you want.
 
+Packaged Models
+----------------
 As more features are added to Flask-Security, the list of required fields and tables grow.
 As you use these features, and therefore require these fields and tables, database migrations are required;
 which are a bit of a pain. To make things easier - Flask-Security includes mixins that
@@ -23,12 +25,22 @@ be easily extended to add any sort of custom fields and can be found in the
 The provided models are versioned since they represent actual DB models, and any
 changes require a schema migration (and perhaps a data migration). Applications
 must specifically import the version they want (and handle any required migration).
+Your application code should import just the required version e.g.::
+
+    from flask_security.models import fsqla_v3 as fsqla
+
+
+A single method ``fsqla.FsModels.set_db_info`` is provided to glue the supplied models to your
+DB instance. This is only needed if you use the packaged models.
+
+Model Specification
+-------------------
 
 Your `User` model needs a Primary Key - Flask-Security doesn't actually reference
 this - so it can be any name or type your application needs. It should be used in the
 foreign relationship between `User` and `Role`. The `WebAuthn` model also
 references this primary key (which can be overridden by providing a
-suitable implementation of ``get_user_mapping``).
+suitable implementation of :py:meth:`flask_security.WebAuthnMixin.get_user_mapping`).
 
 At the bare minimum your `User` and `Role` model should include the following fields:
 
@@ -109,14 +121,14 @@ will require the following additional field:
 * ``us_phone_number`` (string, 64 bytes, nullable, unique)
 
 Separate Identity Domains
-~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^
 If you want authentication tokens to not be invalidated when the user changes their
 password add the following to your `User` model:
 
 * ``fs_token_uniquifier`` (string, 64 bytes, unique, non-nullable)
 
 Username
-~~~~~~~~~
+^^^^^^^^
 If you set :py:data:`SECURITY_USERNAME_ENABLE` to `True`, then your `User` model
 requires the following additional field:
 

--- a/flask_security/changeable.py
+++ b/flask_security/changeable.py
@@ -84,7 +84,7 @@ def admin_change_password(user: User, new_passwd: str, notify: bool = True) -> N
 
     :param user: The user object to change
     :param new_passwd: The new plain-text password to assign to the user.
-    :param notify: If True and SECURITY_SEND_PASSWORD_CHANGE_EMAIL is True
+    :param notify: If True and :py:data:`SECURITY_SEND_PASSWORD_CHANGE_EMAIL` is True
         send the 'change_notice' email to the user.
     """
     change_user_password(user, new_passwd, notify=notify, autologin=False)

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -440,10 +440,6 @@ class UserDatastore:
                     enorm = app.security._mail_util.validate(email)
                 except ValueError:
 
-        .. note::
-            The roles kwparam is modified as part of the call - it will, if necessary,
-            be converted from names to role instances.
-
         .. danger::
            Be aware that whatever `password` is passed in will
            be stored directly in the DB. Do NOT pass in a plaintext password!

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -230,7 +230,8 @@ def handle_csrf(method: str, json_response: bool = False) -> ResponseValue | Non
     do anything. Furthermore - since this is called PRIOR to form instantiation
     if the request is JSON - it MUST send the csrf_token as a header.
 
-    If the passed in method is not in *SECURITY_CSRF_PROTECT_MECHANISMS* then not only
+    If the passed in method is not in
+    :py:data:`SECURITY_CSRF_PROTECT_MECHANISMS` then not only
     will no CSRF code be run, but a flag in the current context ``fs_ignore_csrf``
     will be set so that downstream code knows to ignore any CSRF checks.
 
@@ -295,8 +296,8 @@ def auth_token_required(fn: DecoratedView) -> DecoratedView:
     """Decorator that protects endpoints using token authentication. The token
     should be added to the request by the client by using a query string
     variable with a name equal to the configuration value of
-    *SECURITY_TOKEN_AUTHENTICATION_KEY* or in a request header named that of
-    the configuration value of *SECURITY_TOKEN_AUTHENTICATION_HEADER*
+    :py:data:`SECURITY_TOKEN_AUTHENTICATION_KEY` or in a request header named that of
+    the configuration value of :py:data:`SECURITY_TOKEN_AUTHENTICATION_HEADER`
 
     Once authenticated, if so configured, CSRF protection will be tested.
     """
@@ -459,7 +460,7 @@ def unauth_csrf(
     This decorator will always require CSRF if the caller is authenticated.
 
     This decorator will suppress CSRF if caller isn't authenticated and has set the
-    *SECURITY_CSRF_IGNORE_UNAUTH_ENDPOINTS* config variable.
+    :py:data:`SECURITY_CSRF_IGNORE_UNAUTH_ENDPOINTS` config variable.
 
     :param fall_through: if set to True, then if CSRF fails here - simply keep going.
         This is appropriate if underlying view is form based and once the form is
@@ -629,7 +630,7 @@ def permissions_accepted(*fsperms: str) -> DecoratedView:
 def anonymous_user_required(f: DecoratedView) -> DecoratedView:
     """Decorator which requires that caller NOT be logged in.
     If a logged in user accesses an endpoint protected with this decorator
-    they will be redirected to the *SECURITY_POST_LOGIN_VIEW*.
+    they will be redirected to the :py:data:`SECURITY_POST_LOGIN_VIEW`.
     If the caller requests a JSON response, a 400 will be returned.
 
     .. versionchanged:: 3.3.0

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -243,7 +243,7 @@ def unique_username(form, field):
 
 def unique_identity_attribute(form, field):
     """A validator that checks the field data against all configured
-    SECURITY_USER_IDENTITY_ATTRIBUTES.
+    :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES`.
     This can be used as part of registration.
 
     Be aware that the "mapper" function likely also normalizes the input in addition

--- a/flask_security/models/fsqla.py
+++ b/flask_security/models/fsqla.py
@@ -51,7 +51,12 @@ class FsModels:
     ):
         """Initialize Model.
         This needs to be called after the DB object has been created
-        (e.g. db = Sqlalchemy())
+        (e.g. db = Sqlalchemy()).
+
+        .. note::
+            This should only be used if you are utilizing the fsqla data
+            models. With your own models you would need similar but slightly
+            difficult code.
         """
         cls.db = appdb
         cls.user_table_name = user_table_name

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -164,12 +164,12 @@ def login_user(
 ) -> bool:
     """Perform the login routine.
 
-    If *SECURITY_TRACKABLE* is used, make sure you commit changes after this
+    If :py:data:`SECURITY_TRACKABLE` is used, make sure you commit changes after this
     request (i.e. ``app.security.datastore.commit()``).
 
     :param user: The user to login
     :param remember: Flag specifying if the remember cookie should be set.
-                     If ``None`` use value of SECURITY_DEFAULT_REMEMBER_ME
+                     If ``None`` use value of :py:data:`SECURITY_DEFAULT_REMEMBER_ME`
     :param authn_via: A list of strings denoting which mechanism(s) the user
         authenticated with.
         These should be one or more of ["password", "sms", "authenticator", "email"] or
@@ -330,7 +330,7 @@ def check_and_update_authn_fresh(
 
 def get_hmac(password: str | bytes) -> bytes:
     """Returns a Base64 encoded HMAC+SHA512 of the password signed with
-    the salt specified by *SECURITY_PASSWORD_SALT*.
+    the salt specified by :py:data:`SECURITY_PASSWORD_SALT`.
 
     :param password: The password to sign
     """
@@ -395,10 +395,11 @@ def verify_and_update_password(password: str | bytes, user: User) -> bool:
 def hash_password(password: str | bytes) -> str:
     """Hash the specified plaintext password.
 
-    Unless the hash algorithm (as specified by `SECURITY_PASSWORD_HASH`) is listed in
-    the configuration variable `SECURITY_PASSWORD_SINGLE_HASH`,
+    Unless the hash algorithm (as specified by
+    :py:data:`SECURITY_PASSWORD_HASH`) is listed in
+    the configuration variable :py:data:`SECURITY_PASSWORD_SINGLE_HASH`,
     perform a double hash - first create an HMAC from the plaintext password
-    and the value of `SECURITY_PASSWORD_SALT`,
+    and the value of :py:data:`SECURITY_PASSWORD_SALT`,
     then use the configured hashing algorithm.
     This satisfies OWASP/ASVS section 2.4.5: 'provide additional
     iteration of a key derivation'.
@@ -872,9 +873,9 @@ def get_identity_attribute(attr: str, app: Flask | None = None) -> dict[str, t.A
 def lookup_identity(identity):
     """
     Lookup identity in DB.
-    This loops through, in order, SECURITY_USER_IDENTITY_ATTRIBUTES, and first
-    calls the mapper function to validate/normalize. Then the db.find_user is called
-    on the specified user model attribute.
+    This loops through, in order, :py:data:`SECURITY_USER_IDENTITY_ATTRIBUTES`,
+    and first calls the mapper function to validate/normalize.
+    Then the db.find_user is called on the specified user model attribute.
     """
     for mapping in config_value("USER_IDENTITY_ATTRIBUTES"):
         attr = list(mapping.keys())[0]
@@ -930,7 +931,7 @@ def uia_username_mapper(identity: str) -> str | None:
 def use_double_hash(password_hash=None):
     """Return a bool indicating whether a password should be hashed twice."""
     # Default to plaintext for backward compatibility with
-    # SECURITY_PASSWORD_SINGLE_HASH = False
+    # :py:data:`SECURITY_PASSWORD_SINGLE_HASH` = False
     single_hash = config_value("PASSWORD_SINGLE_HASH") or {"plaintext"}
 
     if password_hash is None:

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,3 +3,6 @@ Sphinx~=7.2
 sphinx-issues==3.0.1
 packaging
 Flask-Login
+Flask-SQLAlchemy
+sqlalchemy
+sqlalchemy-utils


### PR DESCRIPTION
Remove many internal UserDatastore methods - create_webauthn, find_user_from_webauthn, mf_set_recovery_codes, mf_delete_recovery_codes, set_webauthn_user_handle, us_get_totp_secrets, us_set_totp_secrets. These are all low level implementation methods.

remove documentation for transform_url - that is internal.

Add simple documentation for FsModels.set_db_info when application uses our packaged fsqla models.

improve documentation for Models.

Add more refs to method documentation.

closes #888