### PR TITLE
Chore - fix tests to run w/o flask_sqlalchemy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,10 +75,10 @@ jobs:
         - name: update pip
           run: |
             python -m pip install -U pip
-        - name: nobabel, nowebauthn, noauthlib, async
+        - name: nobabel, nowebauthn, noauthlib, noflasksqlalchemy, async
           run: |
             pip install tox
-            tox -e nobabel,nowebauthn,noauthlib,async
+            tox -e nobabel,nowebauthn,noauthlib,noflasksqlalchemy,async
   cov:
       runs-on: ubuntu-latest
       steps:

--- a/examples/fsqlalchemy1/tests/test_api.py
+++ b/examples/fsqlalchemy1/tests/test_api.py
@@ -1,4 +1,8 @@
 # Copyright 2019-2022 by J. Christopher Wagner (jwag). All rights reserved.
+# flake8: noqa: F402
+import pytest
+
+pytest.importorskip("flask_sqlalchemy")
 
 from fsqlalchemy1.app import Blog
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1080,6 +1080,7 @@ def test_verifying_token_from_version_4x(app, client):
 
 def test_change_token_uniquifier(app):
     pytest.importorskip("sqlalchemy")
+    pytest.importorskip("flask_sqlalchemy")
 
     # make sure that existing token no longer works once we change the token uniquifier
     from sqlalchemy import Column, String
@@ -1133,6 +1134,7 @@ def test_change_token_uniquifier(app):
 
 def test_null_token_uniquifier(app):
     pytest.importorskip("sqlalchemy")
+    pytest.importorskip("flask_sqlalchemy")
 
     # If existing record has a null fs_token_uniquifier, should be set on first use.
     from sqlalchemy import Column, String

--- a/tests/test_change_email.py
+++ b/tests/test_change_email.py
@@ -47,7 +47,9 @@ def capture_change_email_requests():
 
 
 @pytest.mark.settings(change_email_error_view="/change-email")
