### PR TITLE
add comment about back compatibility of template #969

### DIFF
--- a/flask_security/templates/security/_menu.html
+++ b/flask_security/templates/security/_menu.html
@@ -1,3 +1,7 @@
+<!-- 
+  this version is not compatible with Flask-Security <5.4 
+  because non-authenticated users handling was changed
+-->
 {% if security.registerable or security.recoverable or security.confirmable or security.unified_signin or security.two_factor or security.webauthn %}
   <hr>
   <h2>{{ _fsdomain('Menu') }}</h2>


### PR DESCRIPTION
related to issue #969

Common way to overwrite templates is

> Create a template with the same name for the template you wish to override

While using Flask-Security <5.4 copying code of the template /_menu.html from Flask-security repo will lead to error

> _fs_is_user_authenticated is undefined

I figured out that _fs_is_user_authenticated was added to the template on [commit](https://github.com/Flask-Middleware/flask-security/pull/877/commits/6b3795cfcb0f2544d92f1c8411aaf839c69c1577)


Those changes related to a new way of handling non-authenticated users 

There should be a note/comment in the template [_menu.html](flask_security/templates/security/_menu.html) about its compatibility with previous versions.

This PR has now impact on code.

@jwag956 appreciate