### PR TITLE
Use 'modern' query for all sqlalchemy datastores

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,20 +14,24 @@ Features & Improvements
 - (:issue:`944`) Change default password hash to argon2 (was bcrypt). See below for details.
 - (:pr:`990`) Add freshness capability to auth tokens (enables /us-setup to function w/ just auth tokens).
 - (:pr:`991`) Add support /tf-setup to not require sessions (use a state token).
-- (:issue:`xxx`) Add support for Flask-SQLAlchemy-Lite - including new all-inclusive models
-  that confirm to sqlalchemy latest best-practice (type-annotated).
+- (:issue:`994`) Add support for Flask-SQLAlchemy-Lite - including new all-inclusive models
+  that conform to sqlalchemy latest best-practice (type-annotated).
+- (:pr:`xxx`) Convert other sqlalchemy-based datastores from legacy 'model.query' to best-practice 'select'
 
 Fixes
 +++++
 - (:pr:`972`) Set :py:data:`SECURITY_CSRF_COOKIE` at beginning (GET /login) of authentication
   ritual - just as we return the CSRF token. (thanks @e-goto)
 - (:issue:`973`) login and unified sign in should handle GET for authenticated user consistently.
+- (:pr:`995`) Don't show sms options if not defined in US_ENABLED_METHODS. (fredipevcin)
 
 Docs and Chores
 +++++++++++++++
 - (:pr:`979`) Update Russian translations (ademaro)
-- (:pr:`981` and :pr:`956`) Improve docs
-- (:pr:`xx`) The long deprecated `get_token_status` is no longer exported
+- (:pr:`1004`) Update ES and IT translations (gissimo)
+- (:pr:`981` and :pr:`977`) Improve docs
+- (:pr:`992`) The long deprecated `get_token_status` is no longer exported
+- (:pr:`992`) Drop Python 3.8 support.
 
 Backwards Compatibility Concerns
 +++++++++++++++++++++++++++++++++
@@ -38,6 +42,10 @@ Backwards Compatibility Concerns
 - Changes to /tf-setup
     The old path - using state set in the session still works as before. The new path is
     just for the case an authenticated user wants to change their 2FA setup.
+- Changes to sqlalchemy-based datastores
+    Flask-Security no longer uses the legacy model.query - all DB access is done via
+    `select(xx).where(xx)`. As a result the find_user() method now only takes a SINGLE
+    column:value from its kwargs - in prior releases all kwargs were passed into the query.filter.
 
 Version 5.4.3
 -------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -65,6 +65,9 @@ Datastores
 .. autoclass:: flask_security.SQLAlchemyUserDatastore
     :show-inheritance:
 
+.. autoclass:: flask_security.FSQLALiteUserDatastore
+    :show-inheritance:
+
 .. autoclass:: flask_security.SQLAlchemySessionUserDatastore
     :show-inheritance:
 
@@ -111,6 +114,8 @@ Datastores
 Packaged Models
 ---------------
 .. autoclass:: flask_security.models.fsqla.FsModels
+   :members:
+.. autoclass:: flask_security.models.sqla.FsModels
    :members:
 
 Utils

--- a/docs/models.rst
+++ b/docs/models.rst
@@ -52,6 +52,9 @@ Your application code should import just the required version e.g.::
 A single method ``sqla.FsModels.set_db_info`` is provided to glue the supplied mixins to your
 models. This is only needed if you use the packaged models.
 
+.. note::
+    This model requires Python >= 3.10.
+
 Model Specification
 -------------------
 
@@ -61,7 +64,7 @@ foreign relationship between `User` and `Role`. The `WebAuthn` model also
 references this primary key (which can be overridden by providing a
 suitable implementation of :py:meth:`flask_security.WebAuthnMixin.get_user_mapping`).
 
-At the bare minimum your `User` and `Role` model should include the following fields:
+At the bare minimum your `User` and `Role` model must include the following fields:
 
 **User**
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,7 @@ import tempfile
 import time
 import typing as t
 from datetime import datetime
+import sys
 from urllib.parse import urlsplit
 
 from passlib.ifc import PasswordHash
