### PR TITLE
Improve CSRF and SPA (CSRF_COOKIE).

### DIFF
--- a/docs/spa.rst
+++ b/docs/spa.rst
@@ -191,7 +191,7 @@ Some background material:
 .. _Single Page Applications (spa): https://en.wikipedia.org/wiki/Single-page_application
 .. _Nginx: https://www.nginx.com/
 .. _S3: https://www.savjee.be/2018/05/Content-security-policy-and-aws-s3-cloudfront/
-.. _Flask-Talisman: https://github.com/GoogleCloudPlatform/flask-talisman
+.. _Flask-Talisman: https://pypi.org/project/flask-talisman/
 .. _CORS: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 .. _Flask-CORS: https://github.com/corydolphin/flask-cors
 .. _Zappa: https://github.com/Miserlou/Zappa

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -590,14 +590,20 @@ def us_signin() -> ResponseValue:
             return base_render_json(form, include_auth_token=True)
 
         return redirect(get_post_login_redirect())
-    elif request.method == "POST" and cv("RETURN_GENERIC_RESPONSES"):
+
+    # Here on GET or failed POST validate
+    if request.method == "POST" and cv("RETURN_GENERIC_RESPONSES"):
         rinfo = dict(
             identity=dict(replace_msg="GENERIC_AUTHN_FAILED"),
             passcode=dict(replace_msg="GENERIC_AUTHN_FAILED"),
         )
         form_errors_munge(form, rinfo)
 
-    # Here on GET or failed POST validate
+    if request.method == "GET":
+        # set CSRF COOKIE if configured. This is the equivalent of forms and
+        # base_render_json always sending the csrf_token
+        session["fs_cc"] = "set"
+
     code_methods = _compute_code_methods()
     if _security._want_json(request):
         payload = {

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -216,6 +216,11 @@ def login() -> "ResponseValue":
             fields_to_squash["username"] = dict(replace_msg="GENERIC_AUTHN_FAILED")
         form_errors_munge(form, fields_to_squash)
 
+    if request.method == "GET":
+        # set CSRF COOKIE if configured. This is the equivalent of forms and
+        # base_render_json always sending the csrf_token
+        session["fs_cc"] = "set"
+
     if _security._want_json(request):
         payload = {
             "identity_attributes": get_identity_attributes(),
@@ -227,6 +232,7 @@ def login() -> "ResponseValue":
         and cv("REQUIRES_CONFIRMATION_ERROR_VIEW")
         and not cv("RETURN_GENERIC_RESPONSES")
     ):
+        # Validation failed BECAUSE user needs to confirm
         assert form.user_authenticated
         do_flash(*get_message("CONFIRMATION_REQUIRED"))
         return redirect(

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,12 +12,12 @@ types-requests
 
 # for dev - might not install Flask-Security - list those dependencies here
 flask
-flask_wtf
-flask_login
+flask-wtf
+flask-login
 wtforms
 markupsafe
 passlib
 blinker
-email-validator
+email_validator
 itsdangerous
 importlib_resources>=5.10.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
-Pallets-Sphinx-Themes~=2.1
-Sphinx~=7.2
-sphinx-issues==3.0.1
+Pallets-Sphinx-Themes
+Sphinx
+sphinx-issues
 packaging
 Flask-Login
 Flask-SQLAlchemy

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,7 +5,7 @@ Flask-Mailman
 Flask-Principal
 peewee; python_version < '3.12'
 Flask-SQLAlchemy
-argon2_cffi
+argon2-cffi
 authlib
 bcrypt
 bleach

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -301,6 +301,11 @@ def app(request: pytest.FixtureRequest) -> SecurityFixture:
     def echo_json():
         return jsonify(flask_request.get_json())
 
+    @app.route("/json_auth", methods=["POST"])
+    @auth_required()
+    def echo_jsonauth():
+        return jsonify(flask_request.get_json())
+
     @app.route("/unauthz", methods=["GET", "POST"])
     def unauthz():
         return render_template("index.html", content="Unauthorized")


### PR DESCRIPTION
We used to set the CSRF_COOKIE (if configured) at the end of a successful authentication. For 2-factor that meant that /tf-validate needed to have the CSRF-HEADER set manually (as well as /login). There seems no reason not to set the CSRF-COOKIE on GET /login - just as we return the csrf_token - so that all endpoints can use the cookie if wanted (which is what many js frameworks do).

There appeared to be no CSRF tests for logging in with unified sign in - now there is.

closes #965