### PR TITLE
Fix 2 CSRF issues.

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1667,18 +1667,18 @@ class Security:
         if cv("CSRF_COOKIE_NAME", app=app) and not csrf:
             # Common use case is for cookie value to be used as contents for header
             # which is only looked at when CsrfProtect is initialized.
-            # Yes, this is opinionated - they can always get CSRF token via:
-            # 'get /login'
             raise ValueError(
                 "CSRF_COOKIE defined however CsrfProtect not part of application"
             )
 
         if csrf:
             csrf.exempt("flask_security.views.logout")
+            # Add configured header to WTF_CSRF_HEADERS
+            if ch := cv("CSRF_HEADER", app=app):
+                if ch not in app.config["WTF_CSRF_HEADERS"]:
+                    app.config["WTF_CSRF_HEADERS"].append(ch)
         if cv("CSRF_COOKIE_NAME", app=app):
             app.after_request(csrf_cookie_handler)
-            # Add configured header to WTF_CSRF_HEADERS
-            app.config["WTF_CSRF_HEADERS"].append(cv("CSRF_HEADER", app=app))
 
     def set_form_info(self, name: str, form_info: FormInfo) -> None:
         """Set form instantiation info.

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -246,8 +246,8 @@ def handle_csrf(method: str, json_response: bool = False) -> ResponseValue | Non
                     payload = json_error_response(errors=e.description)
                     return _security._render_json(payload, 400, None, None)
                 raise
-        else:
-            set_request_attr("fs_ignore_csrf", True)
+            return None
+    set_request_attr("fs_ignore_csrf", True)
     return None
 
 


### PR DESCRIPTION
1) If CSRF_COOKIE_NAME wasn't set, then our CSRF_HEADER wasn't added to the list in WTforms and therefore didn't work. 2) If you set CSRF_PROTECT_MECHANISMS to an empty list (to hopefully disable CSRF) - it in fact didn't stop CSRF...

closes #870