### PR TITLE
Add support for changing email.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,20 @@ Flask-Security Changelog
 
 Here you can see the full list of changes between each Flask-Security release.
 
+Version 5.5.0
+-------------
+
+Released TBD
+
+Features
+++++++++
+- (:issue:`956`) Add support for changing registered user's email (:py:data:`SECURITY_CHANGE_EMAIL`).
+
+Fixes
++++++
+- (:pr:`972`) Set :py:data:`SECURITY_CSRF_COOKIE` at beginning (GET /login) of authentication
+  ritual - just as we return the CSRF token. (thanks @e-goto)
+
 Version 5.4.3
 -------------
 
@@ -11,10 +25,10 @@ Released March 23, 2024
 Fixes
 +++++
 - (:issue:`950`) Regression - some templates no longer getting correct config (thanks pete7863).
-- (:issue:`954`) CSRF not properly ignored for application forms using SECURITY_CSRF_PROTECT_MECHANISMS.
+- (:issue:`954`) CSRF not properly ignored for application forms using :py:data:`SECURITY_CSRF_PROTECT_MECHANISMS`.
 - (:pr:`957`) Improve jp translations (e-goto)
 - (:issue:`959`) Regression - datetime_factory should still be an attribute (thanks TimotheeJeannin)
-- (:issue:`942`) GENERIC_RESPONSES hide email validation/syntax errors.
+- (:issue:`942`) :py:data:`SECURITY_RETURN_GENERIC_RESPONSES` hide email validation/syntax errors.
 
 Version 5.4.2
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -223,6 +223,7 @@ Security() instantiation.
 Forms
 -----
 
+.. autoclass:: flask_security.ChangeEmailForm
 .. autoclass:: flask_security.ChangePasswordForm
 .. autoclass:: flask_security.ConfirmRegisterForm
 .. autoclass:: flask_security.ForgotPasswordForm

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -268,7 +268,7 @@ These configuration keys are used globally across all features.
 
 .. py:data:: SECURITY_REDIRECT_BEHAVIOR
 
-    Passwordless login, confirmation, reset password, unified signin, and oauth signin
+    Passwordless login, confirmation, reset password, unified signin, change_email, and oauth signin
     have GET endpoints that validate the passed token and redirect to an action form.
     For Single-Page-Applications style UIs which need to control their own internal URL routing these redirects
     need to not contain forms, but contain relevant information as query parameters.
@@ -279,6 +279,8 @@ These configuration keys are used globally across all features.
     - :py:data:`SECURITY_POST_OAUTH_LOGIN_VIEW`  (if :py:data:`SECURITY_OAUTH_ENABLE` is True)
     - :py:data:`SECURITY_LOGIN_ERROR_VIEW`
     - :py:data:`SECURITY_CONFIRM_ERROR_VIEW`
+    - :py:data:`SECURITY_POST_CHANGE_EMAIL_VIEW`
+    - :py:data:`SECURITY_CHANGE_EMAIL_ERROR_VIEW`
     - :py:data:`SECURITY_POST_CONFIRM_VIEW`
     - :py:data:`SECURITY_RESET_ERROR_VIEW`
     - :py:data:`SECURITY_RESET_VIEW`
@@ -902,7 +904,7 @@ Confirmable
     Specifies the view to redirect to if a confirmation error occurs.
     This value can be set to a URL or an endpoint name.
     If this value is ``None``, the user is presented the default view
-    to resend a confirmation link. In the case of ``SECURITY_REDIRECT_BEHAVIOR`` == ``"spa"``
+    to resend a confirmation link. In the case of :py:data:`SECURITY_REDIRECT_BEHAVIOR` == ``"spa"``
     query params in the redirect will contain the error.
 
     Default: ``None``.
@@ -1075,6 +1077,71 @@ Recoverable
     Sets subject for the password notice.
 
     Default: ``_("Your password has been reset")``.
