### PR TITLE
Try a different approach to typing datastores.

### DIFF
--- a/docs/models.rst
+++ b/docs/models.rst
@@ -12,6 +12,20 @@ and `Role` data model. The fields on your models must follow a particular conven
 depending on the functionality your app requires. Aside from this, you're free
 to add any additional fields to your model(s) if you want.
 
+.. note::
+    The User, Role, and WebAuthn models MUST subclass their respective mixin (along
+    with any other mixin the datastore requires). The pre-packaged models described
+    below do this for you.
+
+    .. code-block:: python
+
+        from flask_security import UserMixin, RoleMixin, WebAuthMixin
+
+        class User(<db specific base>, UserMixin):
+            ... define columns here
+
+        ... same for Role and WebAuthn
+
 Packaged Models
 ----------------
 As more features are added to Flask-Security, the list of required fields and tables grow.
@@ -38,6 +52,18 @@ Flask-SQLAlchemy
 Your application code should import just the required version e.g.::
 
     from flask_security.models import fsqla_v3 as fsqla
+    from flask_sqlalchemy import SQLAlchemy
+
+    db = SQLAlchemy(app)
+
+    # Define models
+    fsqla.FsModels.set_db_info(db)
+
+    class Role(db.Model, fsqla.FsRoleMixin):
+        pass
+
+    class User(db.Model, fsqla.FsUserMixin):
+        pass
 
 
 A single method ``fsqla.FsModels.set_db_info`` is provided to glue the supplied models to your
@@ -48,6 +74,24 @@ Flask-SQLAlchemy-Lite
 Your application code should import just the required version e.g.::
 
     from flask_security.models import sqla as sqla
+    from flask_sqlalchemy_lite import SQLAlchemy
+
+    db = SQLAlchemy(app)
+
+    # Define models
+    class Model(DeclarativeBase):
+        pass
+
+    # NOTE: call this PRIOR to declaring models
+    sqla.FsModels.set_db_info(base_model=Model)
+
+    class Role(Model, sqla.FsRoleMixin):
+        __tablename__ = "Role"
+        pass
+
+    class User(Model, sqla.FsUserMixin):
+        __tablename__ = "User"
+        pass
 
 A single method ``sqla.FsModels.set_db_info`` is provided to glue the supplied mixins to your
 models. This is only needed if you use the packaged models.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -55,9 +55,9 @@ Flask-SQLAlchemy Application
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following code sample illustrates how to get started as quickly as
-possible using Flask-SQLAlchemy and the built-in model mixins:
+possible using Flask-SQLAlchemy and the built-in model mixins.
 
-::
+.. code-block:: python
 
     import os
 
@@ -104,7 +104,7 @@ possible using Flask-SQLAlchemy and the built-in model mixins:
 
     # Setup Flask-Security
     user_datastore = SQLAlchemyUserDatastore(db, User, Role)
-    app.security = Security(app, user_datastore)
+    security = Security(app, user_datastore)
 
     # Views
     @app.route("/")
@@ -116,8 +116,8 @@ possible using Flask-SQLAlchemy and the built-in model mixins:
     with app.app_context():
         # Create User to test with
         db.create_all()
-        if not app.security.datastore.find_user(email="test@me.com"):
-            app.security.datastore.create_user(email="test@me.com", password=hash_password("password"))
+        if not security.datastore.find_user(email="test@me.com"):
+            security.datastore.create_user(email="test@me.com", password=hash_password("password"))
         db.session.commit()
 
     if __name__ == '__main__':
@@ -154,7 +154,7 @@ Note that Flask-SQLAlchemy-Lite is a very thin wrapper above sqlalchemy.orm
 and just provides session and engine initialization. Everything else is
 pure sqlalchemy (unlike Flask-SQLAlchemy).
 
-::
+.. code-block:: python
 
     import os
 
@@ -203,7 +203,7 @@ pure sqlalchemy (unlike Flask-SQLAlchemy).
 
     # Setup Flask-Security
     user_datastore = FSQLALiteUserDatastore(db, User, Role)
