### PR TITLE
Add support for Flask-SQLAlchemy-Lite datastore

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Features & Improvements
 - (:issue:`944`) Change default password hash to argon2 (was bcrypt). See below for details.
 - (:pr:`990`) Add freshness capability to auth tokens (enables /us-setup to function w/ just auth tokens).
 - (:pr:`991`) Add support /tf-setup to not require sessions (use a state token).
+- (:issue:`xxx`) Add support for Flask-SQLAlchemy-Lite - including new all-inclusive models
+  that confirm to sqlalchemy latest best-practice (type-annotated).
 
 Fixes
 +++++

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -127,6 +127,10 @@ intersphinx_mapping = {
     "wtforms": ("https://wtforms.readthedocs.io/", None),
     "flask_wtforms": ("https://flask-wtf.readthedocs.io", None),
     "flask_sqlalchemy": ("https://flask-sqlalchemy.palletsprojects.com/", None),
+    "flask_sqlalchemy_lite": (
+        "https://flask-sqlalchemy-lite.readthedocs.io/en/latest/",
+        None,
+    ),
     "flask_login": ("https://flask-login.readthedocs.io/en/latest/", None),
     "passlib": ("https://passlib.readthedocs.io/en/stable", None),
     "authlib": ("https://docs.authlib.org/en/latest/", None),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -49,6 +49,7 @@ extensions out of the box for data persistence:
 3. `Peewee Flask utils <https://docs.peewee-orm.com/en/latest/peewee/playhouse.html#flask-utils>`_
 4. `PonyORM <https://pypi.python.org/pypi/pony/>`_ - NOTE: not currently working - Help needed!.
 5. `SQLAlchemy sessions <https://docs.sqlalchemy.org/en/20/orm/session_basics.html>`_
+6. `Flask-SQLAlchemy-Lite <https://pypi.python.org/pypi/flask-sqlalchemy-lite/>`_
 
 
 Getting Started

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -22,6 +22,7 @@ from .core import (
     current_user,
 )
 from .datastore import (
+    FSQLALiteUserDatastore,
     UserDatastore,
     SQLAlchemyUserDatastore,
     AsaList,

--- a/flask_security/models/sqla.py
+++ b/flask_security/models/sqla.py
@@ -1,0 +1,221 @@
+"""
+Copyright 2024-2024 by J. Christopher Wagner (jwag). All rights reserved.
+:license: MIT, see LICENSE for more details.
+
+
+Complete models for all features when using SqlAlchemy.
+These are pure sqlalchemy declarative models - so should work with Flask-SQLAlchemy-Lite
+as well as just sqlalchemy (such as using a scoped session).
+
+You can change the table names by passing them in to the set_db_info() method.
+
+BE AWARE: Once any version of this is shipped no changes can be made - instead
+a new version needs to be created.
+"""
+
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy import (
+    Column,
+    LargeBinary,
+    String,
+    Table,
+    Text,
+    ForeignKey,
+)
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.ext.mutable import MutableList
+from sqlalchemy.sql import func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from flask_security import AsaList, RoleMixin, UserMixin, WebAuthnMixin, naive_utcnow
+
+
+class FsModels:
+    """
+    Helper class for model mixins.
+    """
+
+    roles_users = None
+    fs_model_version = 1
+    base_model: DeclarativeBase
+    user_table_name = "user"
+    role_table_name = "role"
+    webauthn_table_name = "webauthn"
+
+    @classmethod
+    def set_db_info(
+        cls,
+        *,
+        base_model,
+        user_table_name="user",
+        role_table_name="role",
+        webauthn_table_name="webauthn",
+    ):
+        """Initialize Model.
+        This MUST be called PRIOR to declaring your User/Role/WebAuthn model in order
+        for table name altering to work.
+
+        .. note::
+            This should only be used if you are utilizing the sqla data
+            models. With your own models you would need similar but slightly
+            different code.
+        """
+        cls.base_model = base_model
+        cls.user_table_name = user_table_name
+        cls.role_table_name = role_table_name
+        cls.webauthn_table_name = webauthn_table_name
+        cls.roles_users = Table(
+            "roles_users",
+            cls.base_model.metadata,
+            Column(
+                "user_id", ForeignKey(f"{cls.user_table_name}.id"), primary_key=True
+            ),
+            Column(
+                "role_id", ForeignKey(f"{cls.role_table_name}.id"), primary_key=True
+            ),
+        )
+
+
+class FsRoleMixin(RoleMixin):
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column(String(80), unique=True)
+    description: Mapped[str | None] = mapped_column(String(255))
+    # A comma separated list of strings
+    permissions: Mapped[list[str] | None] = mapped_column(  # type: ignore[assignment]
+        MutableList.as_mutable(AsaList()),
+    )
+    update_datetime: Mapped[datetime.datetime] = mapped_column(
+        server_default=func.now(),
+        onupdate=naive_utcnow,
+    )
+
+    @declared_attr
+    def users(cls):
+        return relationship(
+            "User",
+            secondary="roles_users",
+            back_populates="roles",
+        )
+
+
+class FsUserMixin(UserMixin):
+    """User information"""
+
+    # flask_security basic fields
+    id: Mapped[int] = mapped_column(primary_key=True)
+    email: Mapped[str] = mapped_column(String(255), unique=True)
+    # Make username unique but not required.
+    username: Mapped[str | None] = mapped_column(String(255), unique=True)
+    # Change password to nullable so we can tell after registration whether
+    # a user has a password or not.
+    password: Mapped[str | None] = mapped_column(String(255))
+    active: Mapped[bool] = mapped_column()
+
+    # Flask-Security user identifier
+    fs_uniquifier: Mapped[str] = mapped_column(String(64), unique=True)
+
+    # confirmable
+    confirmed_at: Mapped[datetime.datetime | None] = mapped_column()
+
+    # trackable
+    last_login_at: Mapped[datetime.datetime | None] = mapped_column()
+    current_login_at: Mapped[datetime.datetime | None] = mapped_column()
+    last_login_ip: Mapped[str | None] = mapped_column(String(64))
+    current_login_ip: Mapped[str | None] = mapped_column(String(64))
+    login_count: Mapped[int | None] = mapped_column()
+
+    # 2FA
+    tf_primary_method: Mapped[str | None] = mapped_column(String(64))
+    tf_totp_secret: Mapped[str | None] = mapped_column(String(255))
+    tf_phone_number: Mapped[str | None] = mapped_column(String(128))
+
+    # unified sign in
+    us_totp_secrets: Mapped[str | None] = mapped_column(Text)
+    # since phone can be used to authenticate - must be unique.
+    us_phone_number: Mapped[str | None] = mapped_column(String(128), unique=True)
+
+    try:
+        import webauthn as webauthn_pkg
+
+        # List of WebAuthn registrations
+        @declared_attr
+        def webauthn(cls):
+            return relationship(
+                "WebAuthn", back_populates="user", cascade="all, delete"
+            )
+
+    except ImportError:  # pragma: no cover
+        pass
+
+    # The user handle as required during registration.
+    # Note max length 64 as specified in spec.
+    fs_webauthn_user_handle: Mapped[str | None] = mapped_column(String(64), unique=True)
+
+    # MFA - one time recovery codes - comma separated.
+    mf_recovery_codes: Mapped[list[str] | None] = mapped_column(
+        MutableList.as_mutable(AsaList())
+    )
+
+    @declared_attr
+    def roles(cls):
+        # The first arg is a class name, the backref is a column name
+        return relationship(
+            "Role",
+            secondary="roles_users",
+            back_populates="users",
+        )
+
+    create_datetime: Mapped[datetime.datetime] = mapped_column(
+        server_default=func.now()
+    )
+    update_datetime: Mapped[datetime.datetime] = mapped_column(
+        server_default=func.now(),
+        onupdate=naive_utcnow,
+    )
+
+
+class FsWebAuthnMixin(WebAuthnMixin):
+    """WebAuthn"""
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    credential_id: Mapped[bytes] = mapped_column(
+        LargeBinary(1024), index=True, unique=True
+    )
+    public_key: Mapped[bytes] = mapped_column(LargeBinary)
+    sign_count: Mapped[int | None] = mapped_column(default=0)
+    transports: Mapped[list[str] | None] = mapped_column(
+        MutableList.as_mutable(AsaList())
+    )
+    backup_state: Mapped[bool] = mapped_column()  # Upcoming post V3 spec
+    device_type: Mapped[str] = mapped_column(String(64))
+
+    # a JSON string as returned from registration
+    extensions: Mapped[str | None] = mapped_column(String(255))
+    create_datetime: Mapped[datetime.datetime] = mapped_column(
+        server_default=func.now()
+    )
+    lastuse_datetime: Mapped[datetime.datetime] = mapped_column()
+    # name is provided by user - we make sure is unique per user
+    name: Mapped[str] = mapped_column(String(64))
+
+    # Usage - a credential can EITHER be for first factor or secondary factor
+    usage: Mapped[str] = mapped_column(String(64))
+
+    try:
+        import webauthn as webauthn_pkg
+
+        @declared_attr
+        def user(cls):
+            return relationship("User", back_populates="webauthn")
+
+    except ImportError:  # pragma: no cover
+        pass
+
+    @declared_attr
+    def user_id(cls) -> Mapped[int]:
+        return mapped_column(
+            ForeignKey(f"{FsModels.user_table_name}.id", ondelete="CASCADE")
+        )

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
-plugins = sqlalchemy.ext.mypy.plugin
 
 pretty = True
 show_error_codes = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,8 @@ dynamic = [
 ]
 dependencies = [
     # flask dependencies include werkzeug, jinja2, itsdangerous, click, blinker
-    "Flask>=2.3.2",
-    "Flask-Login>=0.6.2",
+    "Flask>=3.0.0",
+    "Flask-Login>=0.6.3",
     "Flask-Principal>=0.4.0",
     "Flask-WTF>=1.1.2",
     "email-validator>=2.0.0",
@@ -53,16 +53,17 @@ dependencies = [
 
 [project.optional-dependencies]
 babel = ["babel>=2.12.1", "flask_babel>=3.1.0"]
-fsqla = ["flask_sqlalchemy>=3.0.3", "sqlalchemy>=2.0.12", "sqlalchemy-utils>=0.41.1"]
+fsqla = ["flask_sqlalchemy>=3.1.0", "sqlalchemy>=2.0.18", "sqlalchemy-utils>=0.41.1"]
 common = ["argon2_cffi>=21.3.0", "bcrypt>=4.0.1", "flask_mailman>=0.3.0", "bleach>=6.0.0"]
 mfa = ["cryptography>=40.0.2", "qrcode>=7.4.2", "phonenumberslite>=8.13.11", "webauthn>=2.0.0"]
 low = [
     # Lowest supported versions
-    "Flask==2.3.2",
-    "Flask-SQLAlchemy==3.0.3",
+    "Flask==3.0.0",
+    "Flask-SQLAlchemy==3.1.0",
+    "Flask-SQLAlchemy-Lite==0.1.0;python_version>='3.10'",
     "Flask-Babel==3.1.0",
     "Flask-Mailman==0.3.0",
-    "Flask-Login==0.6.2",
+    "Flask-Login==0.6.3",
     "Flask-WTF==1.1.2",
     "peewee==3.16.2",
     "argon2_cffi==21.3.0",
@@ -83,10 +84,10 @@ low = [
     "requests",
     # passlib required setuptools
     "setuptools",
-    "sqlalchemy==2.0.12",
+    "sqlalchemy==2.0.18",
     "sqlalchemy-utils==0.41.1",
     "webauthn==2.0.0",
-    "werkzeug==2.3.3",
+    "werkzeug==3.0.1",
     "zxcvbn==4.4.28"
 ]
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,7 +7,7 @@ psycopg2-binary
 pymysql
 pre-commit
 tox
-sqlalchemy[mypy]
+sqlalchemy
 types-requests
 
 # for dev - might not install Flask-Security - list those dependencies here

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -5,6 +5,7 @@ Flask-Mailman
 Flask-Principal
 peewee; python_version < '3.12'
 Flask-SQLAlchemy
+Flask-SQLAlchemy-Lite; python_version >= '3.10'
 argon2-cffi
 authlib
 bcrypt

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -201,9 +201,7 @@ def test_expired_confirmation_token(client, get_message):
 
 
 @pytest.mark.registerable()
-def test_email_conflict_for_confirmation_token(
-    app, client, get_message, sqlalchemy_datastore
-):
+def test_email_conflict_for_confirmation_token(app, client, get_message):
     with capture_registrations() as registrations:
         data = dict(email="mary@lp.com", password="awesome sunset", next="")
         client.post("/register", data=data, follow_redirects=True)
@@ -214,8 +212,8 @@ def test_email_conflict_for_confirmation_token(
     # Change the user's email
     user.email = "tom@lp.com"
     with app.app_context():
-        sqlalchemy_datastore.put(user)
-        sqlalchemy_datastore.commit()
+        app.security.datastore.put(user)
+        app.security.datastore.commit()
 
     response = client.get("/confirm/" + token, follow_redirects=True)
     msg = get_message("INVALID_CONFIRMATION_TOKEN")

--- a/tests/test_recoverable.py
+++ b/tests/test_recoverable.py
@@ -354,7 +354,7 @@ def test_bad_reset_token(client, get_message):
     assert get_message("INVALID_RESET_PASSWORD_TOKEN") in response.data
 
 
-def test_reset_token_deleted_user(app, client, get_message, sqlalchemy_datastore):
+def test_reset_token_deleted_user(app, client, get_message):
     with capture_reset_password_requests() as requests:
         client.post("/reset", data=dict(email="gene@lp.com"), follow_redirects=True)
 
@@ -364,8 +364,8 @@ def test_reset_token_deleted_user(app, client, get_message, sqlalchemy_datastore
     with app.app_context():
         # load user (and role) to get into session so cascade delete works.
         user = app.security.datastore.find_user(email="gene@lp.com")
-        sqlalchemy_datastore.delete(user)
-        sqlalchemy_datastore.commit()
+        app.security.datastore.delete(user)
+        app.security.datastore.commit()
 
     response = client.post(
         "/reset/" + token,

--- a/tox.ini
+++ b/tox.ini
@@ -87,7 +87,7 @@ commands =
 deps =
     -r requirements/tests.txt
 commands =
-    pip uninstall -y flask_sqlalchemy
+    pip uninstall -y flask_sqlalchemy flask_sqlalchemy_lite
     tox -e compile_catalog
     pytest --basetemp={envtmpdir} {posargs:tests}
 


### PR DESCRIPTION
- This introduces new pre-configured models that use 'modern' sqlalchemy type annotations
- The querying is done using the 2.0 select() mechanism (rather than the old query interface)
- Enhance view_scaffold test harness to work with either Flask-SQLAlchemy or Flask-SQLAlchemy-Lite
- FS-Lite requires newer Flask/Werkzeug - bump up lowest tested versions
- per sqlalchemy best practice - don't install mypy extension or stubs

close #989