+
+Change_Email
+------------
+.. versionadded:: 5.5.0
+
+.. py:data:: SECURITY_CHANGE_EMAIL
+
+    It ``True`` an endpoint is created that allows a user to change their email address.
+
+    Default: ``False``
+.. py:data:: SECURITY_CHANGE_EMAIL_SUBJECT
+
+    Sets the subject for the change email confirmation email.
+
+    Default: ``_("Confirm your new email address")``.
+.. py:data:: SECURITY_CHANGE_EMAIL_TEMPLATE
+
+    Specifies the path to the template for the change email page.
+
+    Default: ``"security/change_email.html"``.
+.. py:data:: SECURITY_CHANGE_EMAIL_WITHIN
+
+    Specifies the amount of time a user has before their change email
+    token expires. Always pluralize the time unit for this value.
+
+    Default: ``"2 hours"``
+.. py:data:: SECURITY_POST_CHANGE_EMAIL_VIEW
+
+    Specifies the view to redirect to after a user successfully confirms their new email address.
+    This value can be set to a URL or an endpoint name. If this value is
+    ``None``, the user is redirected to the value of :py:data:`SECURITY_POST_LOGIN_VIEW`.
+    Note that if the request URL or form has a ``next`` parameter, that will take precedence.
+    In the case of :py:data:`SECURITY_REDIRECT_BEHAVIOR` == ``"spa"`` this value must be set.
+
+    Default: ``None``.
+.. py:data:: SECURITY_CHANGE_EMAIL_ERROR_VIEW
+
+    Specifies the view to redirect to if a change email confirmation error occurs.
+    This value can be set to a URL or an endpoint name.
+    If this value is ``None``, the user is redirected back to the change_email page.
+    In the case of :py:data:`SECURITY_REDIRECT_BEHAVIOR` == ``"spa"``
+    this value must be set, and the query params in the redirect will contain the error.
+
+    Default: ``None``.
+.. py:data:: SECURITY_CHANGE_EMAIL_URL
+
+    Specifies the change-email endpoint URL.
+
+    Default: ``"/change-email"``.
+.. py:data:: SECURITY_CHANGE_EMAIL_CONFIRM_URL
+
+    Specifies the change-email confirmation endpoint URL. This is a GET
+    only endpoint (accessed via a link in an email).
+
+    Default: ``"/change-email-confirm"``.
+.. py:data:: SECURITY_EMAIL_CHANGE_SALT
+
+    Specifies the salt value when generating change email confirmation links/tokens.
+
+    Default: ``"change-email-salt"``.
+
+Additional relevant configuration variables:
+
+    - :py:data:`SECURITY_FRESHNESS` - Used to protect /change-email.
+    - :py:data:`SECURITY_FRESHNESS_GRACE_PERIOD` - Used to protect /change-email.
 
 Two-Factor
 -----------
@@ -1709,6 +1776,7 @@ Feature Flags
 -------------
 All feature flags. By default all are 'False'/not enabled.
 
+* :py:data:`SECURITY_CHANGE_EMAIL`
 * :py:data:`SECURITY_CONFIRMABLE`
 * :py:data:`SECURITY_REGISTERABLE`
 * :py:data:`SECURITY_RECOVERABLE`
@@ -1729,6 +1797,8 @@ A list of all URLs and Views:
 * :py:data:`SECURITY_LOGOUT_URL`
 * :py:data:`SECURITY_VERIFY_URL`
 * :py:data:`SECURITY_REGISTER_URL`
+* :py:data:`SECURITY_CHANGE_EMAIL_URL`
+* :py:data:`SECURITY_CHANGE_EMAIL_CONFIRM_URL`
 * :py:data:`SECURITY_RESET_URL`
 * :py:data:`SECURITY_CHANGE_URL`
 * :py:data:`SECURITY_CONFIRM_URL`
@@ -1777,6 +1847,7 @@ A list of all templates:
 * :py:data:`SECURITY_REGISTER_USER_TEMPLATE`
 * :py:data:`SECURITY_RESET_PASSWORD_TEMPLATE`
 * :py:data:`SECURITY_CHANGE_PASSWORD_TEMPLATE`
+* :py:data:`SECURITY_CHANGE_EMAIL_TEMPLATE`
 * :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_TEMPLATE`
 * :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES_TEMPLATE`
 * :py:data:`SECURITY_SEND_CONFIRMATION_TEMPLATE`
@@ -1802,6 +1873,9 @@ The default messages and error levels can be found in ``core.py``.
 * ``SECURITY_MSG_ALREADY_CONFIRMED``
 * ``SECURITY_MSG_API_ERROR``
 * ``SECURITY_MSG_ANONYMOUS_USER_REQUIRED``
+* ``SECURITY_MSG_CHANGE_EMAIL_EXPIRED``
+* ``SECURITY_MSG_CHANGE_EMAIL_CONFIRMED``
+* ``SECURITY_MSG_CHANGE_EMAIL_SENT``
 * ``SECURITY_MSG_CODE_HAS_BEEN_SENT``
 * ``SECURITY_MSG_CONFIRMATION_EXPIRED``
 * ``SECURITY_MSG_CONFIRMATION_REQUEST``

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -21,6 +21,7 @@ following is a list of view templates:
 * `security/register_user.html`
 * `security/reset_password.html`
 * `security/change_password.html`
+* `security/change_email.html`
 * `security/send_confirmation.html`
 * `security/send_login.html`
 * `security/verify.html`
@@ -47,6 +48,7 @@ Flask application context processor:
 
 * ``<template_name>_form``: A form object for the view.
 * ``security``: The Flask-Security extension object.
+* ``config``: Injected by Flask - this holds all extensions' configuration.
 * ``url_for_security``: A function that returns the configured URL for the passed Security endpoint.
 * ``_fsdomain``: A function used to `tag` strings for extraction and localization.
 * ``_fs_is_user_authenticated``: Returns True if argument (user) is authenticated.
@@ -77,6 +79,7 @@ The following is a list of all the available context processor decorators:
 * ``register_context_processor``: Register view
 * ``reset_password_context_processor``: Reset password view
 * ``change_password_context_processor``: Change password view
+* ``change_email_context_processor``: Change email view
 * ``send_confirmation_context_processor``: Send confirmation view
 * ``send_login_context_processor``: Send login view
 * ``mail_context_processor``: Whenever an email will be sent
@@ -162,6 +165,7 @@ The following is a list of all the available form overrides:
 * ``forgot_password_form``: Forgot password form
 * ``reset_password_form``: Reset password form
 * ``change_password_form``: Change password form
