### PR TITLE
Update /login and /us-signin to have the same behavior when called by…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,12 +11,18 @@ Released TBD
 Features & Improvements
 +++++++++++++++++++++++
 - (:issue:`956`) Add support for changing registered user's email (:py:data:`SECURITY_CHANGE_EMAIL`).
-- (:pr:`xxx`) Change default password hash to argon2 (was bcrypt). See below for details.
+- (:issue:`944`) Change default password hash to argon2 (was bcrypt). See below for details.
 
 Fixes
 +++++
 - (:pr:`972`) Set :py:data:`SECURITY_CSRF_COOKIE` at beginning (GET /login) of authentication
   ritual - just as we return the CSRF token. (thanks @e-goto)
+- (:issue:`973`) login and unified sign in should handle GET for authenticated user consistently
+
+Docs and Chores
++++++++++++++++
+- (:pr:`979`) Update Russian translations (ademaro)
+- (:pr:`981` and :pr:`956`) Improve docs
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
@@ -151,7 +157,7 @@ Backwards Compatibility Concerns
   Flask-Security now changes any `None` key to `""`.
 - The default unauthorized handler behavior has changed slightly and is now documented. The default
   (:data:`SECURITY_UNAUTHORIZED_VIEW` == ``None``) has not changed (a default HTTP 403 response).
-  The precise behavior when :data:`SECURITY_UNAUTHORIZED_VIEW` was set was never documented.
+  The precise behavior when :data:`SECURITY_UNAUTHORIZED_VIEW` is set was never documented.
   The important change is that Flask-Security no longer ever looks at the request.referrer header and
   will never redirect to it. If an application needs that, it can provide a callable that can return
   that or any other header.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -31,8 +31,9 @@ paths:
             Login form or user information. The JSON response will always
             carry the csrf_token information.
             If SECURITY_CSRF_COOKIE_NAME is set then a cookie with the csrf token will be set.
-            If the caller is logged in, then
-            additional information is returned. This can be very useful for single-page applications where during a force refresh, all state is lost.
+            If the caller is already authenticated, then
+            additional information is returned for JSON requests.
+            This can be very useful for single-page applications where during a force refresh, all state is lost.
             By performing this GET, the session cookie will authenticate the user and the response will contain user information.
           content:
             text/html:
@@ -43,7 +44,7 @@ paths:
             application/json:
               schema:
                 allOf:
-                  - $ref: '#/components/schemas/BaseJsonResponse'
+                  - $ref: '#/components/schemas/DefaultJsonResponse'
                   - type: object
                     properties:
                       response:
@@ -102,8 +103,8 @@ paths:
                 example: render_template(SECURITY_LOGIN_USER_TEMPLATE) with error values
         302:
           description: >
-            If the caller already authenticated, the form contents is ignored and a
-            redirect is done: redirect(next) or redirect(SECURITY_POST_LOGIN_VIEW).
+            If the caller is already authenticated, the form contents is ignored and a
+            redirect is done: redirect(SECURITY_POST_LOGIN_VIEW) (note that 'next' is ignored).
 
             If the caller is NOT already authenticated, and the form contents are
             validated the caller will be redirected to:
@@ -734,7 +735,13 @@ paths:
       summary: GET Unified Sign In form
       responses:
         200:
-          description: Sign in form
+          description: >
+            Sign in form
+            If SECURITY_CSRF_COOKIE_NAME is set then a cookie with the csrf token will be set.
+            If the caller is already authenticated, then
+            additional information is returned for JSON requests.
+            This can be very useful for single-page applications where during a force refresh, all state is lost.
+            By performing this GET, the session cookie will authenticate the user and the response will contain user information.
           content:
             text/html:
               schema:
@@ -743,17 +750,19 @@ paths:
                 example: render_template(SECURITY_US_SIGNIN_TEMPLATE)
             application/json:
               schema:
-                type: object
-                properties:
-                  available_methods:
-                    type: string
-                    description: Config setting SECURITY_US_ENABLED_METHODS
-                  code_methods:
-                    type: string
-                    description: All SECURITY_US_ENABLED_METHODS that require a code to be generated and sent.
-                  identity_attributes:
-                    type: string
-                    description: Configuration setting SECURITY_USER_IDENTITY_ATTRIBUTES
+                allOf:
+                  - $ref: '#/components/schemas/DefaultJsonResponse'
+                  - type: object
+                    properties:
+                      available_methods:
+                        type: string
+                        description: Config setting SECURITY_US_ENABLED_METHODS
+                      code_methods:
+                        type: string
+                        description: All SECURITY_US_ENABLED_METHODS that require a code to be generated and sent.
+                      identity_attributes:
+                        type: string
+                        description: Configuration setting SECURITY_USER_IDENTITY_ATTRIBUTES
     post:
       summary: Unified Sign In
       parameters:
@@ -786,8 +795,8 @@ paths:
                 example: render_template(SECURITY_US_SIGNIN_TEMPLATE) with error values
         302:
           description: >
-            If the caller already authenticated, the form contents is ignored and a
-            redirect is done: redirect(next) or redirect(SECURITY_POST_LOGIN_VIEW).
+            If the caller already authenticated, the form contents are ignored and a
+            redirect is done: redirect(SECURITY_POST_LOGIN_VIEW) (note that 'next' is ignored).
 
             If the caller is NOT already authenticated, and the form contents are
             validated the caller will be redirected to:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -199,6 +199,16 @@ def test_get_already_authenticated(client):
     response = client.get("/login", follow_redirects=True)
     assert b"Post Login" in response.data
 
+    # should still get extra goodies
+    headers = {"Accept": "application/json", "Content-Type": "application/json"}
+    response = client.get("/login", headers=headers)
+    assert response.status_code == 200
+
+    jresponse = response.json["response"]
+    assert all(a in jresponse for a in ["identity_attributes"])
+    assert "authentication_token" not in jresponse["user"]
+    assert all(a in jresponse["user"] for a in ["email", "last_update"])
+
 
 @pytest.mark.settings(post_login_view="/post_login")
 def test_get_already_authenticated_next(client):


### PR DESCRIPTION
… an already authenticated user. They were similar - now identical.

GET w/ JSON now returns the same attributes (possible identity attributes etc) as a GET when not authenticated.

close #973