-    app.security = Security(app, user_datastore)
+    security = Security(app, user_datastore)
 
     # Views
     @app.route("/")
@@ -215,8 +215,8 @@ pure sqlalchemy (unlike Flask-SQLAlchemy).
     with app.app_context():
         # Create User to test with
         Model.metadata.create_all(db.engine)
-        if not app.security.datastore.find_user(email="test@me.com"):
-            app.security.datastore.create_user(email="test@me.com", password=hash_password("password"))
+        if not security.datastore.find_user(email="test@me.com"):
+            security.datastore.create_user(email="test@me.com", password=hash_password("password"))
         db.session.commit()
 
     if __name__ == '__main__':
@@ -254,97 +254,100 @@ possible using `SQLAlchemy in a declarative way
 This example shows how to split your application into 3 files: app.py, database.py
 and models.py.
 
-- app.py ::
+- app.py
+    .. code-block:: python
 
-    import os
+        import os
 
-    from flask import Flask, render_template_string
-    from flask_security import Security, current_user, auth_required, hash_password, \
-         SQLAlchemySessionUserDatastore, permissions_accepted
-    from database import db_session, init_db
-    from models import User, Role
+        from flask import Flask, render_template_string
+        from flask_security import Security, current_user, auth_required, hash_password, \
+             SQLAlchemySessionUserDatastore, permissions_accepted
+        from database import db_session, init_db
+        from models import User, Role
 
-    # Create app
-    app = Flask(__name__)
-    app.config['DEBUG'] = True
+        # Create app
+        app = Flask(__name__)
+        app.config['DEBUG'] = True
 
-    # Generate a nice key using secrets.token_urlsafe()
-    app.config['SECRET_KEY'] = os.environ.get("SECRET_KEY", 'pf9Wkove4IKEAXvy-cQkeDPhv9Cb3Ag-wyJILbq_dFw')
-    # Generate a good salt for password hashing using: secrets.SystemRandom().getrandbits(128)
-    app.config['SECURITY_PASSWORD_SALT'] = os.environ.get("SECURITY_PASSWORD_SALT", '146585145368132386173505678016728509634')
-    # Don't worry if email has findable domain
-    app.config["SECURITY_EMAIL_VALIDATOR_ARGS"] = {"check_deliverability": False}
+        # Generate a nice key using secrets.token_urlsafe()
+        app.config['SECRET_KEY'] = os.environ.get("SECRET_KEY", 'pf9Wkove4IKEAXvy-cQkeDPhv9Cb3Ag-wyJILbq_dFw')
+        # Generate a good salt for password hashing using: secrets.SystemRandom().getrandbits(128)
+        app.config['SECURITY_PASSWORD_SALT'] = os.environ.get("SECURITY_PASSWORD_SALT", '146585145368132386173505678016728509634')
+        # Don't worry if email has findable domain
+        app.config["SECURITY_EMAIL_VALIDATOR_ARGS"] = {"check_deliverability": False}
 
-    # manage sessions per request - make sure connections are closed and returned
-    app.teardown_appcontext(lambda exc: db_session.close())
+        # manage sessions per request - make sure connections are closed and returned
+        app.teardown_appcontext(lambda exc: db_session.close())
 
-    # Setup Flask-Security
-    user_datastore = SQLAlchemySessionUserDatastore(db_session, User, Role)
-    app.security = Security(app, user_datastore)
+        # Setup Flask-Security
+        user_datastore = SQLAlchemySessionUserDatastore(db_session, User, Role)
+        security = Security(app, user_datastore)
 
-    # Views
-    @app.route("/")
-    @auth_required()
-    def home():
-        return render_template_string('Hello {{current_user.email}}!')
+        # Views
+        @app.route("/")
+        @auth_required()
+        def home():
+            return render_template_string('Hello {{current_user.email}}!')
 
-    @app.route("/user")
-    @auth_required()
-    @permissions_accepted("user-read")
-    def user_home():
-        return render_template_string("Hello {{ current_user.email }} you are a user!")
+        @app.route("/user")
+        @auth_required()
+        @permissions_accepted("user-read")
+        def user_home():
+            return render_template_string("Hello {{ current_user.email }} you are a user!")
 
-    # one time setup
-    with app.app_context():
-        init_db()
-        # Create a user and role to test with
-        app.security.datastore.find_or_create_role(
-            name="user", permissions={"user-read", "user-write"}
-        )
-        db_session.commit()
-        if not app.security.datastore.find_user(email="test@me.com"):
-            app.security.datastore.create_user(email="test@me.com",
-            password=hash_password("password"), roles=["user"])
-        db_session.commit()
+        # one time setup
+        with app.app_context():
+            init_db()
+            # Create a user and role to test with
+            security.datastore.find_or_create_role(
+                name="user", permissions={"user-read", "user-write"}
+            )
+            db_session.commit()
+            if not security.datastore.find_user(email="test@me.com"):
+                security.datastore.create_user(email="test@me.com",
+                password=hash_password("password"), roles=["user"])
+            db_session.commit()
 
-    if __name__ == '__main__':
-        # run application (can also use flask run)
-        app.run()
+        if __name__ == '__main__':
+            # run application (can also use flask run)
+            app.run()
 
-- database.py ::
+- database.py
+    .. code-block:: python
 
-    from sqlalchemy import create_engine
-    from sqlalchemy.orm import scoped_session, sessionmaker
-    from sqlalchemy.ext.declarative import declarative_base
-    from flask_security.models import sqla
+        from sqlalchemy import create_engine
+        from sqlalchemy.orm import scoped_session, sessionmaker
+        from sqlalchemy.ext.declarative import declarative_base
+        from flask_security.models import sqla
 
-    engine = create_engine('sqlite:////tmp/test.db')
-    db_session = scoped_session(sessionmaker(autocommit=False,
-                                             autoflush=False,
-                                             bind=engine))
-    Base = declarative_base()
-    # This creates the RolesUser table and is where
-    # you would pass in non-standard tables names.
-    sqla.FsModels.set_db_info(base_model=Base)
+        engine = create_engine('sqlite:////tmp/test.db')
+        db_session = scoped_session(sessionmaker(autocommit=False,
+                                                 autoflush=False,
+                                                 bind=engine))
+        Base = declarative_base()
+        # This creates the RolesUser table and is where
+        # you would pass in non-standard tables names.
+        sqla.FsModels.set_db_info(base_model=Base)
 
 
-    def init_db():
-        # import all modules here that might define models so that
-        # they will be registered properly on the metadata.  Otherwise
-        # you will have to import them first before calling init_db()
-        import models
-        Base.metadata.create_all(bind=engine)
+        def init_db():
+            # import all modules here that might define models so that
+            # they will be registered properly on the metadata.  Otherwise
+            # you will have to import them first before calling init_db()
+            import models
+            Base.metadata.create_all(bind=engine)
 
-- models.py ::
+- models.py
+    .. code-block:: python
 
-    from database import Base
-    from flask_security.models import sqla as sqla
+        from database import Base
+        from flask_security.models import sqla as sqla
 
-    class Role(Base, sqla.FsRoleMixin):
-        __tablename__ = 'role'
+        class Role(Base, sqla.FsRoleMixin):
+            __tablename__ = 'role'
 
-    class User(Base, sqla.FsUserMixin):
-        __tablename__ = 'user'
+        class User(Base, sqla.FsUserMixin):
+            __tablename__ = 'user'
 
 You can run this either with::
 
@@ -373,9 +376,9 @@ MongoEngine Application
 
 The following code sample illustrates how to get started as quickly as
 possible using MongoEngine (of course you have to install and start up a
-local MongoDB instance):
+local MongoDB instance).
 
-::
+.. code-block:: python
 
     import os
 
@@ -425,7 +428,7 @@ local MongoDB instance):
 
     # Setup Flask-Security
     user_datastore = MongoEngineUserDatastore(db, User, Role)
-    app.security = Security(app, user_datastore)
+    security = Security(app, user_datastore)
 
     # Views
     @app.route("/")
@@ -442,11 +445,11 @@ local MongoDB instance):
     # one time setup
     with app.app_context():
         # Create a user and role to test with
-        app.security.datastore.find_or_create_role(
+        security.datastore.find_or_create_role(
             name="user", permissions={"user-read", "user-write"}
         )
-        if not app.security.datastore.find_user(email="test@me.com"):
-            app.security.datastore.create_user(email="test@me.com",
+        if not security.datastore.find_user(email="test@me.com"):
+            security.datastore.create_user(email="test@me.com",
             password=hash_password("password"), roles=["user"])
 
     if __name__ == '__main__':
@@ -472,9 +475,9 @@ Peewee Application
 ~~~~~~~~~~~~~~~~~~
 
 The following code sample illustrates how to get started as quickly as
-possible using Peewee:
+possible using Peewee.
 
-::
+.. code-block:: python
 
     import os
 
@@ -529,7 +532,7 @@ possible using Peewee:
 
     # Setup Flask-Security
     user_datastore = PeeweeUserDatastore(db, User, Role, UserRoles)
-    app.security = Security(app, user_datastore)
+    security = Security(app, user_datastore)
 
     # Views
     @app.route('/')
@@ -543,8 +546,8 @@ possible using Peewee:
         for Model in (Role, User, UserRoles):
             Model.drop_table(fail_silently=True)
             Model.create_table(fail_silently=True)
-        if not app.security.datastore.find_user(email="test@me.com"):
-            app.security.datastore.create_user(email="test@me.com", password=hash_password("password"))
+        if not security.datastore.find_user(email="test@me.com"):
+            security.datastore.create_user(email="test@me.com", password=hash_password("password"))
 
     if __name__ == '__main__':
         app.run()

--- a/docs/two_factor_configurations.rst
+++ b/docs/two_factor_configurations.rst
@@ -97,7 +97,7 @@ possible using SQLAlchemy:
 
     # Setup Flask-Security
     user_datastore = SQLAlchemyUserDatastore(db, User, Role)
-    app.security = Security(app, user_datastore)
+    security = Security(app, user_datastore)
 
     mail = Mail(app)
 
@@ -111,8 +111,8 @@ possible using SQLAlchemy:
     with app.app_context():
         # Create a user to test with
         db.create_all()
-        if not app.security.datastore.find_user(email='test@me.com'):
-            app.security.datastore.create_user(email='test@me.com', password='password')
+        if not security.datastore.find_user(email='test@me.com'):
+            security.datastore.create_user(email='test@me.com', password='password')
         db.session.commit()
 
     if __name__ == '__main__':

--- a/flask_security/changeable.py
+++ b/flask_security/changeable.py
@@ -22,7 +22,7 @@ from .signals import password_changed
 from .utils import config_value as cv, hash_password, login_user, send_mail
 
 if t.TYPE_CHECKING:  # pragma: no cover
-    from .datastore import User
+    from flask_security import UserMixin
 
 
 def send_password_changed_notice(user):
@@ -36,7 +36,7 @@ def send_password_changed_notice(user):
 
 
 def change_user_password(
-    user: User, password: str | None, notify: bool = True, autologin: bool = True
+    user: UserMixin, password: str | None, notify: bool = True, autologin: bool = True
 ) -> None:
     """Change the specified user's password
 
@@ -73,7 +73,9 @@ def change_user_password(
     )
 
 
-def admin_change_password(user: User, new_passwd: str, notify: bool = True) -> None:
+def admin_change_password(
+    user: UserMixin, new_passwd: str, notify: bool = True
+) -> None:
     """
     Administratively change a user's password.
     Note that this will immediately render the user's existing sessions (and possibly

--- a/flask_security/forms.py
+++ b/flask_security/forms.py
@@ -56,7 +56,7 @@ from .utils import (
 )
 
 if t.TYPE_CHECKING:  # pragma: no cover
-    from .datastore import User
+    from flask_security import UserMixin
 
 _default_field_labels = {
     "email": _("Email Address"),
@@ -436,7 +436,7 @@ class SendConfirmationForm(Form, UserEmailFormMixin):
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
-        self.user: User | None = None  # set by valid_user_email
+        self.user: UserMixin | None = None  # set by valid_user_email
         if request and request.method == "GET":
             self.email.data = request.args.get("email", None)
 
@@ -458,7 +458,7 @@ class ForgotPasswordForm(Form, UserEmailFormMixin):
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
         self.requires_confirmation: bool = False
-        self.user: User | None = None  # set by valid_user_email
+        self.user: UserMixin | None = None  # set by valid_user_email
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):
@@ -487,7 +487,7 @@ class PasswordlessLoginForm(Form):
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
-        self.user: User | None = None  # set by valid_user_email
+        self.user: UserMixin | None = None  # set by valid_user_email
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):
@@ -527,7 +527,7 @@ class LoginForm(Form, PasswordFormMixin, NextFormMixin):
             )
             self.password.description = html
         self.requires_confirmation: bool = False
-        self.user: User | None = None
+        self.user: UserMixin | None = None
         # ifield can be set by subclasses to skip identity checks.
         self.ifield: Field | None = None
         # If True then user has authenticated so we can show detailed errors
@@ -602,9 +602,9 @@ class VerifyForm(Form, PasswordFormMixin):
 
     submit = SubmitField(get_form_field_label("verify_password"))
 
-    def __init__(self, *args: t.Any, user: User, **kwargs: t.Any):
+    def __init__(self, *args: t.Any, user: UserMixin, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
-        self.user: User = user
+        self.user: UserMixin = user
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):  # pragma: no cover
@@ -705,7 +705,7 @@ class ResetPasswordForm(Form, NewPasswordFormMixin, PasswordConfirmFormMixin):
     """The default reset password form"""
 
     # filled in by caller
-    user: User
+    user: UserMixin
 
     submit = SubmitField(get_form_field_label("reset_password"))
 
@@ -827,7 +827,7 @@ class TwoFactorVerifyCodeForm(Form, CodeFormMixin):
         self.window: int = 0
         self.primary_method: str = ""
         self.tf_totp_secret: str = ""
-        self.user: User | None = None  # set by view
+        self.user: UserMixin | None = None  # set by view
 
     def validate(self, **kwargs: t.Any) -> bool:
         if not super().validate(**kwargs):  # pragma: no cover
@@ -876,7 +876,7 @@ class DummyForm(Form):
 
     def __init__(self, *args: t.Any, **kwargs: t.Any):
         super().__init__(*args, **kwargs)
-        self.user: User | None = kwargs.get("user", None)
+        self.user: UserMixin | None = kwargs.get("user", None)
 
 
 def build_form_from_request(form_name: str, **kwargs: dict[str, t.Any]) -> Form:

--- a/flask_security/models/fsqla.py
+++ b/flask_security/models/fsqla.py
@@ -11,6 +11,9 @@ BE AWARE: Once any version of this is shipped no changes can be made - instead
 a new version needs to be created.
 """
 
+# mypy: disable-error-code="assignment"
+# pyright: reportAssignmentType = false, reportIncompatibleVariableOverride=false
+
 from typing import cast
 from sqlalchemy import (
     Boolean,

--- a/flask_security/models/fsqla_v2.py
+++ b/flask_security/models/fsqla_v2.py
@@ -13,6 +13,9 @@ This is Version 2:
     - Make username unique (but not required).
 """
 
+# mypy: disable-error-code="assignment"
+# pyright: reportAssignmentType = false, reportIncompatibleVariableOverride=false
+
 from sqlalchemy import Column, String, Text
 from sqlalchemy.ext.declarative import declared_attr
 

--- a/flask_security/models/fsqla_v3.py
+++ b/flask_security/models/fsqla_v3.py
@@ -16,6 +16,9 @@ This is Version 3:
     - Add support for list types.
 """
 
+# mypy: disable-error-code="assignment"
+# pyright: reportAssignmentType = false, reportIncompatibleVariableOverride=false
+
 from sqlalchemy import (
     Boolean,
     Column,

--- a/flask_security/models/sqla.py
+++ b/flask_security/models/sqla.py
@@ -13,6 +13,9 @@ BE AWARE: Once any version of this is shipped no changes can be made - instead
 a new version needs to be created.
 """
 
+# mypy: disable-error-code="assignment"
+# pyright: reportAssignmentType = false, reportIncompatibleVariableOverride=false
+
 from __future__ import annotations
 
 import datetime

--- a/flask_security/proxies.py
+++ b/flask_security/proxies.py
@@ -1,4 +1,4 @@
-# Copyright 2021 by J. Christopher Wagner (jwag). All rights reserved.
+# Copyright 2021-2024 by J. Christopher Wagner (jwag). All rights reserved.
 
 import typing as t
 
@@ -7,15 +7,14 @@ from werkzeug.local import LocalProxy
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from passlib.context import CryptContext
-    from .core import Security
-    from .datastore import CanonicalUserDatastore
+    from .core import Security, UserDatastore
 
 # Convenient references
 _security: "Security" = LocalProxy(  # type: ignore
     lambda: current_app.extensions["security"]
 )
 
-_datastore: "CanonicalUserDatastore" = LocalProxy(  # type:ignore
+_datastore: "UserDatastore" = LocalProxy(  # type:ignore
     lambda: _security.datastore
 )
 

--- a/flask_security/twofactor.py
+++ b/flask_security/twofactor.py
@@ -40,8 +40,7 @@ from .signals import (
 
 if t.TYPE_CHECKING:  # pragma: no cover
     import flask
-    from .core import Security
-    from .datastore import User
+    from flask_security import Security, UserMixin
     from flask.typing import ResponseValue
 
 
@@ -124,7 +123,7 @@ def complete_two_factor_process(user, primary_method, totp_secret, is_changing):
     return completion_message, token
 
 
-def set_rescue_options(form: TwoFactorRescueForm, user: User) -> dict[str, str]:
+def set_rescue_options(form: TwoFactorRescueForm, user: UserMixin) -> dict[str, str]:
     # Based on config - set up options for rescue.
     # Note that this modifies the passed in Form as well as returns
     # a dict that can be returned as part of a JSON response.
@@ -176,14 +175,14 @@ class CodeTfPlugin(TfPluginBase):
     ) -> None:
         pass
 
-    def get_setup_methods(self, user: User) -> list[str]:
+    def get_setup_methods(self, user: UserMixin) -> list[str]:
         if is_tf_setup(user):
             assert user.tf_primary_method is not None
             return [user.tf_primary_method]
         return []
 
     def tf_login(
-        self, user: User, json_payload: dict[str, t.Any], next_loc: str | None
+        self, user: UserMixin, json_payload: dict[str, t.Any], next_loc: str | None
     ) -> ResponseValue:
         """Helper for two-factor authentication login
 

--- a/flask_security/unified_signin.py
+++ b/flask_security/unified_signin.py
@@ -94,7 +94,7 @@ from .webauthn import has_webauthn
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from flask.typing import ResponseValue
-    from .datastore import User
+    from flask_security import UserMixin
 
 if get_quart_status():  # pragma: no cover
     from quart import redirect
@@ -147,7 +147,7 @@ class _UnifiedPassCodeForm(Form):
     """Common form for signin and verify/reauthenticate."""
 
     # filled in by caller
-    user: User
+    user: UserMixin
 
     # Filled in here
     authn_via: str
@@ -364,7 +364,7 @@ class UnifiedSigninSetupValidateForm(Form):
     """The unified sign in setup validation form"""
 
     # These 2 filled in by view
-    user: User
+    user: UserMixin
     totp_secret: str
 
     passcode = StringField(

--- a/flask_security/webauthn_util.py
+++ b/flask_security/webauthn_util.py
@@ -30,7 +30,7 @@ except ImportError:  # pragma: no cover
 
 if t.TYPE_CHECKING:  # pragma: no cover
     import flask
-    from .datastore import User
+    from flask_security import UserMixin
 
 
 class WebauthnUtil:
@@ -60,7 +60,7 @@ class WebauthnUtil:
         return request.host_url.rstrip("/")
 
     def registration_options(
-        self, user: User, usage: str, existing_options: dict[str, t.Any]
+        self, user: UserMixin, usage: str, existing_options: dict[str, t.Any]
     ) -> dict[str, t.Any]:
         """
         :param user: User object - could be used to configure on a per-user basis.
@@ -76,7 +76,7 @@ class WebauthnUtil:
         return existing_options
 
     def authenticator_selection(
-        self, user: User, usage: str
+        self, user: UserMixin, usage: str
     ) -> AuthenticatorSelectionCriteria:
         """
         :param user: User object - could be used to configure on a per-user basis.
@@ -120,7 +120,7 @@ class WebauthnUtil:
 
     def authentication_options(
         self,
-        user: User | None,
+        user: UserMixin | None,
         usage: list[str],
         existing_options: dict[str, t.Any],
     ) -> dict[str, t.Any]:
@@ -138,7 +138,7 @@ class WebauthnUtil:
         return existing_options
 
     def user_verification(
-        self, user: User | None, usage: list[str]
+        self, user: UserMixin | None, usage: list[str]
     ) -> UserVerificationRequirement:
         """
         As part of signin - do we want/need user verification.

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,7 +4,7 @@ pretty = True
 show_error_codes = True
 
 # this sucks - but most of our packages don't yet have types.
-ignore_missing_imports = True
+disable_error_code = import-untyped
 
 no_implicit_optional = True
 disallow_incomplete_defs = True
@@ -22,3 +22,10 @@ warn_unused_configs = True
 [mypy-flask_security.cli]
 # Due to click 8.1.4
 ignore_errors = True
+
+[mypy-quart.*]
+ignore_missing_imports = True
+[mypy-flask_mail.*]
+ignore_missing_imports = True
+[mypy-twilio.*]
+ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,3 +96,8 @@ version = {attr = "flask_security.__version__"}
 
 [tool.djlint]
     ignore="H005,H006"  # lang, img height/width
+
+[tool.pyright]
+    include=["flask_security", "tests/view_scaffold.py"]
+    analyzeUnannotatedFunctions = "none"
+    reportMissingImports = false

--- a/tests/test_changeable.py
+++ b/tests/test_changeable.py
@@ -4,7 +4,7 @@
 
     Changeable tests
 
-    :copyright: (c) 2019-2023 by J. Christopher Wagner (jwag).
+    :copyright: (c) 2019-2024 by J. Christopher Wagner (jwag).
     :license: MIT, see LICENSE for more details.
 """
 
@@ -14,10 +14,8 @@ import pytest
 from flask import Flask
 import markupsafe
 
-from flask_security.core import UserMixin
+from flask_security import PasswordUtil, UserMixin, password_changed, user_authenticated
 from flask_security.forms import _default_field_labels
-from flask_security.password_util import PasswordUtil
-from flask_security.signals import password_changed, user_authenticated
 from flask_security.utils import localize_callback
 from tests.test_utils import (
     authenticate,

--- a/tests/test_registerable.py
+++ b/tests/test_registerable.py
@@ -18,15 +18,13 @@ from tests.test_utils import (
     logout,
 )
 
-from flask_security import Security
-from flask_security.core import UserMixin
+from flask_security import Security, UserMixin, user_registered, user_not_registered
 from flask_security.forms import (
     ConfirmRegisterForm,
     RegisterForm,
     StringField,
     _default_field_labels,
 )
-from flask_security.signals import user_registered, user_not_registered
 from flask_security.utils import localize_callback
 
 pytestmark = pytest.mark.registerable()

--- a/tox.ini
+++ b/tox.ini
@@ -137,7 +137,6 @@ deps =
     -r requirements/tests.txt
     types-setuptools
     mypy
-    sqlalchemy[mypy]
 commands =
     mypy --install-types --non-interactive flask_security tests
 


### PR DESCRIPTION
Rather than define our own User model (just for typing) - change the annotations to use UserMixin and as part of typing define each possible member and type.

Add annotations to view_scaffold.py - as a test for the new datastore annotations.

add pyright config to pyproject.toml - it throws tons of errors - but view_scaffold not passes.

closes #1001