### PR TITLE
Allow email validation errors to be returned even when GENERIC_RESPON…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     -   id: pyupgrade
         args: [--py38-plus]
 -   repo: https://github.com/psf/black
-    rev: 24.2.0
+    rev: 24.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Here you can see the full list of changes between each Flask-Security release.
 Version 5.4.3
 -------------
 
-Released March xx, 2024
+Released March 23, 2024
 
 Fixes
 +++++
@@ -14,6 +14,7 @@ Fixes
 - (:issue:`954`) CSRF not properly ignored for application forms using SECURITY_CSRF_PROTECT_MECHANISMS.
 - (:pr:`957`) Improve jp translations (e-goto)
 - (:issue:`959`) Regression - datetime_factory should still be an attribute (thanks TimotheeJeannin)
+- (:issue:`942`) GENERIC_RESPONSES hide email validation/syntax errors.
 
 Version 5.4.2
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -198,6 +198,8 @@ Security() instantiation.
   :members:
   :special-members: __init__
 
+.. autoclass:: flask_security.EmailValidateException
+
 .. autoclass:: flask_security.PasswordUtil
   :members:
   :special-members: __init__

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -58,7 +58,7 @@ from .forms import (
     VerifyForm,
     unique_identity_attribute,
 )
-from .mail_util import MailUtil
+from .mail_util import MailUtil, EmailValidateException
 from .oauth_glue import OAuthGlue
 from .oauth_provider import FsOAuthProvider
 from .password_util import PasswordUtil

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -458,7 +458,7 @@ def unauth_csrf(
 
     .. versionadded:: 3.3.0
 
-    .. versionchanged:: 5.4.2
+    .. versionchanged:: 5.4.3
         The fall_through parameter is now ignored.
         Add code to properly handle JSON errors.
     """

--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -90,6 +90,10 @@ def register_existing(form: ConfirmRegisterForm) -> bool:
     issuing requests. One way to mitigate that is to use signals and add specific
     application code.
 
+    Returning False means to return normal error messages.
+    Returns True if the only 'error' is an existing email/user. In this case we
+    simulate a normal registration and email the existing account to inform.
+
     """
 
     if not (
@@ -100,12 +104,14 @@ def register_existing(form: ConfirmRegisterForm) -> bool:
         return False
 
     # There are 2 classes of error - an existing email/username and non-compliant
-    # username/password. We want to give the user feedback on a non-compliant
-    # username/password - but not give away whether the email/username is already taken.
+    # email/username/password. We want to give the user feedback on a non-compliant
+    # input - but not give away whether the email/username is already taken.
     # Since in this case we have an 'existing' entry - we simply Null out those
     # errors.
     # This also means for JSON there is no way to tell if things worked or not.
-    fields_to_squash: dict[str, dict[str, str]] = dict(email=dict())
+    fields_to_squash: dict[str, dict[str, str]] = dict()
+    if form.existing_email_user:
+        fields_to_squash["email"] = dict()
     if hasattr(form, "username") and form.existing_username_user:
         fields_to_squash["username"] = dict()
     form_errors_munge(form, fields_to_squash)


### PR DESCRIPTION
…SES is set to True.

We need to be careful not to expose whether an account already exists - but syntax or other errors should be returned. This enables custom implementations of MailUtil to enforce their own conventions and return useful results to callers.

closes #942