### PR TITLE
Fix datetime_factory as attribute.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Fixes
 - (:issue:`950`) Regression - some templates no longer getting correct config (thanks pete7863).
 - (:issue:`954`) CSRF not properly ignored for application forms using SECURITY_CSRF_PROTECT_MECHANISMS.
 - (:pr:`957`) Improve jp translations (e-goto)
+- (:issue:`959`) Regression - datetime_factory should still be an attribute (thanks TimotheeJeannin)
 
 Version 5.4.2
 -------------

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -1387,6 +1387,7 @@ class Security:
             "render_template",
             "totp_cls",
             "webauthn_util_cls",
+            "datetime_factory",
         ]
         for attr in attr_names:
             if ov := kwargs.get(attr, cv(attr.upper(), app, strict=False)):

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -188,7 +188,7 @@ def login_user(
 
         old_current_login, new_current_login = (
             user.current_login_at,
-            config_value("DATETIME_FACTORY")(),
+            _security.datetime_factory(),
         )
         old_current_ip, new_current_ip = user.current_login_ip, remote_addr
 


### PR DESCRIPTION
datetime_factory should still be set as an attribute - that got lost. Also - trackable didn't use the attribute - it directly referenced the config value - fix that.

Add a test.

close #959