+* ``change_email_form``: Change email form
 * ``send_confirmation_form``: Send confirmation form
 * ``mf_recovery_codes_form``: Setup recovery codes form
 * ``mf_recovery_form``: Use recovery code form
@@ -368,6 +372,8 @@ The following is a list of email templates:
 * `security/email/reset_notice.txt`
 * `security/email/change_notice.txt`
 * `security/email/change_notice.html`
+* `security/email/change_email_instructions.txt`
+* `security/email/change_email_instructions.html`
 * `security/email/welcome.html`
 * `security/email/welcome.txt`
 * `security/email/welcome_existing.html`
@@ -418,6 +424,9 @@ welcome                         SECURITY_SEND_REGISTER_EMAIL         SECURITY_EM
 confirmation_instructions       N/A                                  SECURITY_EMAIL_SUBJECT_CONFIRM                    - user                 confirm_instructions_sent
                                                                                                                        - confirmation_link
                                                                                                                        - confirmation_token
+change_email_instructions       N/A                                  SECURITY_CHANGE_EMAIL_SUBJECT                     - user                 change_email_instructions_sent
+                                                                                                                       - link
+                                                                                                                       - token
 login_instructions              N/A                                  SECURITY_EMAIL_SUBJECT_PASSWORDLESS               - user                 login_instructions_sent
                                                                                                                        - login_link
                                                                                                                        - login_token

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -236,6 +236,10 @@ Thus changing the password also invalidates all authentication tokens. This may 
 behavior, so if the UserModel contains an attribute ``fs_token_uniquifier``, then that will be used
 when generating authentication tokens and so won't be affected by password changes.
 
+Email Change
+------------
+If configured, users can change the email they registered with. This will send a new confirmation email to the new email address.
+
 
 Login Tracking
 --------------
@@ -262,6 +266,7 @@ JSON is supported for the following operations:
 * Unified sign in requests
 * Registration requests
 * Change password requests
+* Change email requests
 * Confirmation requests
 * Forgot password requests
 * Passwordless login requests

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,20 +14,18 @@ Welcome to Flask-Security
 Flask-Security allows you to quickly add common security mechanisms to your
 Flask application. They include:
 
-1. Session based authentication
-2. Role and Permission management
-3. Password hashing
-4. Basic HTTP authentication
-5. Token based authentication
-6. Token based account activation (optional)
-7. Token based password recovery / resetting (optional)
-8. Two-factor authentication (optional)
-9. Unified sign in (optional)
-10. User registration (optional)
-11. Login tracking (optional)
-12. JSON/Ajax Support
-13. WebAuthn Support (optional)
-14. Use 'social'/Oauth for authentication (e.g. google, github, ..) (optional)
+1. Authentication (via session, Basic HTTP, or token)
+2. User registration (optional)
+3. Role and Permission management
+4. Account activation (via email confirmation) (optional)
+5. Password management (recovery and resetting) (optional)
+6. Two-factor authentication (optional)
+7. WebAuthn Support (optional)
+8. Use 'social'/Oauth for authentication (e.g. google, github, ..) (optional)
+9. Change email (optional)
+10. Login tracking (optional)
+11. JSON/Ajax Support
+
 
 Many of these features are made possible by integrating various Flask extensions
 and libraries. They include:

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -73,8 +73,8 @@ Confirmable
 ^^^^^^^^^^^
 
 If you enable account confirmation by setting your application's
-:py:data:`SECURITY_CONFIRMABLE` configuration value to `True`, your `User` model will
-require the following additional field:
+:py:data:`SECURITY_CONFIRMABLE` or :py:data:`SECURITY_CHANGE_EMAIL` configuration value to `True`,
+your `User` model will require the following additional field:
 
 * ``confirmed_at`` (datetime)
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -412,6 +412,104 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DefaultJsonErrorResponse"
+  /change-email:
+    get:
+      summary: GET change email form
+      responses:
+        200:
+          description: change email form
+          content:
+            text/html:
+              schema:
+                type: string
+                description: render_template(SECURITY_CHANGE_EMAIL_TEMPLATE)
+                example: render_template(SECURITY_CHANGE_EMAIL_TEMPLATE)
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/DefaultJsonResponse'
+                  - type: object
+                    properties:
+                      response:
+                        type: object
+                        properties:
+                          current_email:
+                            type: string
+                            description: User's currently registered email
+    post:
+      summary: Generate and send change email confirmation link
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangeEmail"
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/ChangeEmail"
+      responses:
+        200:
+          description: Change email response.
+          content:
+            text/html:
+              schema:
+                description: |
+                  Change email form (errors or not).
+                  If no errors then a confirmation instructions (with link) has been sent to the
+                  requested (new) email.
+                type: string
+                example: render_template(SECURITY_CHANGE_EMAIL_TEMPLATE) with error values
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DefaultJsonResponse"
+        400:
+          description: Errors while validating form
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/DefaultJsonErrorResponse'
+                  - type: object
+                    properties:
+                      response:
+                        type: object
+                        properties:
+                          current_email:
+                            type: string
+                            description: User's currently registered email
+  /change-email/{token}:
+    parameters:
+      - name: token
+        in: path
+        required: true
+        schema:
+          type: string
+    get:
+      summary: Confirm change of user's registered email
+      description: >
+        This is the result of getting a change-email token and is usually
+        the result of clicking the link from a change-email  email.
+        This always results in a redirect().
+      responses:
+        302:
+          description: >
+            Redirects depending on success/error and whether
+            __SECURITY_REDIRECT_BEHAVIOR__ == 'spa'.
+          headers:
+            Location:
+              description: |
+                On spa-success: SECURITY_POST_CHANGE_EMAIL_VIEW?success={SECURITY_MSG_CHANGE_EMAIL_CONFIRMED}
+
+                On spa-error-expired: SECURITY_CHANGE_EMAIL_ERROR_VIEW?error={SECURITY_MSG_CHANGE_EMAIL_EXPIRED}
+
+                On spa-error-invalid-token: SECURITY_CHANGE_EMAIL_ERROR_VIEW?error={SECURITY_MSG_API_ERROR}
+
+                On default-error: SECURITY_CHANGE_EMAIL_ERROR_VIEW || .change_email
+
+                On default-success: SECURITY_POST_CHANGE_EMAIL_VIEW || SECURITY_POST_LOGIN_VIEW
+              schema:
+                type: string
+
   /reset:
     get:
       summary: GET reset password form
