### PR TITLE
change_psycopg2_to_psycopg2-binary

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,7 +3,7 @@
 mypy
 build
 check-wheel-contents
-psycopg2
+psycopg2-binary
 pymysql
 pre-commit
 tox


### PR DESCRIPTION
#923 Ran into an error while trying to pip install dev.txt. Fixed the issue by changing the library