@@ -46,7 +47,6 @@ from flask_security import (
     auth_token_required,
     http_auth_required,
     get_request_attr,
-    naive_utcnow,
     roles_accepted,
     roles_required,
     permissions_accepted,
@@ -564,6 +564,8 @@ def fsqlalite_setup(request, app, tmpdir, realdburl):
 
 @pytest.fixture()
 def sqlalchemy_session_datastore(request, app, tmpdir, realdburl):
+    if sys.version_info < (3, 10):
+        pytest.skip("requires python3.10 or higher")
     return sqlalchemy_session_setup(request, app, tmpdir, realdburl)
 
 
@@ -574,78 +576,48 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl, **engine_kwargs):
     pytest.importorskip("sqlalchemy")
     from sqlalchemy import create_engine
     from sqlalchemy.orm import (
+        mapped_column,
         scoped_session,
         sessionmaker,
-        relationship,
-        backref,
         declarative_base,
     )
     from sqlalchemy.ext.declarative import declared_attr
-    from sqlalchemy.ext.mutable import MutableList
-    from sqlalchemy.sql import func
     from sqlalchemy import (
-        Boolean,
-        DateTime,
         Column,
         Integer,
-        LargeBinary,
-        String,
-        Text,
         ForeignKey,
     )
-    from flask_security import AsaList
+    from flask_security.models import sqla as sqla
 
-    f, path = tempfile.mkstemp(
-        prefix="flask-security-test-db", suffix=".db", dir=str(tmpdir)
-    )
+    if realdburl:
+        db_url, db_info = _setup_realdb(realdburl)
+        engine = db_info["engine"]
+    else:
+        db_url = "sqlite:///:memory:"
+        engine = create_engine(db_url, **engine_kwargs)
 
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///" + path
-
-    engine = create_engine(app.config["SQLALCHEMY_DATABASE_URI"], **engine_kwargs)
     db_session = scoped_session(
         sessionmaker(autocommit=False, autoflush=False, bind=engine)
     )
     app.teardown_appcontext(lambda exc: db_session.close())
     Base = declarative_base()
-    Base.query = db_session.query_property()
+    # Note that in this case we don't call set_db_info since we are using
+    # normal table names AND we need our own RolesUsers table since we modified the
+    # PK names.
 
-    class WebAuthn(Base, WebAuthnMixin):
+    class WebAuthn(Base, sqla.FsWebAuthnMixin):
         __tablename__ = "webauthn"
 
-        id = Column(Integer, primary_key=True)
-        credential_id = Column(
-            LargeBinary(1024), index=True, unique=True, nullable=False
-        )
-        public_key = Column(LargeBinary, nullable=False)
-        sign_count = Column(Integer, default=0)
-        transports = Column(MutableList.as_mutable(AsaList()), nullable=True)
-
-        # a JSON string as returned from registration
-        extensions = Column(String(255), nullable=True)
-        create_datetime = Column(
-            type_=DateTime, nullable=False, server_default=func.now()
-        )
-        lastuse_datetime = Column(type_=DateTime, nullable=False)
-        # name is provided by user - we make sure is unique per user
-        name = Column(String(64), nullable=False)
-        usage = Column(String(64), nullable=False)
-        backup_state = Column(Boolean, nullable=False)  # Upcoming post V3 spec
-        device_type = Column(String(64), nullable=False)
-
         @declared_attr
-        def myuser_id(cls):
-            return Column(
-                Integer,
-                ForeignKey("user.myuserid", ondelete="CASCADE"),
-                nullable=False,
-            )
+        def user_id(self) -> Mapped[int]:
+            return mapped_column(ForeignKey("user.myuserid", ondelete="CASCADE"))
 
         def get_user_mapping(self) -> dict[str, t.Any]:
             """
             Return the filter needed by find_user() to get the user
             associated with this webauthn credential.
             """
-            return dict(myuserid=self.myuser_id)
+            return dict(myuserid=self.user_id)
 
     class RolesUsers(Base):
         __tablename__ = "roles_users"
@@ -653,56 +625,18 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl, **engine_kwargs):
         user_id = Column("user_id", Integer(), ForeignKey("user.myuserid"))
         role_id = Column("role_id", Integer(), ForeignKey("role.myroleid"))
 
-    class Role(Base, RoleMixin):
+    class Role(Base, sqla.FsRoleMixin):
         __tablename__ = "role"
-        myroleid = Column(Integer(), primary_key=True)
-        name = Column(String(80), unique=True)
-        description = Column(String(255))
-        permissions = Column(MutableList.as_mutable(AsaList()), nullable=True)
-        update_datetime = Column(
-            DateTime,
-            nullable=False,
-            server_default=func.now(),
-            onupdate=naive_utcnow,
-        )
+        myroleid: Mapped[int] = mapped_column(primary_key=True)  # type: ignore
+        id: Mapped[int] = mapped_column(nullable=True)  # type: ignore
 
-    class User(Base, UserMixin):
+    class User(Base, sqla.FsUserMixin):
         __tablename__ = "user"