@@ -2044,6 +2142,14 @@ components:
         new_password_confirm:
           type: string
           description: New password - again
+    ChangeEmail:
+      type: object
+      required: [email]
+      properties:
+        email:
+          type: string
+          description: New email requested
+
     EmailLink:
       type: object
       required: [email]

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -12,6 +12,7 @@
 
 # flake8: noqa: F401
 from .changeable import admin_change_password
+from .change_email import ChangeEmailForm
 from .core import (
     Security,
     RoleMixin,

--- a/flask_security/change_email.py
+++ b/flask_security/change_email.py
@@ -1,0 +1,232 @@
+"""
+    flask_security.change_email
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Flask-Security Change Email module
+
+    :copyright: (c) 2024-2024 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+
+    Allow user to change their email address.
+    If CHANGE_EMAIL_CONFIRM is set then the user will receive an email
+    at the new email address with a token that can be used to verify and change
+    emails. Upon success - if CHANGE_EMAIL_NOTIFY_OLD is set, an email will be sent
+    to the old email address.
+"""
+
+from __future__ import annotations
+
+import typing as t
+
+from flask import after_this_request, request
+from flask import current_app
+from flask_login import current_user
+from wtforms import SubmitField
+
+from .decorators import auth_required
+from .forms import (
+    Form,
+    UniqueEmailFormMixin,
+    build_form_from_request,
+    form_errors_munge,
+    get_form_field_label,
+)
+from .proxies import _security, _datastore
+from .quart_compat import get_quart_status
+from .signals import change_email_instructions_sent, change_email_confirmed
+from .utils import (
+    base_render_json,
+    check_and_get_token_status,
+    config_value as cv,
+    do_flash,
+    get_message,
+    get_url,
+    get_within_delta,
+    hash_data,
+    send_mail,
+    url_for_security,
+    verify_hash,
+    view_commit,
+)
+
+if t.TYPE_CHECKING:  # pragma: no cover
+    from flask.typing import ResponseValue
+
+if get_quart_status():  # pragma: no cover
+    from quart import redirect
+else:
+    from flask import redirect
+
+
+class ChangeEmailForm(Form, UniqueEmailFormMixin):
+    submit = SubmitField(label=get_form_field_label("submit"))
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.existing_email_user = None
+
+
+@auth_required(
+    lambda: cv("API_ENABLED_METHODS"),
+    within=lambda: cv("FRESHNESS"),
+    grace=lambda: cv("FRESHNESS_GRACE_PERIOD"),
+)
+def change_email() -> ResponseValue:
+    """Start Change Email for an existing authenticated user"""
+    payload: dict[str, t.Any]
+
+    form: ChangeEmailForm = t.cast(
+        ChangeEmailForm, build_form_from_request("change_email_form")
+    )
+
+    if form.validate_on_submit():
+        _send_instructions(current_user, form.email.data)
+        if not _security._want_json(request):
+            do_flash(*get_message("CHANGE_EMAIL_SENT", email=form.email.data))
+        # Drop through..
+
+    # All paths get here
+    if (
+        request.method == "POST"
+        and cv("RETURN_GENERIC_RESPONSES")
+        and form.existing_email_user
+    ):
+        # Don't let an existing user enumerate registered emails
+        fields_to_squash: dict[str, dict[str, str]] = dict(email=dict())
+        form_errors_munge(form, fields_to_squash)
+        if not form.errors:
+            # only error is existing email - make it appear the same as if it worked
+            # except that we don't send anything - while we could inform the email
+            # that someone is trying to take it over - that could allow a user to
+            # annoy another user.
+            if not _security._want_json(request):
+                do_flash(*get_message("CHANGE_EMAIL_SENT", email=form.email.data))
+            # TODO - should we have a signal so we can tell application what is
+            # is going on (otherwise it is pretty much a black-hole).
+            # drop through - will return a successful response.
+
+    if _security._want_json(request):
+        form.user = current_user
+        payload = dict(current_email=current_user.email)
+        return base_render_json(form, additional=payload)
+
+    return _security.render_template(
+        cv("CHANGE_EMAIL_TEMPLATE"),
+        change_email_form=form,
+        current_email=current_user.email,
+        **_security._run_ctx_processor("change_email"),
+    )
+
+
+def change_email_confirm(token):
+    """
+    View function which handles a change email confirmation request.
+    This is always a GET from an email - so for 'spa' must always redirect.
+    """
+    expired, invalid, user, new_email = _verify_token_status(token)
+
+    if invalid or expired:
+        if expired:
+            m, c = get_message(
+                "CHANGE_EMAIL_EXPIRED",
+                within=cv("CHANGE_EMAIL_WITHIN"),
+            )
+        else:
+            m, c = get_message("API_ERROR")
+        if cv("REDIRECT_BEHAVIOR") == "spa":
+            return redirect(get_url(cv("CHANGE_EMAIL_ERROR_VIEW"), qparams={c: m}))
+        do_flash(m, c)
+        return redirect(
+            get_url(cv("CHANGE_EMAIL_ERROR_VIEW")) or url_for_security("change_email")
+        )
+
+    _update_user_email(user, new_email)
+    after_this_request(view_commit)
+    m, c = get_message("CHANGE_EMAIL_CONFIRMED")
+    if cv("REDIRECT_BEHAVIOR") == "spa":
+        return redirect(
+            get_url(
+                cv("POST_CHANGE_EMAIL_VIEW"),
+                qparams=user.get_redirect_qparams({c: m}),
+            )
+        )
+    do_flash(m, c)
+    return redirect(
+        get_url(cv("POST_CHANGE_EMAIL_VIEW")) or get_url(cv("POST_LOGIN_VIEW"))
+    )
+
+
+def _generate_token(user, new_email):
+    """Generates a unique confirmation token for the specified user.
+
+    :param user: The user to work with
+    :param new_email: The requested email
+    """
+    data = [str(user.fs_uniquifier), hash_data(user.email), new_email]
+    return _security.change_email_serializer.dumps(data)
+
+
+def _generate_link(user, new_email):
+    token = _generate_token(user, new_email)
+    return url_for_security("change_email_confirm", token=token, _external=True), token
+
+
+def _send_instructions(user, new_email):
+    """Sends the change email instructions email for the specified user.
+
+    :param user: The user to send the instructions to
+    :param new_email: The requested new email
+    """
+
+    link, token = _generate_link(user, new_email)
+
+    send_mail(
+        cv("CHANGE_EMAIL_SUBJECT"),
+        new_email,
+        "change_email_instructions",
+        user=user,
+        link=link,
+        token=token,
+    )
+
+    change_email_instructions_sent.send(
+        current_app._get_current_object(),
+        _async_wrapper=current_app.ensure_sync,
+        user=user,
+        new_email=new_email,
+        token=token,
+    )
+
+
+def _verify_token_status(token):
+    """Verify token and contents.
+    In general, we return pretty generic results - including checking the requested
+    new_email is still available (and if not return 'invalid').
+    """
+    expired, invalid, state = check_and_get_token_status(
+        token, "change_email", get_within_delta("CHANGE_EMAIL_WITHIN")
+    )
+    if invalid or expired:
+        return expired, invalid, None, None
+    fid, hashed_email, new_email = state
+    user = _datastore.find_user(fs_uniquifier=fid)
+    if not user or not verify_hash(hashed_email, user.email):
+        return False, True, None, None
+
+    # verify that new_email is still available
+    if _datastore.find_user(email=new_email):
+        return False, True, user, None
+    return expired, invalid, user, new_email
+
+
+def _update_user_email(user, new_email):
+    old_email = user.email
+    user.email = new_email
+    user.confirmed_at = _security.datetime_factory()
+    _datastore.put(user)
+    change_email_confirmed.send(
+        current_app._get_current_object(),
+        _async_wrapper=current_app.ensure_sync,
+        user=user,
+        old_email=old_email,
+    )

--- a/flask_security/signals.py
+++ b/flask_security/signals.py
@@ -5,7 +5,7 @@
     Flask-Security signals module
 
     :copyright: (c) 2012 by Matt Wright.
-    :copyright: (c) 2019-2022 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -49,3 +49,7 @@ us_profile_changed = signals.signal("us-profile-changed")
 wan_registered = signals.signal("wan-registered")
 
 wan_deleted = signals.signal("wan-deleted")
+
+change_email_instructions_sent = signals.signal("change-email-instructions-sent")
+
+change_email_confirmed = signals.signal("change-email")

--- a/flask_security/templates/security/_menu.html
+++ b/flask_security/templates/security/_menu.html
@@ -12,6 +12,11 @@
           <a href="{{ url_for_security('change_password') }}">{{ _fsdomain("Change Password") }}</a>
         </li>
       {% endif %}
+      {% if security.change_email %}
+        <li>
+          <a href="{{ url_for_security('change_email') }}">{{ _fsdomain("Change Registered Email") }}</a>
+        </li>
+      {% endif %}
       {% if security.two_factor %}
         <li>
           <a href="{{ url_for_security('two_factor_setup') }}">{{ _fsdomain("Two Factor Setup") }}</a>

--- a/flask_security/templates/security/change_email.html
+++ b/flask_security/templates/security/change_email.html
@@ -1,0 +1,15 @@
+{% extends "security/base.html" %}
+{% from "security/_macros.html" import render_field_with_errors, render_field, render_field_errors, render_form_errors %}
+
+{% block content %}
+  {% include "security/_messages.html" %}
+  <h1>{{ _fsdomain('Change email') }}</h1>
+  <h3>{{ _fsdomain('Once submitted, an email confirmation will be sent to this new email address.') }}</h3>
+  <form action="{{ url_for_security('change_email') }}" method="post" name="change_email_form">
+    {{ change_email_form.hidden_tag() }}
+    {{ render_form_errors(change_email_form) }}
+    {{ render_field_with_errors(change_email_form.email) }}
+    {{ render_field_errors(change_email_form.csrf_token) }}
+    {{ render_field(change_email_form.submit) }}
+  </form>
+{% endblock content %}

--- a/flask_security/templates/security/email/change_email_instructions.html
+++ b/flask_security/templates/security/email/change_email_instructions.html
@@ -1,0 +1,13 @@
+{# This template receives the following context:
+  link - the link that should be fetched (GET) to confirm
+  token - this token is part of confirmation link - but can be used to
+    construct arbitrary URLs for redirecting.
+  user - the entire user model object
+  security - the Flask-Security configuration
+#}
+<p>{{ _fsdomain('Please confirm your new email address by clicking on the link below:') }}</p>
+<p>
+  <a href="{{ link }}">{{ _fsdomain('Confirm my new email') }}</a>
+</p>
+<p>{{ _fsdomain('This link will expire in %(within)s.', within=config["SECURITY_CHANGE_EMAIL_WITHIN"]) }}</p>
+<p>{{ _fsdomain('Your currently registered email is %(email)s.', email=user.email) }}</p>

--- a/flask_security/templates/security/email/change_email_instructions.txt
+++ b/flask_security/templates/security/email/change_email_instructions.txt
@@ -1,0 +1,13 @@
+{# This template receives the following context:
+  link - the link that should be fetched (GET) to confirm
+  token - this token is part of confirmation link - but can be used to
+    construct arbitrary URLs for redirecting.
+  user - the entire user model object
+  security - the Flask-Security configuration
+#}
+{{ _fsdomain('Please confirm your new email through the link below:') }}
+{{ link }}
+
+{{ _fsdomain('This link will expire in %(within)s.', within=config["SECURITY_CHANGE_EMAIL_WITHIN"]) }}
+
+{{ _fsdomain('Your currently registered email is %(email)s.', email=user.email) }}

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -42,6 +42,7 @@ from flask import (
 from flask_login import current_user
 
 from .changeable import change_user_password
+from .change_email import change_email, change_email_confirm
 from .confirmable import (
     confirm_email_token_status,
     confirm_user,
@@ -1192,6 +1193,19 @@ def create_blueprint(app, state, import_name):
             methods=["GET", "POST"],
             endpoint="change_password",
         )(change_password)
+
+    if state.change_email:
+        change_email_url = cv("CHANGE_EMAIL_URL", app=app)
+        bp.route(
+            change_email_url,
+            methods=["GET", "POST"],
+            endpoint="change_email",
+        )(change_email)
+        bp.route(
+            change_email_url + slash_url_suffix(change_email_url, "<token>"),
+            methods=["GET"],
+            endpoint="change_email_confirm",
+        )(change_email_confirm)
 
     if state.confirmable:
         confirm_url = cv("CONFIRM_URL", app=app)

--- a/pytest.ini
+++ b/pytest.ini
@@ -16,6 +16,7 @@ markers =
     webauthn
     flask_async
     csrf
+    change_email
 
 filterwarnings =
     error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,7 @@ def app(request: pytest.FixtureRequest) -> SecurityFixture:
 
     for opt in [
         "changeable",
+        "change_email",
         "recoverable",
         "registerable",
         "trackable",

--- a/tests/templates/custom_security/change_email.html
+++ b/tests/templates/custom_security/change_email.html
@@ -1,0 +1,3 @@
+CUSTOM CHANGE EMAIL
+{{ global }}
+{{ foo }}

--- a/tests/templates/security/email/change_email_instructions.txt
+++ b/tests/templates/security/email/change_email_instructions.txt
@@ -1,0 +1,12 @@
+{# This template receives the following context:
+  link - the link that should be fetched (GET) to confirm
+  token - this token is part of confirmation link - but can be used to
+    construct arbitrary URLs for redirecting.
+  user - the entire user model object
+  security - the Flask-Security configuration
+#}
+Link:{{ link }}
+Email:{{ user.email }}
+Token:{{ token }}
+RegisterBlueprint:{{ security.register_blueprint }}
+Within:{{ config["SECURITY_CHANGE_EMAIL_WITHIN"] }}

--- a/tests/test_change_email.py
+++ b/tests/test_change_email.py
@@ -1,0 +1,228 @@
+"""
+    test_change_email
+    ~~~~~~~~~~~~~~~~~
+
+    Change email functionality tests
+
+    :copyright: (c) 2024-2024 by J. Christopher Wagner (jwag).
+    :license: MIT, see LICENSE for more details.
+"""
+
+from contextlib import contextmanager
+from datetime import date, timedelta
+import re
+from urllib.parse import urlsplit
+
+import pytest
+from freezegun import freeze_time
+from tests.test_utils import (
+    authenticate,
+    capture_flashes,
+    is_authenticated,
+    json_authenticate,
+    logout,
+)
+from flask_security import hash_password
+from flask_security.signals import (
+    change_email_instructions_sent,
+    change_email_confirmed,
+)
+
+pytestmark = pytest.mark.change_email()
+
+
+@contextmanager
+def capture_change_email_requests():
+    change_email_requests = []
+
+    def _on(app, **data):
+        change_email_requests.append(data)
+
+    change_email_instructions_sent.connect(_on)
+
+    try:
+        yield change_email_requests
+    finally:
+        change_email_instructions_sent.disconnect(_on)
+
+
+@pytest.mark.settings(change_email_error_view="/change-email")
+def test_ce(app, client, get_message):
+    @change_email_confirmed.connect_via(app)
+    def _on(app, **kwargs):
+        assert kwargs["old_email"] == "matt@lp.com"
+        assert kwargs["user"].email == "matt2@lp.com"
+
+    authenticate(client, email="matt@lp.com")
+
+    with capture_change_email_requests() as ce_requests:
+        response = client.post("/change-email", data={"email": "<EMAIL>"})
+        assert get_message("INVALID_EMAIL_ADDRESS") in response.data
+        assert not app.mail.outbox
+
+        response = client.post("/change-email", data=dict(email="matt2@lp.com"))
+        msg = get_message("CHANGE_EMAIL_SENT", email="matt2@lp.com")
+        assert msg in response.data
+        assert "matt2@lp.com" == ce_requests[0]["new_email"]
+        token = ce_requests[0]["token"]
+    assert len(app.mail.outbox) == 1
+    assert app.config["SECURITY_CHANGE_EMAIL_WITHIN"] in app.mail.outbox[0].body
+
+    response = client.get("/change-email/" + token, follow_redirects=True)
+    assert get_message("CHANGE_EMAIL_CONFIRMED") in response.data
+    assert is_authenticated(client, get_message)
+
+    logout(client)
+    authenticate(client, email="matt2@lp.com")
+    assert is_authenticated(client, get_message)
+
+    # try using link again - should fail
+    with capture_flashes() as flashes:
+        client.get("/change-email/" + token, follow_redirects=True)
+    assert flashes[0]["message"].encode("utf-8") == get_message("API_ERROR")
+
+
+def test_ce_json(app, client, get_message):
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+
+    @change_email_confirmed.connect_via(app)
+    def _on(app, **kwargs):
+        assert kwargs["old_email"] == "matt@lp.com"
+        assert kwargs["user"].email == "matt2@lp.com"
+
+    json_authenticate(client, email="matt@lp.com")
+
+    with capture_change_email_requests() as ce_requests:
+        response = client.post("/change-email", json={"email": "<EMAIL>"})
+        assert response.json["response"]["errors"][0].encode("utf=8") == get_message(
+            "INVALID_EMAIL_ADDRESS"
+        )
+        assert not app.mail.outbox
+
+        response = client.post("/change-email", json=dict(email="matt2@lp.com"))
+        assert response.status_code == 200
+        assert response.json["response"]["current_email"] == "matt@lp.com"
+        assert "matt2@lp.com" == ce_requests[0]["new_email"]
+        token = ce_requests[0]["token"]
+    assert len(app.mail.outbox) == 1
+
+    response = client.get(
+        "/change-email/" + token, headers=headers, follow_redirects=True
+    )
+    assert get_message("CHANGE_EMAIL_CONFIRMED") in response.data
+    assert is_authenticated(client, get_message)
+
+    logout(client)
+    authenticate(client, email="matt2@lp.com")
+    assert is_authenticated(client, get_message)
+
+
+@pytest.mark.settings(
+    change_email_within="1 milliseconds", change_email_error_view="/change-email"
+)
+def test_expired_token(client, get_message):
+    # Note that we need relatively new-ish date since session cookies also expire.
+    with freeze_time(date.today() + timedelta(days=-1)):
+        authenticate(client, email="matt@lp.com")
+        with capture_change_email_requests() as ce_requests:
+            client.post("/change-email", data=dict(email="matt2@lp.com"))
+
+        assert "matt2@lp.com" == ce_requests[0]["new_email"]
+        token = ce_requests[0]["token"]
+
+    response = client.get("/change-email/" + token, follow_redirects=True)
+    msg = get_message("CHANGE_EMAIL_EXPIRED", within="1 milliseconds")
+    assert msg in response.data
+
+
+def test_template(app, client, get_message):
+    # Check contents of email template - this uses a test template
+    # in order to check all context vars since the default template
+    # doesn't have all of them.
+
+    authenticate(client, email="matt@lp.com")
+    with capture_change_email_requests() as ce_requests:
+        client.post("/change-email", data=dict(email="matt2@lp.com"))
+        # check email
+        outbox = app.mail.outbox
+        assert outbox[0].to[0] == "matt2@lp.com"
+        matcher = re.findall(r"\w+:.*", outbox[0].body, re.IGNORECASE)
+        # should be 4 - link, email, token, config item
+        assert matcher[1].split(":")[1] == "matt@lp.com"
+        assert matcher[2].split(":")[1] == ce_requests[0]["token"]
+        assert matcher[3].split(":")[1] == "True"  # register_blueprint
+        assert matcher[4].split(":")[1] == "2 hours"
+
+        # check link
+        _, link = matcher[0].split(":", 1)
+        response = client.get(link, follow_redirects=True)
+        assert get_message("CHANGE_EMAIL_CONFIRMED") in response.data
+
+
+@pytest.mark.settings(return_generic_responses=True)
+def test_generic_response(app, client, get_message):
+    authenticate(client, email="matt@lp.com")
+    with capture_change_email_requests():
+        # first try bad formatted email - should get detailed error
+        response = client.post("/change-email", json={"email": "<EMAIL>"})
+        assert response.json["response"]["errors"][0].encode("utf=8") == get_message(
+            "INVALID_EMAIL_ADDRESS"
+        )
+
+        # try existing email - should get same response as if it 'worked'
+        response = client.post("/change-email", data=dict(email="gal@lp.com"))
+        msg = get_message("CHANGE_EMAIL_SENT", email="gal@lp.com")
+        assert msg in response.data
+        # but no email was actually sent
+        assert not app.mail.outbox
+
+
+@pytest.mark.settings(
+    redirect_host="myui.com:8090",
+    redirect_behavior="spa",
+    post_change_email_view="/change-email-redirect",
+    change_email_error_view="/change-email-error",
+)
+def test_spa_get(app, client, get_message):
+    json_authenticate(client, email="matt@lp.com")
+
+    with capture_change_email_requests() as ce_requests:
+        response = client.post("/change-email", data=dict(email="matt2@lp.com"))
+        msg = get_message("CHANGE_EMAIL_SENT", email="matt2@lp.com")
+        assert msg in response.data
+        assert "matt2@lp.com" == ce_requests[0]["new_email"]
+        token = ce_requests[0]["token"]
+    response = client.get("/change-email/" + token, follow_redirects=False)
+    assert response.status_code == 302
+    split = urlsplit(response.headers["Location"])
+    assert "myui.com:8090" == split.netloc
+    assert "/change-email-redirect" == split.path
+
+    # again - should be an error
+    response = client.get("/change-email/" + token, follow_redirects=False)
+    assert response.status_code == 302
+    split = urlsplit(response.headers["Location"])
+    assert "myui.com:8090" == split.netloc
+    assert "/change-email-error" == split.path
+
+
+@pytest.mark.settings(change_email_error_view="/change-email")
+def test_ce_race(app, client, get_message):
+    # test that if an email is taken between the link being sent and
+    # the user confirming - they get an error
+
+    authenticate(client, email="matt@lp.com")
+
+    with capture_change_email_requests() as ce_requests:
+        client.post("/change-email", data=dict(email="matt2@lp.com"))
+        token = ce_requests[0]["token"]
+
+    with app.app_context():
+        app.security.datastore.create_user(
+            email="matt2@lp.com",
+            password=hash_password("password"),
+        )
+        app.security.datastore.commit()
+    with capture_flashes() as flashes:
+        client.get("/change-email/" + token, follow_redirects=True)
+    assert flashes[0]["message"].encode("utf-8") == get_message("API_ERROR")

--- a/tests/test_context_processors.py
+++ b/tests/test_context_processors.py
@@ -15,8 +15,10 @@ from tests.test_utils import authenticate, capture_reset_password_requests, logo
 @pytest.mark.registerable()
 @pytest.mark.confirmable()
 @pytest.mark.changeable()
+@pytest.mark.change_email()
 @pytest.mark.settings(
     login_without_confirmation=True,
+    change_email_template="custom_security/change_email.html",
     change_password_template="custom_security/change_password.html",
     login_user_template="custom_security/login_user.html",
     reset_password_template="custom_security/reset_password.html",
@@ -107,6 +109,15 @@ def test_context_processors(client, app):
     email = app.mail.outbox[1]
     assert "global" in email.body
     assert "bar-mail" in email.body
+
+    @app.security.change_email_context_processor
+    def change_email():
+        return {"foo": "bar-change-email"}
+
+    authenticate(client)
+    response = client.get("/change-email")
+    assert b"global" in response.data
+    assert b"bar-change-email" in response.data
 
 
 @pytest.mark.passwordless()

--- a/tests/view_scaffold.py
+++ b/tests/view_scaffold.py
@@ -134,6 +134,7 @@ def create_app():
     # Turn on all features (except passwordless since that removes normal login)
     for opt in [
         "changeable",
+        "change_email",
         "recoverable",
         "registerable",
         "trackable",


### PR DESCRIPTION
This adds an endpoint - /change-email that allows users to change their email. This sends out a confirmation link to the existing email. As with all other features - this defaults 'False'.

This is a new endpoint, form, view, link, etc.

close #956