### PR TITLE
fixed bug where csrf_token was not recognized for register json api

### DIFF
--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -291,6 +291,7 @@ def logout():
 
 
 @anonymous_user_required
+@unauth_csrf(fall_through=True)
 def register() -> "ResponseValue":
     """View function which handles a registration request."""
 


### PR DESCRIPTION
#925 Fixed a bug where the json register api was returning 400 "CSRF Token is missing" even though the CSRF token was added as a header.

The fix was adding `@unauth_csrf(fall_through=True)` annotation to the register view. Wrote a test for the bug fix as well.