-        myuserid = Column(Integer, primary_key=True)
-        fs_uniquifier = Column(String(64), unique=True, nullable=False)
-        fs_webauthn_user_handle = Column(String(64), unique=True, nullable=True)
-        email = Column(String(255), unique=True)
-        username = Column(String(255), unique=True, nullable=True)
-        password = Column(String(255))
-        security_number = Column(Integer, unique=True)
-        last_login_at = Column(DateTime())
-        current_login_at = Column(DateTime())
-        tf_primary_method = Column(String(255), nullable=True)
-        tf_totp_secret = Column(String(255), nullable=True)
-        tf_phone_number = Column(String(255), nullable=True)
-        mf_recovery_codes = Column(MutableList.as_mutable(AsaList()), nullable=True)
-        us_totp_secrets = Column(Text, nullable=True)
-        us_phone_number = Column(String(64), nullable=True, unique=True)
-        last_login_ip = Column(String(100))
-        current_login_ip = Column(String(100))
-        login_count = Column(Integer)
-        active = Column(Boolean())
-        confirmed_at = Column(DateTime())
-        roles = relationship(
-            "Role",
-            secondary="roles_users",
-            backref=backref("users", lazy="dynamic", cascade_backrefs=False),
+        myuserid: Mapped[int] = mapped_column(primary_key=True)  # type: ignore
+        id: Mapped[int] = mapped_column(nullable=True)  # type: ignore
+        security_number: Mapped[t.Optional[int]] = mapped_column(  # type: ignore
+            unique=True
         )
-        update_datetime = Column(
-            DateTime,
-            nullable=False,
-            server_default=func.now(),
-            onupdate=naive_utcnow,
-        )
-
-        @declared_attr
-        def webauthn(cls):
-            return relationship("WebAuthn", backref="users", cascade="all, delete")
 
         def get_security_payload(self):
             # Make sure we still properly hook up to flask's JSON extension
@@ -713,9 +647,10 @@ def sqlalchemy_session_setup(request, app, tmpdir, realdburl, **engine_kwargs):
         Base.metadata.create_all(bind=engine)
 
     def tear_down():
-        db_session.close()
-        os.close(f)
-        os.remove(path)
+        with app.app_context():
+            Base.metadata.drop_all(bind=engine)
+            if realdburl:
+                _teardown_realdb(db_info)
 
     request.addfinalizer(tear_down)
 
@@ -1002,11 +937,21 @@ def client_nc(request, sqlalchemy_app):
     return app.test_client(use_cookies=False)
 
 
-@pytest.fixture(params=["cl-sqlalchemy", "c2", "cl-mongo", "cl-peewee", "cl-fsqlalite"])
+@pytest.fixture(
+    params=[
+        "cl-fsqlalchemy",
+        "cl-sqla-session",
+        "cl-mongo",
+        "cl-peewee",
+        "cl-fsqlalite",
+    ]
+)
 def clients(request, app, tmpdir, realdburl, realmongodburl):
-    if request.param == "cl-sqlalchemy":
+    if request.param == "cl-fsqlalchemy":
         ds = sqlalchemy_setup(request, app, tmpdir, realdburl)
-    elif request.param == "c2":
+    elif request.param == "cl-sqla-session":
+        if sys.version_info < (3, 10):
+            pytest.skip("requires python3.10 or higher")
         ds = sqlalchemy_session_setup(request, app, tmpdir, realdburl)
     elif request.param == "cl-mongo":
         ds = mongoengine_setup(request, app, tmpdir, realmongodburl)
@@ -1064,6 +1009,8 @@ def datastore(request, app, tmpdir, realdburl, realmongodburl):
     if request.param == "sqlalchemy":
         rv = sqlalchemy_setup(request, app, tmpdir, realdburl)
     elif request.param == "sqlalchemy-session":
+        if sys.version_info < (3, 10):
+            pytest.skip("requires python3.10 or higher")
         rv = sqlalchemy_session_setup(request, app, tmpdir, realdburl)
     elif request.param == "mongoengine":
         rv = mongoengine_setup(request, app, tmpdir, realmongodburl)

--- a/tests/test_datastore.py
+++ b/tests/test_datastore.py
@@ -9,8 +9,9 @@
     :license: MIT, see LICENSE for more details.
 """
 
+import pytest
 from pytest import raises, skip, importorskip
-from tests.test_utils import init_app_with_options, get_num_queries, is_sqlalchemy
+from tests.test_utils import init_app_with_options, capture_queries
 
 from flask_security import (
     RoleMixin,
@@ -97,31 +98,42 @@ def test_activate_returns_false_if_already_true():
     assert not datastore.activate_user(user)
 
 
-def test_find_user(app, datastore):
-    init_app_with_options(app, datastore)
+@pytest.mark.parametrize(
+    "ds",
+    ["sqlalchemy_datastore", "fsqlalite_datastore", "sqlalchemy_session_datastore"],
+)
+def test_find_user(request, app, ds):
+    ds = request.getfixturevalue(ds)
+    init_app_with_options(app, ds)
 
     with app.app_context():
-        user_id = datastore.find_user(email="gene@lp.com").fs_uniquifier
+        user_id = ds.find_user(email="gene@lp.com").fs_uniquifier
 
-        current_nqueries = get_num_queries(datastore)
-        assert user_id == datastore.find_user(security_number=889900).fs_uniquifier
-        end_nqueries = get_num_queries(datastore)
-        if current_nqueries is not None:
-            if is_sqlalchemy(datastore):
-                # This should have done just 1 query across all attrs.
-                assert end_nqueries == (current_nqueries + 1)
+        with capture_queries(ds) as queries:
+            assert user_id == ds.find_user(security_number=889900).fs_uniquifier
+        assert len(queries) == 1
+        assert queries[0].is_select
 
-        assert user_id == datastore.find_user(username="gene").fs_uniquifier
+        assert user_id == ds.find_user(username="gene").fs_uniquifier
 
 
-def test_find_user_multikey(app, datastore):
-    init_app_with_options(app, datastore)
+@pytest.mark.parametrize(
+    "ds",
+    ["sqlalchemy_datastore", "fsqlalite_datastore", "sqlalchemy_session_datastore"],
+)
+@pytest.mark.settings(join_user_roles=False)
+def test_find_user_no_joined_load(request, app, ds):
+    ds = request.getfixturevalue(ds)
+    init_app_with_options(app, ds)
 
     with app.app_context():
-        with raises(ValueError):
-            datastore.find_user(
-                case_insensitive=True, email="gene@lp.com", security_number=889900
-            )
+        with capture_queries(ds) as queries:
+            user = ds.find_user(security_number=889900)
+            assert len(user.roles) == 1
+        assert len(queries) == 2
+        assert queries[0].is_select
+        assert queries[0].statement.column_descriptions[0]["name"] == "User"
+        assert queries[1].statement.column_descriptions[0]["name"] == "Role"
 
 
 def test_find_role(app, datastore):
@@ -151,23 +163,25 @@ def test_add_role_to_user(app, datastore):
         assert datastore.remove_role_from_user(user, "editor") is False
 
 
-def test_create_user_with_roles(app, datastore):
-    init_app_with_options(app, datastore)
+@pytest.mark.parametrize(
+    "ds",
+    ["sqlalchemy_datastore", "fsqlalite_datastore", "sqlalchemy_session_datastore"],
+)
+def test_create_user_with_roles(request, app, ds):
+    ds = request.getfixturevalue(ds)
+    init_app_with_options(app, ds)
 
     with app.app_context():
-        role = datastore.find_role("admin")
-        datastore.commit()
-
-        user = datastore.create_user(
+        role = ds.find_role("admin")
+        user = ds.create_user(
             email="dude@lp.com", username="dude", password="password", roles=[role]
         )
-        datastore.commit()
-        current_nqueries = get_num_queries(datastore)
-        user = datastore.find_user(email="dude@lp.com")
-        assert user.has_role("admin") is True
-        end_nqueries = get_num_queries(datastore)
-        # Verify that getting user and role is just one DB query
-        assert current_nqueries is None or end_nqueries == (current_nqueries + 1)
+        ds.commit()
+        with capture_queries(ds) as queries:
+            user = ds.find_user(email="dude@lp.com")
+            assert user.has_role("admin") is True
+        assert len(queries) == 1
+        assert queries[0].is_select
 
 
 def test_create_user_no_side_effects(app, datastore):


### PR DESCRIPTION
Stop using the model.query and convert to select(xx).where(yy) as recommended in sqlalchemy 2. All 3 sqlalchemy based datastores now share a common implementation.

the sqlalchemy_session datastore tests now use the new sqla models.

Update docs to note that using FsModels.sqla requires pythin 3.10 or higher.

To simplify code - the find_user() method now takes a single kwarg (attribute:value) for selecting - that is all FS ever used so supporting multiple added complexity.

Added a new low-level way to capture queries during unit tests - converted all tests to use that.