### PR TITLE
Fix regression when config no longer set as attributes.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
     -   id: check-merge-conflict
     -   id: fix-byte-order-marker
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.0
+    rev: v3.15.1
     hooks:
     -   id: pyupgrade
         args: [--py38-plus]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,15 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 5.4.3
+-------------
+
+Released xxx
+
+Fixes
++++++
+- (:issue:`950`) Regression - some templates no longer getting correct config (thanks pete7863).
+
 Version 5.4.2
 -------------
 
@@ -42,7 +51,7 @@ Docs and Chores
 +++++++++++++++
 - (:pr:`889`) Improve method translations for unified signin and two factor. Remove support for Flask-Babelex.
 - (:pr:`911`) Chore - stop setting all config as attributes. init_app(\*\*kwargs) can only
-  set forms, flags, and utility classes.
+  set forms, flags, and utility classes (see below for compatibility concerns).
 - (:pr:`873`) Update Spanish and Italian translations. (gissimo)
 - (:pr:`855`) Improve translations for two-factor method selection. (gissimo)
 - (:pr:`866`) Improve German translations. (sr-verde)
@@ -120,6 +129,10 @@ Backwards Compatibility Concerns
   The important change is that Flask-Security no longer ever looks at the request.referrer header and
   will never redirect to it. If an application needs that, it can provide a callable that can return
   that or any other header.
+- Configuration variables (and other things) are no longer added as attributes on the Security instance.
+  For example `security.username_enable` no longer exists - this could be an issue in code or templates.
+  For templates, Flask places `config` in the Jinja context - so rather than using an attribute, use
+  `config["SECURITY_USERNAME_ENABLE"]` for the example above.
 - Open Redirect mitigation. Release 4.1.0 had a fix for :issue:`486` involving a potential
   open redirect. This was very low priority since the default configuration of Werkzeug (always
   convert the Location header to absolute URL) rendered the vulnerability un-exploitable. The solution at that

--- a/flask_security/templates/security/register_user.html
+++ b/flask_security/templates/security/register_user.html
@@ -8,7 +8,7 @@
     {{ register_user_form.hidden_tag() }}
     {{ render_form_errors(register_user_form) }}
     {{ render_field_with_errors(register_user_form.email) }}
-    {% if security.username_enable %}{{ render_field_with_errors(register_user_form.username) }}{% endif %}
+    {% if config["SECURITY_USERNAME_ENABLE"] %}{{ render_field_with_errors(register_user_form.username) }}{% endif %}
     {{ render_field_with_errors(register_user_form.password) }}
     {% if register_user_form.password_confirm %}
       {{ render_field_with_errors(register_user_form.password_confirm) }}

--- a/flask_security/templates/security/wan_register.html
+++ b/flask_security/templates/security/wan_register.html
@@ -21,7 +21,7 @@
       {{ wan_register_form.hidden_tag() }}
       {{ render_field_with_errors(wan_register_form.name) }}
       {# Default is just second factor #}
-      {% if security.wan_allow_as_first_factor %}
+      {% if config["SECURITY_WAN_ALLOW_AS_FIRST_FACTOR"] %}
         <div>
           {% for subfield in wan_register_form.usage %}{{ render_field_with_errors(subfield) }}{% endfor %}
         </div>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -186,7 +186,7 @@ def get_form_action(response, ordinal=0):
 
 def get_form_input(response, field_id):
     # return value of field with the id == field_id or None if not found
-    rex = f'<input id="{field_id}"[^>]*value="([^"]*)">'
+    rex = f'<input [^>]*id="{field_id}"[^>]*value="([^"]*)">'
     matcher = re.findall(
         rex,
         response.data.decode("utf-8"),

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -303,6 +303,10 @@ def test_basic(app, clients, get_message):
     authenticate(clients)
 
     response = clients.get("/wan-register")
+    # default config allows for both primary and secondary usage
+    # so form should have selector
+    assert get_form_input(response, "usage-0")
+    assert get_form_input(response, "usage-1")
 
     # post with no name
     response = clients.post("/wan-register", data=dict())


### PR DESCRIPTION
In a couple templates 'security.xxx' was referenced - those are no longer set as attributes. Use flask's 'config' context variable instead.

closes #950 