### PR TITLE
Allow more flexibility in allowed redirect targets.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Features & Improvements
 - (:issue:`994`) Add support for Flask-SQLAlchemy-Lite - including new all-inclusive models
   that conform to sqlalchemy latest best-practice (type-annotated).
 - (:pr:`1007`) Convert other sqlalchemy-based datastores from legacy 'model.query' to best-practice 'select'
+- (:issue:`983`) Allow applications more flexibility defining redirects.
 
 Fixes
 +++++
@@ -24,7 +25,7 @@ Fixes
   ritual - just as we return the CSRF token. (thanks @e-goto)
 - (:issue:`973`) login and unified sign in should handle GET for authenticated user consistently.
 - (:pr:`995`) Don't show sms options if not defined in US_ENABLED_METHODS. (fredipevcin)
-- (:pr:`xxx`) Change :py:data:`SECURITY_DEPRECATED_HASHING_SCHEMES` to ``["auto"]``.
+- (:pr:`1009`) Change :py:data:`SECURITY_DEPRECATED_HASHING_SCHEMES` to ``["auto"]``.
 
 Docs and Chores
 +++++++++++++++

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -182,12 +182,40 @@ These configuration keys are used globally across all features.
 
     If ``True`` then subdomains (and the root domain) of the top-level host set
     by Flask's ``SERVER_NAME`` configuration will be allowed as post-view redirect targets.
-    This is beneficial if you wish to place your authentiation on one subdomain and
+    This is beneficial if you wish to place your authentication on one subdomain and
     authenticated content on another, for example ``auth.domain.tld`` and ``app.domain.tld``.
 
     Default: ``False``.
 
     .. versionadded:: 4.0.0
+
+.. py:data:: SECURITY_REDIRECT_BASE_DOMAIN
+
+    Set the base domain for checking allowable redirects. The intent here is to
+    allow an application to be server on e.g. "flaskapp.my.org" and redirect
+    to "myservice.my.org" (which maybe isn't a Flask app). Flask's SERVER_NAME
+    can't be used to verify redirects in this case. Note that in most cases
+    the application will want to set Flask's SESSION_COOKIE_DOMAIN to be this base domain -
+    otherwise authorization information won't be sent.
+
+    Default: ``None``
+
+    .. versionadded:: 5.5.0
+
+.. py:data:: SECURITY_REDIRECT_ALLOWED_SUBDOMAINS
+
+    A list of subdomains. Each will be prepended to
+    ``SECURITY_REDIRECT_BASE_DOMAIN`` and checked against the requested redirect.
+
+    Default: ``[]``
+
+    .. versionadded:: 5.5.0
+
+
+.. note::
+    The above 4 config options apply BOTH to the handling of ``next`` parameter
+    as well as all the ``XXX_VIEW`` URL configuration options
+    for those views that perform a redirect after processing.
 
 .. py:data:: SECURITY_CSRF_PROTECT_MECHANISMS
 

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -203,6 +203,8 @@ _default_config: dict[str, t.Any] = {
     "REDIRECT_HOST": None,
     "REDIRECT_BEHAVIOR": None,
     "REDIRECT_ALLOW_SUBDOMAINS": False,
+    "REDIRECT_BASE_DOMAIN": None,
+    "REDIRECT_ALLOWED_SUBDOMAINS": [],
     "FORGOT_PASSWORD_TEMPLATE": "security/forgot_password.html",
     "LOGIN_USER_TEMPLATE": "security/login_user.html",
     "REGISTER_USER_TEMPLATE": "security/register_user.html",
@@ -231,8 +233,8 @@ _default_config: dict[str, t.Any] = {
     "CHANGE_EMAIL_WITHIN": "2 hours",
     "CHANGE_EMAIL_URL": "/change-email",
     "CHANGE_EMAIL_CONFIRM_URL": "/change-email-confirm",
-    "CHANGE_EMAIL_ERROR_VIEW": None,
-    "POST_CHANGE_EMAIL_VIEW": None,
+    "CHANGE_EMAIL_ERROR_VIEW": None,  # spa
+    "POST_CHANGE_EMAIL_VIEW": None,  # spa
     "CHANGE_EMAIL_SALT": "change-email-salt",
     "CHANGE_EMAIL_SUBJECT": _("Confirm your new email address"),
     "TWO_FACTOR_AUTHENTICATOR_VALIDITY": 120,

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ deps =
     git+https://github.com/pallets/flask@main#egg=flask
     git+https://github.com/pallets/flask-sqlalchemy@main#egg=flask-sqlalchemy
     git+https://github.com/pallets/jinja@main#egg=jinja2
+    git+https://github.com/pallets-eco/flask-principal@main#egg=flask-principal
     git+https://github.com/wtforms/wtforms@master#egg=wtforms
     git+https://github.com/maxcountryman/flask-login@main#egg=flask-login
 commands =


### PR DESCRIPTION
Add a new config SECURITY_REDIRECT_BASE_DOMAIN which specifies a domain against which to check SECURITY_REDIRECT_ALLOWED_SUBDOMAINS.
This enables applications where Flask's SERVER_NAME isn't actually at the base so can't be used to validate redirects.

close https://github.com/Flask-Middleware/flask-security/issues/983