-def test_ce(app, client, get_message):
+def test_ce(app, clients, get_message):
+    client = clients
+
     @change_email_confirmed.connect_via(app)
     def _on(app, **kwargs):
         assert kwargs["old_email"] == "matt@lp.com"

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -34,7 +34,8 @@ from tests.test_utils import (
 pytestmark = pytest.mark.changeable()
 
 
-def test_changeable_flag(app, client, get_message):
+def test_changeable_flag(app, clients, get_message):
+    client = clients
     recorded = []
 
     @password_changed.connect_via(app)
@@ -259,6 +260,8 @@ def test_change_invalidates_auth_token(app, client):
 
 
 def test_auth_uniquifier(app):
+    pytest.importorskip("sqlalchemy")
+    pytest.importorskip("flask_sqlalchemy")
     # If add fs_token_uniquifier to user model - change password shouldn't invalidate
     # auth tokens.
     from sqlalchemy import Column, String

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -399,7 +399,7 @@ def test_modify_permissions_multi(app, datastore):
 
 def test_uuid(app, request, tmpdir, realdburl):
     """Test that UUID extension of postgresql works as a primary id for users"""
-    importorskip("sqlalchemy")
+    importorskip("flask_sqlalchemy")
     import uuid
     from flask_sqlalchemy import SQLAlchemy
     from sqlalchemy import Boolean, Column, DateTime, Integer, ForeignKey, String
@@ -592,6 +592,7 @@ def test_mf_recovery_codes(app, datastore):
 
 def test_permissions_fsqla_v2(app):
     importorskip("sqlalchemy")
+    importorskip("flask_sqlalchemy")
     # Make sure folks with fsqla_v2 work with new AsList column type
     from sqlalchemy import insert
     from flask_sqlalchemy import SQLAlchemy
@@ -641,6 +642,7 @@ def test_permissions_fsqla_v2(app):
 
 def test_permissions_41(request, app, realdburl):
     importorskip("sqlalchemy")
+    importorskip("flask_sqlalchemy")
     # Check compatibility with 4.1 DB
     from sqlalchemy import Column, insert
     from flask_sqlalchemy import SQLAlchemy

--- a/tests/test_recovery_codes.py
+++ b/tests/test_recovery_codes.py
@@ -4,7 +4,7 @@
 
     recovery code tests
 
-    :copyright: (c) 2022-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2022-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -24,9 +24,10 @@ pytestmark = pytest.mark.two_factor()
 
 
 @pytest.mark.settings(multi_factor_recovery_codes=True)
-def test_rc_json(app, client, get_message):
+def test_rc_json(app, clients, get_message):
     # Test recovery codes
     # gal has two-factor already setup for 'sms'
+    client = clients
     headers = {"Accept": "application/json", "Content-Type": "application/json"}
     tf_authenticate(app, client)
 

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -517,7 +517,8 @@ def test_form_error(app, client, get_message):
 
 @pytest.mark.settings(username_enable=True)
 @pytest.mark.unified_signin()
-def test_username(app, client, get_message):
+def test_username(app, clients, get_message):
+    client = clients
     data = dict(
         email="dude@lp.com",
         username="dude",

--- a/tests/test_two_factor.py
+++ b/tests/test_two_factor.py
@@ -305,9 +305,10 @@ def test_two_factor_illegal_state(app, client, get_message):
 
 
 @pytest.mark.settings(two_factor_required=True)
-def test_two_factor_flag(app, client, get_message):
+def test_two_factor_flag(app, clients, get_message):
     # trying to verify code without going through two-factor
     # first login function
+    client = clients
     wrong_code = b"000000"
     response = client.post(
         "/tf-validate", data=dict(code=wrong_code), follow_redirects=True
@@ -1113,8 +1114,9 @@ def test_admin_setup_reset(app, client, get_message):
 
 
 @pytest.mark.settings(two_factor_required=True)
-def test_datastore(app, client, get_message):
+def test_datastore(app, clients, get_message):
     # Test that user record is properly set after proper 2FA setup.
+    client = clients
     sms_sender = SmsSenderFactory.createSender("test")
     data = dict(email="gene@lp.com", password="password")
     response = client.post(
@@ -1335,6 +1337,7 @@ def test_bad_sender(app, client, get_message):
 
 def test_replace_send_code(app, get_message):
     pytest.importorskip("sqlalchemy")
+    pytest.importorskip("flask_sqlalchemy")
 
     # replace tf_send_code - and have it return an error to check that.
     from flask_sqlalchemy import SQLAlchemy
@@ -1489,6 +1492,7 @@ def test_setup_nofresh(app, client, get_message):
 @pytest.mark.settings(two_factor_enabled_methods=["email"])
 def test_no_sms(app, get_message):
     pytest.importorskip("sqlalchemy")
+    pytest.importorskip("flask_sqlalchemy")
 
     # Make sure that don't require tf_phone_number if SMS isn't an option.
     from sqlalchemy import (

--- a/tests/test_unified_signin.py
+++ b/tests/test_unified_signin.py
@@ -717,7 +717,8 @@ def test_verify_link_spa(app, client, get_message):
     assert is_authenticated(client, get_message)
 
 
-def test_setup(app, client, get_message):
+def test_setup(app, clients, get_message):
+    client = clients
     set_email(app)
     us_authenticate(client)
     response = client.get("us-setup")
@@ -1005,7 +1006,8 @@ def test_unique_phone(app, client, get_message):
 
 
 @pytest.mark.settings(freshness=timedelta(minutes=0))
-def test_verify(app, client, get_message):
+def test_verify(app, clients, get_message):
+    client = clients
     # Test setup when re-authenticate required
     # With  freshness set to 0 - the first call should require reauth (by
     # redirecting); but the second should work due to grace period.
@@ -1659,6 +1661,7 @@ def test_bad_sender(app, client, get_message):
 @pytest.mark.registerable()
 def test_replace_send_code(app, get_message):
     pytest.importorskip("sqlalchemy")
+    pytest.importorskip("flask_sqlalchemy")
 
     from flask_sqlalchemy import SQLAlchemy
     from flask_security.models import fsqla_v2 as fsqla

--- a/tox.ini
+++ b/tox.ini
@@ -1,4 +1,5 @@
 [tox]
+basepython = python3.11
 envlist =
     py{39,310,311,312,py39}-{low,release}
     mypy
@@ -10,7 +11,7 @@ envlist =
     docs
     coverage
     makedist
-skip_missing_interpreters = true
+skip_missing_interpreters = false
 
 [testenv]
 allowlist_externals = tox
@@ -52,7 +53,6 @@ commands =
     pytest --basetemp={envtmpdir} {posargs:tests}
 
 [testenv:async]
-basepython = python3.11
 deps =
     -r requirements/tests.txt
 commands =
@@ -61,7 +61,6 @@ commands =
     pytest --basetemp={envtmpdir} {posargs:tests}
 
 [testenv:nowebauthn]
-basepython = python3.9
 deps =
     -r requirements/tests.txt
 commands =
@@ -70,7 +69,6 @@ commands =
     pytest --basetemp={envtmpdir} {posargs:tests}
 
 [testenv:nobabel]
-basepython = python3.9
 deps =
     -r requirements/tests.txt
 commands =
@@ -78,7 +76,6 @@ commands =
     pytest --basetemp={envtmpdir} {posargs:tests}
 
 [testenv:noauthlib]
-basepython = python3.9
 deps =
     -r requirements/tests.txt
 commands =
@@ -86,8 +83,15 @@ commands =
     tox -e compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}
 
+[testenv:noflasksqlalchemy]
+deps =
+    -r requirements/tests.txt
+commands =
+    pip uninstall -y flask_sqlalchemy
+    tox -e compile_catalog
+    pytest --basetemp={envtmpdir} {posargs:tests}
+
 [testenv:style]
-basepython = python3.11
 deps = pre-commit
 skip_install = true
 commands =
@@ -95,13 +99,11 @@ commands =
     pre-commit run --all-files --show-diff-on-failure
 
 [testenv:docs]
-basepython = python3.11
 deps = -r requirements/docs.txt
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 
 
 [testenv:coverage]
-basepython = python3.11
 deps =
     -r requirements/tests.txt
 commands =
@@ -119,7 +121,6 @@ commands =
     pytest --basetemp={envtmpdir} {posargs}
 
 [testenv:makedist]
-basepython = python3.11
 deps =
     -r requirements/tests.txt
     build
@@ -132,7 +133,6 @@ commands =
     check-wheel-contents dist
 
 [testenv:mypy]
-basepython = python3.11
 deps =
     -r requirements/tests.txt
     types-setuptools


### PR DESCRIPTION
Also - due to python version mismatch between tox and actions - a bunch of actions were being skipped.

Have more tests run using all available datastores (rather than the normal just flask_sqlalchemy).

A bit of cleanup prior to adding the new flask_sqlalchemy_lite datastore.