### PR TITLE
Add freshness to auth tokens

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Fixes
 - (:pr:`972`) Set :py:data:`SECURITY_CSRF_COOKIE` at beginning (GET /login) of authentication
   ritual - just as we return the CSRF token. (thanks @e-goto)
 - (:issue:`973`) login and unified sign in should handle GET for authenticated user consistently
+- (:pr:`990`) Add freshness capability to auth tokens (enables /us-setup to function w/ just auth tokens)
 
 Docs and Chores
 +++++++++++++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -537,7 +537,9 @@ These are used by the Two-Factor and Unified Signin features.
         - :py:data:`SECURITY_US_SETUP_URL`
         - :py:data:`SECURITY_TWO_FACTOR_SETUP_URL`
         - :py:data:`SECURITY_WAN_REGISTER_URL`
+        - :py:data:`SECURITY_WAN_DELETE_URL`
         - :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES`
+        - :py:data:`SECURITY_CHANGE_EMAIL_URL`
 
     Setting this to a negative number will disable any freshness checking and
     the endpoints:
@@ -552,9 +554,8 @@ These are used by the Two-Factor and Unified Signin features.
     Please see :meth:`flask_security.check_and_update_authn_fresh` for details.
 
     .. note::
-        This stores freshness information in the session - which must be presented
-        (usually via a Cookie) to the above endpoints. To disable this, set it
-        to ``timedelta(minutes=-1)``
+        The timestamp of when the caller/user last successfully authenticated is
+        stored in the session as well as authentication token.
 
     Default: timedelta(hours=24)
 
@@ -563,13 +564,11 @@ These are used by the Two-Factor and Unified Signin features.
 .. py:data:: SECURITY_FRESHNESS_GRACE_PERIOD
 
     A timedelta that provides a grace period when altering sensitive
-    information.
-    This is used to protect the endpoints:
+    information. This ensures that multi-step operations don't get denied
+    because the session/token happens to expire mid-step.
 
-        - :py:data:`SECURITY_US_SETUP_URL`
-        - :py:data:`SECURITY_TWO_FACTOR_SETUP_URL`
-        - :py:data:`SECURITY_WAN_REGISTER_URL`
-        - :py:data:`SECURITY_MULTI_FACTOR_RECOVERY_CODES`
+    Note that this is not implemented for freshness information carried in the
+    auth token.
 
     N.B. To avoid strange behavior, be sure to set the grace period less than
     the freshness period.
@@ -578,6 +577,18 @@ These are used by the Two-Factor and Unified Signin features.
     Default: timedelta(hours=1)
 
     .. versionadded:: 3.4.0
+
+.. py:data:: SECURITY_FRESHNESS_ALLOW_AUTH_TOKEN
+
+    Controls whether the freshness data set in the auth token can be used to
+    satisfy freshness checks. Some applications might want to force freshness
+    protected endpoints to always use browser based access with sessions - they
+    should set this to ``False``.
+
+    Default: ``True``
+
+
+    .. versionadded:: 5.5.0
 
 Core - Compatibility
 ---------------------
@@ -1672,8 +1683,8 @@ WebAuthn
 
 Additional relevant configuration variables:
 
-    * :py:data:`SECURITY_FRESHNESS` - Used to protect /us-setup.
-    * :py:data:`SECURITY_FRESHNESS_GRACE_PERIOD` - Used to protect /us-setup.
+    * :py:data:`SECURITY_FRESHNESS` - Used to protect /wan-register and /wan-delete.
+    * :py:data:`SECURITY_FRESHNESS_GRACE_PERIOD` - Used to protect /wan-register and /wan-delete.
 
 Recovery Codes
 --------------

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -77,7 +77,8 @@ Token Authentication
 --------------------
 
 Token based authentication can be used by retrieving the user auth token from an
-authentication endpoint (e.g. ``/login``, ``/us-signin``, ``/wan-signin``).
+authentication endpoint (e.g. ``/login``, ``/us-signin``, ``/wan-signin``, ``/verify``,
+``/us-verify``, ``/wan-verify``).
 Perform an HTTP POST with a query param of ``include_auth_token`` and the authentication details
 as JSON data.
 A successful call will return the authentication token. This token can be used in subsequent
@@ -100,6 +101,10 @@ at first use if null.
 Authentication tokens have 2 options for specifying expiry time :data:`SECURITY_TOKEN_MAX_AGE`
 is applied to ALL authentication tokens. Each authentication token can itself have an embedded
 expiry value (settable via the :data:`SECURITY_TOKEN_EXPIRE_TIMESTAMP` callable).
+
+Authentication tokens also convey freshness by recording the time the token was generated.
+This is used for endpoints protected with :func:`.auth_required` with a ``within``
+value set.
 
 .. note::
     While every Flask-Security endpoint will accept an authentication token header,

--- a/docs/patterns.rst
+++ b/docs/patterns.rst
@@ -101,13 +101,16 @@ Flask-Security itself uses this as part of securing the following endpoints:
     - .tf_setup ("/tf-setup")
     - .us_setup ("/us-setup")
     - .mf_recovery_codes ("/mf-recovery-codes")
+    - .change_email ("/change-email")
 
 Using the :py:data:`SECURITY_FRESHNESS` and :py:data:`SECURITY_FRESHNESS_GRACE_PERIOD` configuration variables.
 
 .. tip::
-    Freshness requires a session (cookie) be sent as part of the request. Without
-    a session, freshness will fail. If your application doesn't/can't send session cookies
-    you can disable freshness by setting ``SECURITY_FRESHNESS`` to ``timedelta(minutes=-1)``
+    The timestamp of the users last successful authentication is stored in the session
+    as well as in the authentication token. One of these must be presented or freshness
+    will fail. You can disallow using the value in the authentication token by setting
+    :py:data:`SECURITY_FRESHNESS_ALLOW_AUTH_TOKEN` to ``False``.
+    You can disable freshness by setting ``SECURITY_FRESHNESS`` to ``timedelta(minutes=-1)``
 
 .. _redirect_topic:
 

--- a/examples/unified_signin/client/client.py
+++ b/examples/unified_signin/client/client.py
@@ -1,5 +1,5 @@
 """
-Copyright 2020-2021 by J. Christopher Wagner (jwag). All rights reserved.
+Copyright 2020-2024 by J. Christopher Wagner (jwag). All rights reserved.
 :license: MIT, see LICENSE for more details.
 
 This relies on session/session cookie for continued authentication.
@@ -83,6 +83,9 @@ def register(server_url, session, email, password):
 def ussetup(server_url, session, password, phone):
     # unified sign in - setup sms with a phone number
     # Use the backdoor to grab verification SMS.
+
+    # reset freshness to show how that would work
+    resp = session.get(f"{server_url}/api/resetfresh")
 
     csrf_token = session.cookies["XSRF-TOKEN"]
     resp = session.post(

--- a/examples/unified_signin/server/api.py
+++ b/examples/unified_signin/server/api.py
@@ -6,7 +6,7 @@ Copyright 2020-2024 by J. Christopher Wagner (jwag). All rights reserved.
 
 from datetime import datetime, timezone
 
-from flask import Blueprint, abort, current_app, jsonify
+from flask import Blueprint, abort, current_app, jsonify, session
 from flask_security import auth_required
 
 from app import SmsCaptureSender
@@ -39,3 +39,16 @@ def popsms():
     if msg:
         return jsonify(sms=msg)
     abort(400)
+
+
+@api.route("/resetfresh", methods=["GET"])
+def resetfresh():
+    # This resets the callers session freshness field - just for testing
+    old_paa = (
+        session["fs_paa"]
+        - current_app.config["SECURITY_FRESHNESS"].total_seconds()
+        - 100
+    )
+    session["fs_paa"] = old_paa
+    session.pop("fs_gexp", None)
+    return jsonify()

--- a/examples/unified_signin/server/app.py
+++ b/examples/unified_signin/server/app.py
@@ -1,5 +1,5 @@
 """
-Copyright 2020-2022 by J. Christopher Wagner (jwag). All rights reserved.
+Copyright 2020-2024 by J. Christopher Wagner (jwag). All rights reserved.
 :license: MIT, see LICENSE for more details.
 
 A simple example of server and client utilizing unified sign in and other
@@ -13,7 +13,6 @@ This example is designed for a JSON and session cookie based client.
 
 """
 
-import datetime
 import os
 
 from flask import Flask
@@ -75,6 +74,8 @@ def create_app():
     # We aren't interested in form-based APIs - so no need for flashing.
     app.config["SECURITY_FLASH_MESSAGES"] = False
 
+    app.config["SECURITY_AUTO_LOGIN_AFTER_CONFIRM"] = True
+
     # Allow signing in with a phone number or email
     app.config["SECURITY_USER_IDENTITY_ATTRIBUTES"] = [
         {"email": {"mapper": uia_email_mapper, "case_insensitive": True}},
@@ -107,12 +108,6 @@ def create_app():
     # have session and remember cookie be samesite (flask/flask_login)
     app.config["REMEMBER_COOKIE_SAMESITE"] = "strict"
     app.config["SESSION_COOKIE_SAMESITE"] = "strict"
-
-    # This means the first 'fresh-required' endpoint after login will always require
-    # re-verification - but after that the grace period will kick in.
-    # This isn't likely something a normal app would need/want to do.
-    app.config["SECURITY_FRESHNESS"] = datetime.timedelta(minutes=0)
-    app.config["SECURITY_FRESHNESS_GRACE_PERIOD"] = datetime.timedelta(minutes=2)
 
     # As of Flask-SQLAlchemy 2.4.0 it is easy to pass in options directly to the
     # underlying engine. This option makes sure that DB connections from the pool

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -332,9 +332,7 @@ def auth_required(
         timedelta.total_seconds() is used for the calculations:
 
             - If > 0, then the caller must have authenticated within the time specified
-              (as measured using the session cookie).
-            - If 0 and not within the grace period (see below) the caller will
-              always be redirected to re-authenticate.
+              (as measured using the session cookie or authentication token).
             - If < 0 (the default) no freshness check is performed.
 
         Note that Basic Auth, by definition, is always 'fresh' and will never result in
@@ -422,8 +420,7 @@ def auth_required(
             for method, mechanism in mechanisms:
                 if mechanism and mechanism():
                     # successfully authenticated. Basic auth is by definition 'fresh'.
-                    # Note that using token auth is ok - but caller still has to pass
-                    # in a session cookie if freshness checking is required.
+                    # If 'within' is set - check for freshness of authentication.
                     if not check_and_update_authn_fresh(within, grace, method):
                         return _security._reauthn_handler(within, grace)
                     if eresponse := handle_csrf(method, _security._want_json(request)):

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -1407,29 +1407,24 @@ def test_no_sms(app, get_message):
     app.security = Security(app, datastore=ds)
 
     with app.app_context():
-        client = app.test_client()
-
         ds.create_user(
             email="trp@lp.com",
             password=hash_password("password"),
         )
         ds.commit()
 
-        data = dict(email="trp@lp.com", password="password")
-        client.post("/login", data=data, follow_redirects=True)
+    client = app.test_client()
+    data = dict(email="trp@lp.com", password="password")
+    client.post("/login", data=data, follow_redirects=True)
 
-        response = client.post(
-            "/tf-setup", data=dict(setup="email"), follow_redirects=True
-        )
-        msg = b"Enter code to complete setup"
-        assert msg in response.data
+    response = client.post("/tf-setup", data=dict(setup="email"), follow_redirects=True)
+    msg = b"Enter code to complete setup"
+    assert msg in response.data
 
-        code = app.mail.outbox[0].body.split()[-1]
-        # submit right token and show appropriate response
-        response = client.post(
-            "/tf-validate", data=dict(code=code), follow_redirects=True
-        )
-        assert b"You successfully changed your two-factor method" in response.data
+    code = app.mail.outbox[0].body.split()[-1]
+    # submit right token and show appropriate response
+    response = client.post("/tf-validate", data=dict(code=code), follow_redirects=True)
+    assert b"You successfully changed your two-factor method" in response.data
 
 
 @pytest.mark.settings(two_factor_post_setup_view="/post_setup_view")


### PR DESCRIPTION
This enables us-setup to be totally functional with auth tokens (not requiring a session cookie).

- Authentication tokens now carry freshness information - namely the timestamp that the client/user successfully authenticated.
- Both sessions and auth tokens place the timestamp into a request global - fs_paa
- @auth_required() freshness checking looks at the request global - a config parameter SECURITY_FRESHNESS_ALLOW_AUTH_TOKEN can be set to False which forces any request using an auth token to be 'not-fresh' (the previous behavior).
- Removed code for freshness 'within' == 0 - which was a hack for testing - we have better testing utilities now.
- fixed/improved example for unified signin.
- doc improvements...